### PR TITLE
Rename Job to match filename in build-requester-image.yml

### DIFF
--- a/.github/workflows/build-requester-image.yml
+++ b/.github/workflows/build-requester-image.yml
@@ -1,4 +1,4 @@
-name: Requester Image Build
+name: Build Requester Image
 
 on:
   push:


### PR DESCRIPTION
Experience shows that once you have more than a few workflows, it is very helpful for the `name` in the file to match the file name.