### PR TITLE
[MINOR]: `env_vars` instead of `env_var`

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -36,7 +36,7 @@ from vllm.utils import FlexibleArgumentParser
 # Define a the expected JSON structure in dataclass
 class VllmConfig(BaseModel):
     options: str
-    env_var: Optional[Dict[str, Any]] = None
+    env_vars: Optional[Dict[str, Any]] = None
 
 
 # VLLM process manager
@@ -178,8 +178,8 @@ def vllm_kickoff(vllm_config: VllmConfig):
 
     logger.info(f"VLLM process (PID: {os.getpid()}) started.")
     # Set env vars in the current process
-    if vllm_config.env_var:
-        set_env_vars(vllm_config.env_var)
+    if vllm_config.env_vars:
+        set_env_vars(vllm_config.env_vars)
 
     # prepare args
     receive_args = vllm_config.options.split()

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -42,23 +42,23 @@ def test_set_env_vars():
 def test_vllmconfig_with_options():
     config = VllmConfig(options="test_options")
     assert config.options == "test_options"
-    assert config.env_var is None
+    assert config.env_vars is None
     env_var_data = {"TEST_ENV_VAR": "test_value"}
-    config = VllmConfig(options="test_options", env_var=env_var_data)
+    config = VllmConfig(options="test_options", env_vars=env_var_data)
     assert config.options == "test_options"
-    assert config.env_var == env_var_data
+    assert config.env_vars == env_var_data
 
 
 def test_vllmconfig_validations():
     with pytest.raises(ValidationError):
-        VllmConfig(env_var={"TEST_ENV_VAR": "test_value"})
+        VllmConfig(env_vars={"TEST_ENV_VAR": "test_value"})
 
     with pytest.raises(ValidationError):
         VllmConfig(options=123)  # options should be a string
 
     with pytest.raises(ValidationError):
         VllmConfig(
-            options="test_options", env_var="not_a_dict"
+            options="test_options", env_vars="not_a_dict"
         )  # env_var should be a dict
 
 


### PR DESCRIPTION
**Context:**
To address Mike's comment [here](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/11#discussion_r2347905061).

**Tests:**
Unit Tests:
```
$ python -m pytest tests/test_launcher.py 
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/diego/Documents/my_stuff/llm-d-fast-model-actuation/inference_server/launcher
plugins: anyio-4.10.0
collected 5 items                                                                                                                                                                                        

tests/test_launcher.py .....                                                                                                                                                                       [100%]

=========================================================================================== 5 passed in 4.05s ============================================================================================
```

Command with new variable name:
<img width="860" height="336" alt="Screenshot 2025-09-15 at 2 56 48 PM" src="https://github.com/user-attachments/assets/cc86d048-176d-419c-b0c6-daae666ebf1d" />
