### PR TITLE
Start to implement the dual pods controller

### DIFF
--- a/cmd/requester/README.md
+++ b/cmd/requester/README.md
@@ -1,4 +1,6 @@
-This document shows the steps to exercise the requester and dual-pods controller in a local k8s environment.
+This document shows the steps to exercise the requester and dual-pods controller
+in a local k8s environment with model `ibm-granite/granite-3.3-2b-instruct`
+cached on local PV in the cluster.
 
 Build the requester container image (use your favorate `REQUESTER_IMG_REG`).
 ```shell
@@ -29,14 +31,13 @@ metadata:
           - vllm
           - serve
           - --port=8000
-          - ibm-granite/granite-3.3-2b-instruct
-          # - /pvcs/local/hf/models--deepseek-ai--DeepSeek-R1-Distill-Qwen-32B/snapshots/711ad2ea6aa40cfca18895e8aca02ab92df1a746
+          - /pvcs/local/default/vcp/hf/models--ibm-granite--granite-3.3-2b-instruct/snapshots/c4179de4bf66635b0cf11f410a73ebf95f85d506
           - --max-model-len=32768
           env:
           - name: CUDA_VISIBLE_DEVICES
             value: "{{ .GPUIndices }}"
-          # - name: VLLM_CACHE_ROOT
-          #   value: /pvcs/shared/vllm
+          - name: VLLM_CACHE_ROOT
+            value: /pvcs/shared/vcp/vllm
           resources:
             limits:
               cpu: "2"
@@ -47,14 +48,19 @@ metadata:
               port: 8000
             initialDelaySeconds: 60
             periodSeconds: 5
-          # volumeMounts:
-          # - name: local
-          #   readOnly: true
-          #   mountPath: /pvcs/local
-        # volumes:
-        # - name: local
-        #   persistentVolumeClaim:
-        #     claimName: {{ .LocalVolume }}
+          volumeMounts:
+          - name: local
+            readOnly: true
+            mountPath: /pvcs/local
+          - name: shared
+            mountPath: /pvcs/shared
+        volumes:
+        - name: local
+          persistentVolumeClaim:
+            claimName: {{ .LocalVolume }}
+        - name: shared
+          persistentVolumeClaim:
+            claimName: {{ .SharedVolume }}
 spec:
   containers:
     - name: requester
@@ -76,16 +82,15 @@ spec:
           memory: 250Mi
 EOF
 ```
-In the yaml above, the currently commented lines are for model caching.
 
 Check the allocated GPU.
 ```console
 $ kubectl get po my-request -owide
 NAME         READY   STATUS    RESTARTS   AGE   IP           NODE               NOMINATED NODE   READINESS GATES
-my-request   0/1     Running   0          12s   10.0.0.111   ip-172-31-58-228   <none>           <none>
-$ REQ_IP=10.0.0.111
+my-request   0/1     Running   0          14s   10.0.0.148   ip-172-31-58-228   <none>           <none>
+$ REQ_IP=10.0.0.148
 $ curl $REQ_IP:8081/v1/dual-pod/accelerators
-["GPU-b26140c6-bd79-2798-d936-0ed16a4f0733"]
+["GPU-7450f677-9aa8-0150-8b11-68727d721976"]
 ```
 
 Check the controller-created server-running pod.
@@ -94,8 +99,8 @@ $ kubectl get po my-request-server -oyaml | yq .metadata
 annotations:
   dual-pod.llm-d.ai/role: runner
   kubectl.kubernetes.io/last-applied-configuration: |
-    {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"dual-pod.llm-d.ai/admin-port":"8081","dual-pod.llm-d.ai/role":"requester","dual-pod.llm-d.ai/server-patch":"spec:\n  containers:\n  - name: inference-server\n    image: docker.io/vllm/vllm-openai:v0.8.5\n    command:\n    - vllm\n    - serve\n    - --port=8000\n    - ibm-granite/granite-3.3-2b-instruct\n    # - /pvcs/local/hf/models--deepseek-ai--DeepSeek-R1-Distill-Qwen-32B/snapshots/711ad2ea6aa40cfca18895e8aca02ab92df1a746\n    - --max-model-len=32768\n    env:\n    - name: CUDA_VISIBLE_DEVICES\n      value: \"{{ .GPUIndices }}\"\n    # - name: VLLM_CACHE_ROOT\n    #   value: /pvcs/shared/vllm\n    resources:\n      limits:\n        cpu: \"2\"\n        memory: 6Gi\n    readinessProbe:\n      httpGet:\n        path: /health\n        port: 8000\n      initialDelaySeconds: 60\n      periodSeconds: 5\n    # volumeMounts:\n    # - name: local\n    #   readOnly: true\n    #   mountPath: /pvcs/local\n  # volumes:\n  # - name: local\n  #   persistentVolumeClaim:\n  #     claimName: {{ .LocalVolume }}\n"},"labels":{"app":"my-request"},"name":"my-request","namespace":"default"},"spec":{"containers":[{"image":"quay.io/my-namespace/requester:latest","imagePullPolicy":"IfNotPresent","name":"requester","ports":[{"containerPort":8080},{"containerPort":8081}],"readinessProbe":{"httpGet":{"path":"/ready","port":8080},"initialDelaySeconds":2,"periodSeconds":5},"resources":{"limits":{"cpu":"1","memory":"250Mi","nvidia.com/gpu":"1"}}}]}}
-creationTimestamp: "2025-09-24T01:58:04Z"
+    {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"dual-pod.llm-d.ai/admin-port":"8081","dual-pod.llm-d.ai/role":"requester","dual-pod.llm-d.ai/server-patch":"spec:\n  containers:\n  - name: inference-server\n    image: docker.io/vllm/vllm-openai:v0.8.5\n    command:\n    - vllm\n    - serve\n    - --port=8000\n    - /pvcs/local/default/vcp/hf/models--ibm-granite--granite-3.3-2b-instruct/snapshots/c4179de4bf66635b0cf11f410a73ebf95f85d506\n    - --max-model-len=32768\n    env:\n    - name: CUDA_VISIBLE_DEVICES\n      value: \"{{ .GPUIndices }}\"\n    - name: VLLM_CACHE_ROOT\n      value: /pvcs/shared/vcp/vllm\n    resources:\n      limits:\n        cpu: \"2\"\n        memory: 6Gi\n    readinessProbe:\n      httpGet:\n        path: /health\n        port: 8000\n      initialDelaySeconds: 60\n      periodSeconds: 5\n    volumeMounts:\n    - name: local\n      readOnly: true\n      mountPath: /pvcs/local\n    - name: shared\n      mountPath: /pvcs/shared\n  volumes:\n  - name: local\n    persistentVolumeClaim:\n      claimName: {{ .LocalVolume }}\n  - name: shared\n    persistentVolumeClaim:\n      claimName: {{ .SharedVolume }}\n"},"name":"my-request","namespace":"default"},"spec":{"containers":[{"image":"quay.io/my-namespace/requester:latest","imagePullPolicy":"IfNotPresent","name":"requester","ports":[{"containerPort":8080},{"containerPort":8081}],"readinessProbe":{"httpGet":{"path":"/ready","port":8080},"initialDelaySeconds":2,"periodSeconds":5},"resources":{"limits":{"cpu":"1","memory":"250Mi","nvidia.com/gpu":"1"}}}]}}
+creationTimestamp: "2025-09-24T13:07:56Z"
 name: my-request-server
 namespace: default
 ownerReferences:
