### PR TITLE
🐛 Add VLLM_SERVER_DEV_MODE=1 where overlooked

### DIFF
--- a/docs/e2e-recipe.md
+++ b/docs/e2e-recipe.md
@@ -241,6 +241,8 @@ spec:
               - --max-model-len=32768
               - --gpu-memory-utilization=0.8
               env:
+              - name: VLLM_SERVER_DEV_MODE
+                value: "1"
               - name: VLLM_CACHE_ROOT
                 value: /pvcs/shared/vcp/vllm
               - name: FLASHINFER_WORKSPACE_BASE


### PR DESCRIPTION
This PR fixes an oversight in `docs/e2e-recipe.md`, the environment variable setting VLLM_SERVER_DEV_MODE=1 was missing in one of the two definitions of `function mkrs`.