### PR TITLE
E2E fixes

### DIFF
--- a/test/e2e/mkrs.sh
+++ b/test/e2e/mkrs.sh
@@ -37,7 +37,7 @@ spec:
               - --startup-delay=22
               resources:
                 limits:
-                  cpu: "1"
+                  cpu: "200m"
                   memory: 9Gi
               readinessProbe:
                 httpGet:
@@ -79,7 +79,7 @@ spec:
           resources:
             limits:
               nvidia.com/gpu: "1"
-              cpu: "1"
+              cpu: "200m"
               memory: 250Mi
       serviceAccount: testreq
 EOF

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -324,8 +324,10 @@ rs5=$(test/e2e/mkrs.sh)
 
 expect "kubectl get pods -o name | grep -c '^pod/$rs5' | grep -w 2"
 
-# Controller should have requested deletion of provider for RS 2
-[ -n "$(kubectl get pod $prv2 -o jsonpath={.metadata.deletionTimestamp})" ]
+# Provider for RS 2 should be gone or going
+if dsts="$(kubectl get pod $prv2 -o jsonpath={.metadata.deletionTimestamp})"
+then [ -n "$dsts" ]
+fi
 
 pods=($(kubectl get pods -o name | grep "^pod/$rs5" | sed s%pod/%%))
 req5=${pods[0]}


### PR DESCRIPTION
This PR adds checking to catch the fact that the test has been running out of CPU. And reduces the CPU need so that the test passes.

Fixes #122