@@ -104,19 +109,21 @@ ownerReferences:
     controller: true
     kind: Pod
     name: my-request
-    uid: 2f8f375b-1b1a-4a31-8215-affe151a0519
-resourceVersion: "22030645"
-uid: 1de925c4-d29a-4dd3-ab00-bb8b542df469
+    uid: 8539f131-c558-488c-b5a7-2112667a487f
+resourceVersion: "22055196"
+uid: c597c0ba-1d3e-4ae2-a2f7-4e8db7d71dad
 $ kubectl get po my-request-server -oyaml | yq .spec.containers[0]
 command:
   - vllm
   - serve
   - --port=8000
-  - ibm-granite/granite-3.3-2b-instruct
+  - /pvcs/local/default/vcp/hf/models--ibm-granite--granite-3.3-2b-instruct/snapshots/c4179de4bf66635b0cf11f410a73ebf95f85d506
   - --max-model-len=32768
 env:
   - name: CUDA_VISIBLE_DEVICES
     value: "0"
+  - name: VLLM_CACHE_ROOT
+    value: /pvcs/shared/vcp/vllm
 image: docker.io/vllm/vllm-openai:v0.8.5
 imagePullPolicy: IfNotPresent
 name: inference-server
@@ -142,8 +149,13 @@ resources:
 terminationMessagePath: /dev/termination-log
 terminationMessagePolicy: File
 volumeMounts:
+  - mountPath: /pvcs/local
+    name: local
+    readOnly: true
+  - mountPath: /pvcs/shared
+    name: shared
   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-    name: kube-api-access-lz97w
+    name: kube-api-access-jphnp
     readOnly: true
 ```
 
@@ -152,17 +164,19 @@ Make inference request after the server-running pod becomes ready.
 $ kubectl wait pod/my-request-server --for=condition=Ready --timeout=120s
 pod/my-request-server condition met
 $ kc get po -owide
-NAME                READY   STATUS    RESTARTS   AGE     IP           NODE               NOMINATED NODE   READINESS GATES
-my-request          1/1     Running   0          4m26s   10.0.0.221   ip-172-31-58-228   <none>           <none>
-my-request-server   1/1     Running   0          4m18s   10.0.0.204   ip-172-31-58-228   <none>           <none>
-$ curl -s http://10.0.0.204:8000/v1/completions \
+NAME                              READY   STATUS    RESTARTS   AGE     IP           NODE               NOMINATED NODE   READINESS GATES
+ip-172-31-58-228-na               1/1     Running   0          41m     10.0.0.45    ip-172-31-58-228   <none>           <none>
+my-request                        1/1     Running   0          2m21s   10.0.0.148   ip-172-31-58-228   <none>           <none>
+my-request-server                 1/1     Running   0          2m12s   10.0.0.254   ip-172-31-58-228   <none>           <none>
+vcp-model-ctlr-67c7c8dd8b-kwrjv   1/1     Running   0          41m     10.0.0.8     ip-172-31-58-228   <none>           <none>
+$ curl -s http://10.0.0.254:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "ibm-granite/granite-3.3-2b-instruct",
+    "model": "/pvcs/local/default/vcp/hf/models--ibm-granite--granite-3.3-2b-instruct/snapshots/c4179de4bf66635b0cf11f410a73ebf95f85d506",
     "prompt": "The capital of France is",
     "max_tokens": 30
   }'
-{"id":"cmpl-9b6ccd4b6bc24459bd3d55075f89c349","object":"text_completion","created":1758680479,"model":"ibm-granite/granite-3.3-2b-instruct","choices":[{"index":0,"text":" Paris.\nThe capital of Spain is Madrid.\nThe capital of Italy is Rome.\nThe capital of Germany is Ber","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":35,"completion_tokens":30,"prompt_tokens_details":null}}
+{"id":"cmpl-bd1b393927c947aab318a1cf5f595473","object":"text_completion","created":1758719471,"model":"/pvcs/local/default/vcp/hf/models--ibm-granite--granite-3.3-2b-instruct/snapshots/c4179de4bf66635b0cf11f410a73ebf95f85d506","choices":[{"index":0,"text":" Paris.\nThe capital of the United States is Washington, D.C.\nThe capital of China is Beijing.\nThe","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":35,"completion_tokens":30,"prompt_tokens_details":null}}
 ```
 
 Check the relayed readiness.
