### PR TITLE
Make E2E test go faster

### DIFF
--- a/test/e2e/mkrs.sh
+++ b/test/e2e/mkrs.sh
@@ -32,7 +32,9 @@ spec:
             containers:
             - name: inference-server
               image: $server_img
-              command: [ /ko-app/test-server ]
+              command:
+              - /ko-app/test-server
+              - --startup-delay=22
               resources:
                 limits:
                   cpu: "2"


### PR DESCRIPTION
This PR modifies the E2E test script to run more quickly, by making the test server delay less time before becoming "ready".

This PR also modifies the E2E test script to put blank lines around and a green check mark before each success notification.