### PR TITLE
Make dual-pod controller use gpu-map ConfigMap

### DIFF
--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -282,7 +282,7 @@ func (ctl *controller) processConfigMap(ctx context.Context, cmRef cache.ObjectN
 	for nodeName, mapStr := range cm.Data {
 		_, err := ctl.nodeLister.Get(nodeName)
 		if err != nil && errors.IsNotFound(err) {
-			logger.V(3).Info("Ignoring entry in GPU map because key is not a Node name", "nodeName", nodeName)
+			logger.V(3).Info("Ignoring entry in GPU map because key is not a Node name", "key", nodeName)
 			continue
 		}
 		var nodesMap map[string]uint

--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -38,6 +38,12 @@ import (
 )
 
 const ControllerName = "dual-pods-controller"
+
+// GPUMapName is the name of the ConfigMap(s) parsed to discover the mapping from GPU UUID to location.
+// Any ConfigMap found with this name will be taken as the whole of the answer.
+// TODO: get clarity on whether to focus on one namespace.
+// Every data item in the ConfigMap is expected to have a name that is the name of a Node
+// and a value that is JSON for a map from UUID to index.
 const GPUMapName = "gpu-map"
 
 type Controller interface {


### PR DESCRIPTION
This PR supplies the controller-side functionality to map GPU UUID to index, which is needed in Milestones 1 and 2 but not 3.

This PR also introduces the usual command line flags for kube client configuration.

This PR also introduces focus on one namespace (which I think is right but I am not sure).