@@ -184,4 +198,8 @@ Clean up.
 ```console
 $ kubectl delete po my-request
 pod "my-request" deleted
+$ kubectl get po # a few moments later
+NAME                              READY   STATUS    RESTARTS   AGE
+ip-172-31-58-228-na               1/1     Running   0          43m
+vcp-model-ctlr-67c7c8dd8b-kwrjv   1/1     Running   0          43m
 ```

--- a/cmd/requester/README.md
+++ b/cmd/requester/README.md
@@ -1,19 +1,60 @@
-This document shows the steps to exercise the requester in a local k8s environment.
+This document shows the steps to exercise the requester and dual-pods controller in a local k8s environment.
 
 Build the requester container image (use your favorate `REQUESTER_IMG_REG`).
 ```shell
 make build-requester REQUESTER_IMG_REG=$REQUESTER_IMG_REG
 ```
 
-Create a pod.
+In a 2nd terminal, run the dual-pods controller.
+```shell
+go run ./cmd/dual-pods-controller/ -v 5
+```
+
+Switch back to the 1st terminal, create a server-requesting pod.
 ```shell
 kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
-  name: my-server-request
-  labels:
-    app: my-server-request
+  name: my-request
+  annotations:
+    dual-pod.llm-d.ai/role: requester
+    dual-pod.llm-d.ai/admin-port: "8081"
+    dual-pod.llm-d.ai/server-patch: |
+      spec:
+        containers:
+        - name: inference-server
+          image: docker.io/vllm/vllm-openai:v0.8.5
+          command:
+          - vllm
+          - serve
+          - --port=8000
+          - ibm-granite/granite-3.3-2b-instruct
+          # - /pvcs/local/hf/models--deepseek-ai--DeepSeek-R1-Distill-Qwen-32B/snapshots/711ad2ea6aa40cfca18895e8aca02ab92df1a746
+          - --max-model-len=32768
+          env:
+          - name: CUDA_VISIBLE_DEVICES
+            value: "{{ .GPUIndices }}"
+          # - name: VLLM_CACHE_ROOT
+          #   value: /pvcs/shared/vllm
+          resources:
+            limits:
+              cpu: "2"
+              memory: 6Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          # volumeMounts:
+          # - name: local
+          #   readOnly: true
+          #   mountPath: /pvcs/local
+        # volumes:
+        # - name: local
+        #   persistentVolumeClaim:
+        #     claimName: {{ .LocalVolume }}
 spec:
   containers:
     - name: requester
@@ -24,11 +65,10 @@ spec:
         - containerPort: 8081
       readinessProbe:
         httpGet:
-          path: /readyz
+          path: /ready
           port: 8080
         initialDelaySeconds: 2
         periodSeconds: 5
-        failureThreshold: 3
       resources:
         limits:
           nvidia.com/gpu: "1"
@@ -36,42 +76,112 @@ spec:
           memory: 250Mi
 EOF
 ```
+In the yaml above, the currently commented lines are for model caching.
 
 Check the allocated GPU.
 ```console
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ kubectl get po my-server-request -owide
-NAME                READY   STATUS    RESTARTS   AGE   IP           NODE               NOMINATED NODE   READINESS GATES
-my-server-request   0/1     Running   0          26s   10.0.0.233   ip-172-31-58-228   <none>           <none>
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ thepodip=10.0.0.233
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ curl $thepodip:8081/v1/dual-pod/accelerators
-["GPU-845e0388-9896-3a61-8ac9-3643833770d2"]
+$ kubectl get po my-request -owide
+NAME         READY   STATUS    RESTARTS   AGE   IP           NODE               NOMINATED NODE   READINESS GATES
+my-request   0/1     Running   0          12s   10.0.0.111   ip-172-31-58-228   <none>           <none>
+$ REQ_IP=10.0.0.111
+$ curl $REQ_IP:8081/v1/dual-pod/accelerators
+["GPU-b26140c6-bd79-2798-d936-0ed16a4f0733"]
 ```
 
