### PR TITLE
Stop inheriting annotations

### DIFF
--- a/dockerfiles/Dockerfile.requester
+++ b/dockerfiles/Dockerfile.requester
@@ -32,6 +32,4 @@ FROM nvcr.io/nvidia/cuda:12.8.0-base-ubuntu22.04
 WORKDIR /
 COPY --from=builder /workspace/bin/requester /app/requester
 
-USER 65532:65532
-
 ENTRYPOINT ["/app/requester"]

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -39,7 +39,7 @@ package api
 // --- by the following procedure ---
 // into the spec and label and annotation metadata given to the kube-apiserver
 // to define the server-running Pod.
-// 1. Remove the annotations whose name begins with "dual-pod.llm-d.ai/".
+// 1. Remove all annotations;
 // 2. Apply the patch
 
 const ServerPatchAnnotationName = "dual-pod.llm-d.ai/server-patch"


### PR DESCRIPTION
This PR makes a design change, so that the nominal server-running Pod's annotations are not based on the server-requesting Pod's annotations but only come from the server patch. I make this change because I observed in trials that the server-requesting Pod had several annotations that were (a) added by various platform components and (b) were specific to the network identity of the server-requesting Pod. I doubt that we can write an adequate rule for filtering out all the platform-supplied annotations that are specific to the server-requesting Pod's identity.

This PR also improves the example in cmd/requester/README.md to use a ReplicaSet instead of a Pod.

This PR also removes the userid stipulation in the requester Dockerfile, because this gives OpenShift indigestion (under normal circumstances, which I do not seem to have at the moment in my test cluster).