### PR TITLE
[Minor]: GET method

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -169,6 +169,16 @@ async def delete_vllm():
     return JSONResponse(content=result, status_code=HTTPStatus.ACCEPTED)
 
 
+@app.get("/v1/vllm")
+async def status_info():
+    """Get status of the vLLM instance"""
+    result = vllm_manager.get_status()
+    return JSONResponse(
+        content=result,
+        status_code=HTTPStatus.OK,
+    )
+
+
 # Define a function to be executed by the child process
 def vllm_kickoff(vllm_config: VllmConfig):
     """


### PR DESCRIPTION
**Context:**
Due to an error with the `HTTPie` commands, I forgot to add the `GET` method to fetch information about the `vLLM` instance.

**Test:**
Test has been passed:
```
$ python -m pytest tests/test_launcher.py 
============================================================================================= test session starts =============================================================================================
platform darwin -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/diego/Documents/my_stuff/llm-d-fast-model-actuation/inference_server/launcher
plugins: anyio-4.10.0
collected 5 items                                                                                                                                                                                             

tests/test_launcher.py .....                                                                                                                                                                            [100%]

============================================================================================== 5 passed in 4.09s ==============================================================================================
```

**E2E:**
1- Get info from a running instance:
<img width="796" height="249" alt="Screenshot 2025-09-16 at 2 59 58 PM" src="https://github.com/user-attachments/assets/5cc6c457-d40c-47cb-91da-c1764d0c6c03" />

2- Get info from a stopped instance:
<img width="830" height="277" alt="Screenshot 2025-09-16 at 3 00 54 PM" src="https://github.com/user-attachments/assets/3fecbaef-95c4-4379-be31-6cdea7acfa03" />