-Mock the relayed readiness.
+Check the controller-created server-running pod.
 ```console
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ curl $thepodip:8080/ready
-Service Unavailable
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ curl -X POST "http://$thepodip:8081/v1/become-ready"
-OK
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ curl $thepodip:8080/ready
-OK
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ curl -X POST "http://$thepodip:8081/v1/become-unready"
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ curl $thepodip:8080/ready
-Service Unavailable
+$ kubectl get po my-request-server -oyaml | yq .metadata
+annotations:
+  dual-pod.llm-d.ai/role: runner
+  kubectl.kubernetes.io/last-applied-configuration: |
+    {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"dual-pod.llm-d.ai/admin-port":"8081","dual-pod.llm-d.ai/role":"requester","dual-pod.llm-d.ai/server-patch":"spec:\n  containers:\n  - name: inference-server\n    image: docker.io/vllm/vllm-openai:v0.8.5\n    command:\n    - vllm\n    - serve\n    - --port=8000\n    - ibm-granite/granite-3.3-2b-instruct\n    # - /pvcs/local/hf/models--deepseek-ai--DeepSeek-R1-Distill-Qwen-32B/snapshots/711ad2ea6aa40cfca18895e8aca02ab92df1a746\n    - --max-model-len=32768\n    env:\n    - name: CUDA_VISIBLE_DEVICES\n      value: \"{{ .GPUIndices }}\"\n    # - name: VLLM_CACHE_ROOT\n    #   value: /pvcs/shared/vllm\n    resources:\n      limits:\n        cpu: \"2\"\n        memory: 6Gi\n    readinessProbe:\n      httpGet:\n        path: /health\n        port: 8000\n      initialDelaySeconds: 60\n      periodSeconds: 5\n    # volumeMounts:\n    # - name: local\n    #   readOnly: true\n    #   mountPath: /pvcs/local\n  # volumes:\n  # - name: local\n  #   persistentVolumeClaim:\n  #     claimName: {{ .LocalVolume }}\n"},"labels":{"app":"my-request"},"name":"my-request","namespace":"default"},"spec":{"containers":[{"image":"quay.io/my-namespace/requester:latest","imagePullPolicy":"IfNotPresent","name":"requester","ports":[{"containerPort":8080},{"containerPort":8081}],"readinessProbe":{"httpGet":{"path":"/ready","port":8080},"initialDelaySeconds":2,"periodSeconds":5},"resources":{"limits":{"cpu":"1","memory":"250Mi","nvidia.com/gpu":"1"}}}]}}
+creationTimestamp: "2025-09-24T01:58:04Z"
+name: my-request-server
+namespace: default
+ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Pod
+    name: my-request
+    uid: 2f8f375b-1b1a-4a31-8215-affe151a0519
+resourceVersion: "22030645"
+uid: 1de925c4-d29a-4dd3-ab00-bb8b542df469
+$ kubectl get po my-request-server -oyaml | yq .spec.containers[0]
+command:
+  - vllm
+  - serve
+  - --port=8000
+  - ibm-granite/granite-3.3-2b-instruct
+  - --max-model-len=32768
+env:
+  - name: CUDA_VISIBLE_DEVICES
+    value: "0"
+image: docker.io/vllm/vllm-openai:v0.8.5
+imagePullPolicy: IfNotPresent
+name: inference-server
+readinessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /health
+    port: 8000
+    scheme: HTTP
+  initialDelaySeconds: 60
+  periodSeconds: 5
+  successThreshold: 1
+  timeoutSeconds: 1
+resources:
+  limits:
+    cpu: "2"
+    memory: 6Gi
+    nvidia.com/gpu: "0"
+  requests:
+    cpu: "2"
+    memory: 6Gi
+    nvidia.com/gpu: "0"
+terminationMessagePath: /dev/termination-log
+terminationMessagePolicy: File
+volumeMounts:
+  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    name: kube-api-access-lz97w
+    readOnly: true
 ```
 
-Show the log of the pod.
+Make inference request after the server-running pod becomes ready.
 ```console
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ kubectl logs my-server-request
-I0918 05:42:24.411639       1 server.go:117] "starting server" logger="spi-server" port="8081"
-I0918 05:42:24.411640       1 server.go:73] "starting server" logger="probes-server" port="8080"
-I0918 05:42:24.431092       1 server.go:126] "Got GPU UUIDs" logger="spi-server" uuids=["GPU-7d4a903d-6045-642b-12fd-db4207cd82c4"]
-I0923 06:28:34.915124       1 server.go:91] "Setting ready" logger="spi-server" newReady=true
-I0923 06:30:53.616685       1 server.go:91] "Setting ready" logger="spi-server" newReady=false
+$ kubectl wait pod/my-request-server --for=condition=Ready --timeout=120s
+pod/my-request-server condition met
+$ kc get po -owide
+NAME                READY   STATUS    RESTARTS   AGE     IP           NODE               NOMINATED NODE   READINESS GATES
+my-request          1/1     Running   0          4m26s   10.0.0.221   ip-172-31-58-228   <none>           <none>
+my-request-server   1/1     Running   0          4m18s   10.0.0.204   ip-172-31-58-228   <none>           <none>
+$ curl -s http://10.0.0.204:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ibm-granite/granite-3.3-2b-instruct",
+    "prompt": "The capital of France is",
+    "max_tokens": 30
+  }'
+{"id":"cmpl-9b6ccd4b6bc24459bd3d55075f89c349","object":"text_completion","created":1758680479,"model":"ibm-granite/granite-3.3-2b-instruct","choices":[{"index":0,"text":" Paris.\nThe capital of Spain is Madrid.\nThe capital of Italy is Rome.\nThe capital of Germany is Ber","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":35,"completion_tokens":30,"prompt_tokens_details":null}}
+```
+
+Check the relayed readiness.
+```console
+$ curl $REQ_IP:8080/ready
+OK
+```
+
+Check the log of the server-requesting pod.
+```console
+$ kubectl logs my-request
+I0924 02:12:54.268374       1 server.go:73] "starting server" logger="probes-server" port="8080"
+I0924 02:12:54.268426       1 server.go:117] "starting server" logger="spi-server" port="8081"
+I0924 02:12:54.289478       1 server.go:126] "Got GPU UUIDs" logger="spi-server" uuids=["GPU-b26140c6-bd79-2798-d936-0ed16a4f0733"]
+I0924 02:18:34.915124       1 server.go:91] "Setting ready" logger="spi-server" newReady=true
 ```
 
 Clean up.
 ```console
-(vllm) ubuntu@ip-172-31-58-228:~/llm-d-fast-model-actuation$ kubectl delete po my-server-request
-pod "my-server-request" deleted
+$ kubectl delete po my-request
+pod "my-request" deleted
 ```

