### PR TITLE
Make the push conditional, not the job

### DIFF
--- a/.github/workflows/build-requester-image.yml
+++ b/.github/workflows/build-requester-image.yml
@@ -40,7 +40,6 @@ jobs:
           echo "GITHUB_ACTION_REF=$GITHUB_ACTION_REF"
 
   build-llm-d-requester:
-    if: github.repository_owner == github.actor
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -76,7 +75,7 @@ jobs:
           context: .
           file: ./dockerfiles/Dockerfile.requester
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: "${{ github.repository_owner == github.actor }}"
           provenance: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The PR updates the requester build workflow to always do the build, only the push needs to be conditional.