### PR TITLE
Add node mapper

### DIFF
--- a/scripts/ensure-nodes-mapped.sh
+++ b/scripts/ensure-nodes-mapped.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Usage: $0
+# Usage: $0 [-X]
 # Working directory is irrelevant.
 
 # Purpose: ensure that a ConfigMap named "gpu-map" exists in the current
@@ -9,6 +9,8 @@
 # for a map from GPU UUID to GPU index.
 
 set -e
+
+if [[ "$1" == "-X" ]]; then set -x; fi
 
 if ! kubectl get cm gpu-map &> /dev/null; then
     kubectl create cm gpu-map
@@ -46,6 +48,6 @@ EOF
     kubectl wait pod/${node}-map --for='jsonpath={.status.phase}'=Succeeded
     map=$(kubectl logs ${node}-map | while read index id; do echo -n " \"$id\": $index"; done)
     kubectl delete pod ${node}-map
-    map_qq=$(sed 's/"/\\\"/g' <<<$map)
+    map_qq=$(sed 's/"/\\\"/g' <<<"${map}")
     kubectl patch cm gpu-map -p "{\"data\": {\"${node}\": \"{${map_qq%,}}\"}}"
 done


### PR DESCRIPTION
This PR adds a script that publishes the GPU UUID to index mapping for every node that has nvidia GPUs. The publication is in a ConfigMap object named "gpu-map", in the current Kubernetes namespace. For each relevant node, the script ensures that this ConfigMap has a data item whose name is the node's name. If an item is missing, the script adds it with a value that is JSON for the map from UUID to index.

Successfully tested in the platform-eval cluster.