--- a/cmd/requester/README.md
+++ b/cmd/requester/README.md
@@ -34,8 +34,6 @@ metadata:
           - /pvcs/local/default/vcp/hf/models--ibm-granite--granite-3.3-2b-instruct/snapshots/c4179de4bf66635b0cf11f410a73ebf95f85d506
           - --max-model-len=32768
           env:
-          - name: CUDA_VISIBLE_DEVICES
-            value: "{{ .GPUIndices }}"
           - name: VLLM_CACHE_ROOT
             value: /pvcs/shared/vcp/vllm
           resources:
@@ -57,10 +55,7 @@ metadata:
         volumes:
         - name: local
           persistentVolumeClaim:
-            claimName: {{ .LocalVolume }}
-        - name: shared
-          persistentVolumeClaim:
-            claimName: {{ .SharedVolume }}
+            claimName: vcp-local-{{ .NodeName }}
 spec:
   containers:
     - name: inference-server
@@ -80,6 +75,10 @@ spec:
           nvidia.com/gpu: "1"
           cpu: "1"
           memory: 250Mi
+  volumes:
+  - name: shared
+    persistentVolumeClaim:
+      claimName: vcp-shared
 EOF
 ```
 

--- a/cmd/requester/README.md
+++ b/cmd/requester/README.md
@@ -185,13 +185,16 @@ $ curl $REQ_IP:8080/ready
 OK
 ```
 
-Check the log of the server-requesting pod.
+The log of the server-requesting pod should be something similar to:
 ```console
 $ kubectl logs my-request
-I0924 02:12:54.268374       1 server.go:73] "starting server" logger="probes-server" port="8080"
-I0924 02:12:54.268426       1 server.go:117] "starting server" logger="spi-server" port="8081"
-I0924 02:12:54.289478       1 server.go:126] "Got GPU UUIDs" logger="spi-server" uuids=["GPU-b26140c6-bd79-2798-d936-0ed16a4f0733"]
-I0924 02:18:34.915124       1 server.go:91] "Setting ready" logger="spi-server" newReady=true
+I0925 03:49:12.802218       1 server.go:64] "starting server" logger="probes-server" port="8080"
+I0925 03:49:12.822784       1 server.go:83] "Got GPU UUIDs" logger="spi-server" uuids=["GPU-7450f677-9aa8-0150-8b11-68727d721976"]
+I0925 03:49:12.822877       1 server.go:122] "starting server" logger="spi-server" port="8081"
+I0925 03:49:12.997258       1 server.go:91] "Setting ready" logger="spi-server" newReady=false
+I0925 03:49:13.007460       1 server.go:91] "Setting ready" logger="spi-server" newReady=false
+I0925 03:49:14.009086       1 server.go:91] "Setting ready" logger="spi-server" newReady=false
+I0925 03:50:25.022997       1 server.go:91] "Setting ready" logger="spi-server" newReady=true
 ```
 
 Clean up.

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -78,13 +78,7 @@ type RunnerData struct {
 	// NodeName is the name of the Node to which the Pod is bound
 	NodeName string
 
-	// GPUIndices is a string that represents accelerators by their indices.
-	GPUIndices string
-
 	// LocalVolume is the name of the PVC that is dedicated to storage specific
 	// to that node.
 	LocalVolume string
-
-	// SharedVolume is the name of the PVC that is shared across all nodes.
-	SharedVolume string
 }

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -44,11 +44,6 @@ package api
 
 const ServerPatchAnnotationName = "dual-pod.llm-d.ai/server-patch"
 
-// RequesterContainerName is the 'main' container in the server-requesting pod
-// whose job includes reporting the associated accelerators, exposing the
-// readiness from the server-running pod to server-requesting pod, etc.
-const RequesterContainerName = "requester"
-
 // InferenceServerContainerName is the name of the container which is described by the server patch.
 // This container is expected to run the inference server using vLLM.
 const InferenceServerContainerName = "inference-server"

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -53,7 +53,7 @@ const InferenceServerContainerName = "inference-server"
 const ServerRunningPodNameSuffix = "-server"
 
 // AdminPortAnnotationName is the name of an annotation whose value
-// is the name of the port on the server-requesting pod to be
+// is the name of the port on the "inference-server" container to be
 // queried to get the set of associated accelerators.
 const AdminPortAnnotationName = "dual-pod.llm-d.ai/admin-port"
 

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -44,7 +44,12 @@ package api
 
 const ServerPatchAnnotationName = "dual-pod.llm-d.ai/server-patch"
 
-// ServerPatchAnnotationName is the name of the container which is described by the server patch.
+// RequesterContainerName is the 'main' container in the server-requesting pod
+// whose job includes reporting the associated accelerators, exposing the
+// readiness from the server-running pod to server-requesting pod, etc.
+const RequesterContainerName = "requester"
+
+// InferenceServerContainerName is the name of the container which is described by the server patch.
 // This container is expected to run the inference server using vLLM.
 const InferenceServerContainerName = "inference-server"
 
@@ -53,19 +58,24 @@ const InferenceServerContainerName = "inference-server"
 const ServerRunningPodNameSuffix = "-server"
 
 // AdminPortAnnotationName is the name of an annotation whose value
-// is the name of the port on the "inference-server" container to be
+// is the name of the port on the server-requesting pod to be
 // queried to get the set of associated accelerators.
 const AdminPortAnnotationName = "dual-pod.llm-d.ai/admin-port"
 
-const AdminPortAnnotationDefaultValue = "8081"
+// AdminPortDefaultValue is the default port number of the server-requesting pod
+// to be queried to get the set of associated accelerators.
+const AdminPortDefaultValue = "8081"
 
-// RequesterRoleAnnotationName is the name of an annotation that
+// PodRoleAnnotationName is the name of an annotation that
 // indicates the role of a Pod. The value of the annotation is
 // either "requester" for a server-requesting Pod,
 // or "runner" for a server-running Pod.
 const PodRoleAnnotationName = "dual-pod.llm-d.ai/role"
 
+// PodRoleAnnotationValueRequesting signals a server-requesting pod among the dual pods.
 const PodRoleAnnotationValueRequesting = "requester"
+
+// PodRoleAnnotationValueRunning signals a server-running pod among the dual pods.
 const PodRoleAnnotationValueRunning = "runner"
 
 // RunnerData is the data made available to the server patch.
@@ -73,7 +83,13 @@ type RunnerData struct {
 	// NodeName is the name of the Node to which the Pod is bound
 	NodeName string
 
+	// GPUIndices is a string that represents accelerators by their indices.
+	GPUIndices string
+
 	// LocalVolume is the name of the PVC that is dedicated to storage specific
 	// to that node.
 	LocalVolume string
+
+	// SharedVolume is the name of the PVC that is shared across all nodes.
+	SharedVolume string
 }

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -44,17 +44,36 @@ package api
 
 const ServerPatchAnnotationName = "dual-pod.llm-d.ai/server-patch"
 
+// ServerPatchAnnotationName is the name of the container which is described by the server patch.
+// This container is expected to run the inference server using vLLM.
+const InferenceServerContainerName = "inference-server"
+
+// ServerRunningPodNameSuffix is the suffix that is appended to the name of the
+// server-requesting Pod to form the name of the server-running Pod.
+const ServerRunningPodNameSuffix = "-server"
+
 // AdminPortAnnotationName is the name of an annotation whose value
 // is the name of the port on the "inference-server" container to be
 // queried to get the set of associated accelerators.
 const AdminPortAnnotationName = "dual-pod.llm-d.ai/admin-port"
 
+const AdminPortAnnotationDefaultValue = "8081"
+
+// RequesterRoleAnnotationName is the name of an annotation that
+// indicates the role of a Pod. The value of the annotation is
+// either "requester" for a server-requesting Pod,
+// or "runner" for a server-running Pod.
+const PodRoleAnnotationName = "dual-pod.llm-d.ai/role"
+
+const PodRoleAnnotationValueRequesting = "requester"
+const PodRoleAnnotationValueRunning = "runner"
+
 // RunnerData is the data made available to the server patch.
 type RunnerData struct {
-  // NodeName is the name of the Node to which the Pod is bound
-  NodeName string
+	// NodeName is the name of the Node to which the Pod is bound
+	NodeName string
 
-  // LocalVolume is the name of the PVC that is dedicated to storage specific
-  // to that node.
-  LocalVolume string
+	// LocalVolume is the name of the PVC that is dedicated to storage specific
+	// to that node.
+	LocalVolume string
 }

--- a/pkg/controller/dual-pods/server-requesting.go
+++ b/pkg/controller/dual-pods/server-requesting.go
@@ -76,8 +76,9 @@ func (ctl *controller) processServerRequestingPod(ctx context.Context, requestin
 	logger.V(5).Info("Building server-running pod from patch", "name", requestingPod.Name, "patch", serverPatch)
 	serverRunningPod, err := composeServerRunningPod(requestingPod, serverTemplateData{
 		GPUIndices: gpuIndices,
-		// TODO: this should be exposed as a command-line flag or environment variable
-		LocalVolume: "my-pvc",
+		// TODO: these should be exposed as command-line flags or envars
+		LocalVolume:  "vcp-local-ip-172-31-58-228",
+		SharedVolume: "vcp-shared",
 	})
 	if err != nil {
 		logger.Error(err, "Failed to build server-running pod from patch", "name", requestingPod.Name, "patch", serverPatch)
@@ -110,8 +111,9 @@ func (ctl *controller) processServerRequestingPod(ctx context.Context, requestin
 
 // serverTemplateData defines values available to the server-running pod's template.
 type serverTemplateData struct {
-	GPUIndices  string
-	LocalVolume string
+	GPUIndices   string
+	LocalVolume  string
+	SharedVolume string
 }
 
 func composeServerRunningPod(reqPod *corev1.Pod, data serverTemplateData) (*corev1.Pod, error) {

--- a/pkg/controller/dual-pods/server-requesting.go
+++ b/pkg/controller/dual-pods/server-requesting.go
@@ -202,7 +202,7 @@ func getGPUUUIDs(url string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("http get %q: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)

--- a/pkg/controller/dual-pods/server-requesting.go
+++ b/pkg/controller/dual-pods/server-requesting.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dualpods
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"text/template"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/api"
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/stub/api"
+)
+
+func (ctl *controller) processServerRequestingPod(ctx context.Context, requestingPod *corev1.Pod) (error, bool) {
+	logger := klog.FromContext(ctx)
+	logger.V(5).Info("Processing server-requesting pod", "name", requestingPod.Name)
+
+	serverPatch := requestingPod.Annotations[api.ServerPatchAnnotationName]
+	if serverPatch == "" {
+		logger.V(5).Info("No server patch annotation found", "name", requestingPod.Name)
+		return nil, true
+	}
+	logger.V(5).Info("Found server patch annotation", "name", requestingPod.Name, "patch", serverPatch)
+
+	// get allocated gpu
+	ip := requestingPod.Status.PodIP
+	if ip == "" {
+		return fmt.Errorf("pod %q has no PodIP yet", requestingPod.Name), true
+	}
+	port := requestingPod.Annotations[api.AdminPortAnnotationName]
+	if port == "" {
+		port = api.AdminPortAnnotationDefaultValue
+	}
+	logger.V(5).Info("Querying accelerators", "ip", ip, "port", port)
+	url := fmt.Sprintf("http://%s:%s%s", ip, port, stubapi.AcceleratorQueryPath)
+	gpuUUIDs, err := getGPUUUIDs(url)
+	if err != nil {
+		logger.Error(err, "Failed to fetch GPU UUIDs", "url", url)
+		return err, true
+	}
+	if len(gpuUUIDs) == 0 {
+		logger.V(5).Info("No GPUs found for Pod", "name", requestingPod.Name)
+		return nil, true
+	}
+	logger.V(5).Info("Found GPUs for Pod", "name", requestingPod.Name, "gpuUUIDs", gpuUUIDs)
+	gpuIndices := mapToGPUIndices(gpuUUIDs)
+
+	// use the server patch to build the server-running pod
+	logger.V(5).Info("Building server-running pod from patch", "name", requestingPod.Name, "patch", serverPatch)
+	serverRunningPod, err := composeServerRunningPod(requestingPod, serverTemplateData{
+		GPUIndices: gpuIndices,
+		// TODO: this should be exposed as a command-line flag or environment variable
+		LocalVolume: "my-pvc",
+	})
+	if err != nil {
+		logger.Error(err, "Failed to build server-running pod from patch", "name", requestingPod.Name, "patch", serverPatch)
+		return err, true
+	}
+
+	got, err := ctl.podLister.Pods(serverRunningPod.Namespace).Get(serverRunningPod.Name)
+	if err != nil && !errors.IsNotFound(err) {
+		logger.Error(err, "Failed to get existing server-running pod", "name", serverRunningPod.Name)
+		return err, true
+	}
+	if got != nil {
+		logger.V(5).Info("Server-running pod exists", "name", serverRunningPod.Name)
+
+		// TODO: we should reconcile the existing server-running pod with the one we just built
+		return nil, false
+	}
+
+	logger.V(5).Info("Creating server-running pod", "name", serverRunningPod.Name, "namespace", serverRunningPod.Namespace)
+	_, err = ctl.coreclient.Pods(serverRunningPod.Namespace).Create(ctx, serverRunningPod, metav1.CreateOptions{})
+	if err != nil {
+		logger.Error(err, "Failed to create server-running pod", "name", serverRunningPod.Name)
+		return err, true
+	}
+	logger.V(5).Info("Created server-running pod", "name", serverRunningPod.Name)
+
+	logger.V(5).Info("Processed server-requesting pod", "name", requestingPod.Name)
+	return nil, false
+}
+
+// serverTemplateData defines values available to the server-running pod's template.
+type serverTemplateData struct {
+	GPUIndices  string
+	LocalVolume string
+}
+
+func composeServerRunningPod(reqPod *corev1.Pod, data serverTemplateData) (*corev1.Pod, error) {
+	rawTmpl, ok := reqPod.Annotations[api.ServerPatchAnnotationName]
+	if !ok {
+		return nil, fmt.Errorf("annotation %q not found", api.ServerPatchAnnotationName)
+	}
+
+	tmpl, err := template.New("serverPatch").Option("missingkey=error").Parse(rawTmpl)
+	if err != nil {
+		return nil, fmt.Errorf("parse template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+	renderedPatch := buf.Bytes()
+
+	patchJSON, err := yaml.YAMLToJSON(renderedPatch)
+	if err != nil {
+		return nil, fmt.Errorf("yaml to json: %w", err)
+	}
+
+	reqPod.Spec.Containers = []corev1.Container{}
+	reqPod.Spec.InitContainers = nil
+	origJSON, err := json.Marshal(reqPod)
+	if err != nil {
+		return nil, fmt.Errorf("marshal server-requesting pod: %w", err)
+	}
+
+	// apply strategic merge patch
+	modifiedJSON, err := strategicpatch.StrategicMergePatch(origJSON, patchJSON, &corev1.Pod{})
+	if err != nil {
+		return nil, fmt.Errorf("apply patch: %w", err)
+	}
+
+	// decode back into Pod
+	var pod corev1.Pod
+	if err := json.Unmarshal(modifiedJSON, &pod); err != nil {
+		return nil, fmt.Errorf("unmarshal patched pod: %w", err)
+	}
+
+	// ensure the correct role annotation
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[api.PodRoleAnnotationName] = api.PodRoleAnnotationValueRunning
+
+	// set the inference server container's gpu limits and requests to zero to bypass the nvidia device plugin
+	for i, c := range pod.Spec.Containers {
+		if c.Name != api.InferenceServerContainerName {
+			continue
+		}
+		if pod.Spec.Containers[i].Resources.Limits == nil {
+			pod.Spec.Containers[i].Resources.Limits = corev1.ResourceList{}
+		}
+		pod.Spec.Containers[i].Resources.Limits[corev1.ResourceName("nvidia.com/gpu")] = resource.Quantity{}
+		if pod.Spec.Containers[i].Resources.Requests == nil {
+			pod.Spec.Containers[i].Resources.Requests = corev1.ResourceList{}
+		}
+		pod.Spec.Containers[i].Resources.Requests[corev1.ResourceName("nvidia.com/gpu")] = resource.Quantity{}
+	}
+
+	// connect dual pods
+	pod.Name = reqPod.Name + api.ServerRunningPodNameSuffix
+	pod.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(reqPod, corev1.SchemeGroupVersion.WithKind("Pod")),
+	}
+
+	// clean up
+	delete(pod.Annotations, api.AdminPortAnnotationName)
+	delete(pod.Annotations, api.ServerPatchAnnotationName)
+	pod.ResourceVersion = ""
+	pod.UID = ""
+	pod.CreationTimestamp = metav1.Time{}
+
+	return &pod, nil
+}
+
+func getGPUUUIDs(url string) ([]string, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("http get %q: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var uuids []string
+	if err := json.Unmarshal(body, &uuids); err != nil {
+		return nil, fmt.Errorf("unmarshal uuids: %w", err)
+	}
+
+	return uuids, nil
+}
+
+// findGPUIndices maps GPU UUIDs to GPU indices.
+// This is a stub implementation that just returns "0".
+// The real implementation is planned to be done in a component other than the controller.
+func mapToGPUIndices(gpuUUIDs []string) string {
+	return "0"
+}

--- a/pkg/controller/dual-pods/server-requesting.go
+++ b/pkg/controller/dual-pods/server-requesting.go
@@ -103,7 +103,7 @@ func (ctl *controller) processServerRequestingPod(ctx context.Context, requestin
 		logger.Error(err, "Failed to create server-running pod", "name", serverRunningPod.Name)
 		return err, true
 	}
-	logger.V(5).Info("Created server-running pod", "name", serverRunningPod.Name)
+	logger.V(2).Info("Created server-running pod", "name", serverRunningPod.Name)
 
 	logger.V(5).Info("Processed server-requesting pod", "name", requestingPod.Name)
 	return nil, false

--- a/pkg/controller/dual-pods/server-requesting.go
+++ b/pkg/controller/dual-pods/server-requesting.go
@@ -130,15 +130,6 @@ func composeServerRunningPod(reqPod *corev1.Pod, data api.RunnerData) (*corev1.P
 		return nil, fmt.Errorf("yaml to json: %w", err)
 	}
 
-	// remove the requester container
-	for i, c := range reqPod.Spec.Containers {
-		if c.Name == api.RequesterContainerName {
-			reqPod.Spec.Containers[i] = reqPod.Spec.Containers[len(reqPod.Spec.Containers)-1]
-			reqPod.Spec.Containers = reqPod.Spec.Containers[:len(reqPod.Spec.Containers)-1]
-			break
-		}
-	}
-
 	// marshal into json
 	origJSON, err := json.Marshal(reqPod)
 	if err != nil {

--- a/pkg/controller/dual-pods/server-running.go
+++ b/pkg/controller/dual-pods/server-running.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dualpods
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/api"
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/stub/api"
+)
+
+func (ctl *controller) processServerRunningPod(ctx context.Context, runningPod *corev1.Pod) (error, bool) {
+	logger := klog.FromContext(ctx)
+	logger.V(5).Info("Processing server-running pod", "name", runningPod.Name)
+
+	// get the server-requesting pod from the owner reference
+	if len(runningPod.OwnerReferences) == 0 {
+		logger.V(5).Info("No owner reference found", "name", runningPod.Name)
+		return nil, true
+	}
+	ownerRef := runningPod.OwnerReferences[0]
+	requestingPod, err := ctl.podLister.Pods(runningPod.Namespace).Get(ownerRef.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.V(5).Info("server-requesting pod not found", "name", runningPod.Name, "ownerName", ownerRef.Name)
+			return nil, true
+		}
+		logger.Error(err, "Failed to get server-requesting pod", "name", runningPod.Name, "ownerName", ownerRef.Name)
+		return err, true
+	}
+
+	port := requestingPod.Annotations[api.AdminPortAnnotationName]
+	if port == "" {
+		port = api.AdminPortAnnotationDefaultValue
+	}
+	url := fmt.Sprintf("http://%s:%s", requestingPod.Status.PodIP, port)
+	if runningPod.Status.PodIP != "" {
+		logger.V(5).Info("Server-running pod exists with IP", "name", runningPod.Name)
+		url += stubapi.BecomeReadyPath
+	} else {
+		logger.V(5).Info("Server-running pod exists but has no IP yet", "name", runningPod.Name)
+		url += stubapi.BecomeUnreadyPath
+	}
+	err = postToReadiness(url)
+	if err != nil {
+		logger.Error(err, "Failed to relay the readiness", "url", url)
+		return err, true
+	}
+	logger.V(5).Info("Successfully relayed the readiness", "name", runningPod.Name)
+
+	logger.V(5).Info("Processed server-running pod", "name", runningPod.Name)
+	return nil, false
+}
+
+func postToReadiness(url string) error {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Post(url, "application/json", nil)
+	if err != nil {
+		return fmt.Errorf("http post %q: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/pkg/server/requester/spi/server.go
+++ b/pkg/server/requester/spi/server.go
@@ -35,7 +35,7 @@ import (
 func gpuHandler(gpuUUIDs []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if len(gpuUUIDs) == 0 {
-			http.Error(w, "no GPUs found", http.StatusInternalServerError) // TODO(waltforme): check the code
+			http.Error(w, "no GPUs found", http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
This PR implements some basic logic of the dual-pods controller.

This PR includes a demo exercising the implementation, captured in terminal typescripts, as `cmd/requester/README.md`.

The demo shows
- The creation of server-running pod in response to the creation of the server-requesting pod;
- The loading of locally cached`ibm-granite/granite-3.3-2b-instruct` from in-cluster volume;
- The relayed readiness from the server-running pod to the server-requesting pod;
- The deletion of server-running pod in response to the deletion of the server-requesting pod.

Closes #24 
Closes #25, maybe?