### PR TITLE
DPC Benchmarking Tool

### DIFF
--- a/inference_server/benchmark/benchmark.md
+++ b/inference_server/benchmark/benchmark.md
@@ -1,0 +1,113 @@
+# Dual-Pods Benchmarking Tool
+The **Dual-Pods Benchmarking Tool** measures and reports the startup and readiness
+latency of model-serving pods within the LLM-D Fast Model Actuation workflow.
+
+## Purpose
+The goal is to quantify and compare how quickly a model-serving duo (server-requesting
+and server-providing pods) becomes available under different actuation conditions such
+as cold starts, wake-ups from a sleeping state, using prewarmed pods, etc. These metrics
+will guide future optimizations for the **Dual-Pods Controller (DPC)**. Ultimately, the goal
+is *high predictability*, which is defined as achieving close to 100% hit rate of awakening
+available, sleeping pods on cluster GPUs as function of total inference server
+requests for common user scenarios.
+
+## Baseline Startup Latency
+
+**Objective:**
+Measure the time from **deployment (server-request submission)** to **dual-pod readiness**.
+
+### Inputs
+
+| Parameter           | Type   | Required | Default                                 | Description                                                                                            |
+| ------------------ | ------ | -------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `--namespace`      | `str`  | **Yes**  | —                                       | Openshift namespace to run benchmark                                      |
+| `--yaml`           | `str`  | **Yes**  | —                                       | Path to the server-requesting YAML template file              |
+| `--image`          | `str`  | **Yes*** | —                                       | Image repository for the requester pod. Required *only if* `CONTAINER_IMG_REG` env var is **not** set |
+| `--tag`            | `str`  | **Yes*** | —                                       | Image tag for the requester pod. Required *only if* `CONTAINER_IMG_VERSION` env var is **not** set    |
+| `--cleanup`        | `bool` | No       | `True`                                  | Whether to clean up created resources after the benchmark                                             |
+| `--iterations`     | `int`  | No       | `1`                                     | Number of times to run each benchmark scenario                                                        |
+| `--cluster-domain` | `str`  | No       | `fmaas-platform-eval.fmaas.res.ibm.com` | Cluster domain for Prometheus GPU metrics query                                                           |
+| `--model-path`     | `str`  | No       | `None`                                  | Path to JSON file containing models for scenario (used only in the `new_variant` scenario).                           |
+| `--scenario`       | `str`  | No       | `"scaling"`                             | Benchmark scenario to run: `baseline`, `scaling`, or `new_variant`.                                    |
+
+
+### Outputs
+
+| Output                 | Description                                                                |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `startup_time`         | Total time from deployment to readiness                                    |
+| `availability_mode`    | Indicates whether the vLLM instance was started cold or resumed from sleep |
+
+**Example Usage**
+```bash
+python3 inference_server/benchmark/bechmark_base.py --namespace <str> --yaml <str> --cleanup <bool,default:True> --iterations <int, default:1> --cluster-domain <str> --model-path <str> --scenario <str, default:scaling> --image <str> --tag <str>
+```
+
+**Output Example (Subject to Change)**
+
+```
+2025-12-01 13:59:52,031 - INFO - scale-request-3-1764615426-4pztx-dual-lhv7s:scale-request-3-1764615426-v9jkh bound through a HIT.
+2025-12-01 13:59:52,053 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 13:59:52,496 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 13:59:53,930 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 13:59:53,962 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 13:59:53,972 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 13:59:55,900 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 14:00:03,738 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 14:00:33,850 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 14:01:03,904 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 14:01:22,404 - INFO - Checking readiness of Requester Pod:scale-request-3-1764615426-ktcqd
+2025-12-01 14:01:22,405 - INFO - Requester Pod:scale-request-3-1764615426-ktcqd ready after 108s on node:fmaas-vllm-d-wv25b-worker-h100-3-hmtwn using GPU:GPU-ca8ae222-50e0-b69e-16f2-e49dac1afe28
+2025-12-01 14:01:22,405 - INFO - scale-request-3-1764615426-ktcqd-dual-pptzq:scale-request-3-1764615426-ktcqd bound through a COLD START.
+2025-12-01 14:01:22,405 - INFO - ✅ All pods {'scale-request-3-1764615426-hvxjg', 'scale-request-3-1764615426-v9jkh', 'scale-request-3-1764615426-ktcqd'} Ready after 108.97s
+replicaset.apps "scale-request-3-1764615426" deleted
+pod "scale-request-3-1764615426-9hlb2-dual-dgcg2" deleted
+pod "scale-request-3-1764615426-hvxjg-dual-59hc8" deleted
+pod "scale-request-3-1764615426-4pztx-dual-lhv7s" deleted
+pod "scale-request-3-1764615426-ktcqd-dual-pptzq" deleted
+2025-12-01 14:01:32,868 - INFO - ---------------------------------------------------------------------
+
+Total Runs: 15
+Successful Runs: 15
+Failed Runs: 0
+Requester Pods
+	Min: 9s,
+	Max: 318s
+	Average: 125.4s
+	Median: 115s
+Hits: 3/6 (50%)
+Hit Wake-up Times
+	Min: 9s,
+	Max: 18s
+	Average: 13.0s
+```
+
+## Benchmarking Scenarios (WIP)
+
+| Scenario                      | Description                                                                                                                                           |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fast Replica Scale Up**     | As a ModelService Owner, I can scale up the number of active replicas for a variant from 0 to 1 or 1 to 2 with minimal latency |
+| **Introducing New Variant**   | As a ModelService Owner, I can deploy a newly released variant in anticipation of user requests |
+| **Free Up Cluster Resources** | As a Cluster Operator, I can reduce/deactivate resource intensive variants to make space for numerous smaller model variants |
+| **Resource Request Justification** | As a Workload Owner, I can stress-test my namespace's resources to justify more resource requests (routes, gateways, GPUs) from cluster operator |
+| **Maintenance Planning**      | As a Cluster Operator, I can validate the cluster performance is similar or better after node maintenance schedules and upgrades |
+
+
+## Benchmarking Matrix (WIP)
+
+| Scenario                      | Cold Start (No Launcher)  | Cold Start (w/ Launcher)  | Caching (No Launcher) | Caching (w/ Launcher) | Scale Up (No Sleep) | Scale Up (Sleep + GPU Hit/Bind) |
+| ----------------------------- | ------------------------- | ------------------------- | --------------------  | --------------------- | ------------------- | ------------------------------- |
+| **Introducing New Variant**   |                           |                           |                       |                       |                     |                                 |
+| **Fast Replica Scale Up**     |                           |                           |                       |                       |                     |                                 |
+| **Free Up Cluster Resources** |                           |                           |                       |                       |                     |                                 |
+| **Resource Request Justification** |                      |                           |                       |                       |                     |                                 |
+| **Maintenance Planning**      |                           |                           |                       |                       |                     |                                 |
+
+
+### Next steps
+
+This benchmarking framework may be integrated into an existing or a new LLM-D benchmark harness. It should:
+
+- Continuously measure actuation latency across GPU and node changes in the cluster, plus various model variants.
+
+- Validate improvements across llm-d releases and DPC changes.

--- a/inference_server/benchmark/benchmark_base.py
+++ b/inference_server/benchmark/benchmark_base.py
@@ -1,0 +1,395 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Standard imports
+from datetime import datetime
+from json import loads
+from pathlib import Path
+from statistics import median
+from subprocess import run as invoke_shell
+from typing import Any, Dict, List, Optional
+
+# Local imports
+from kube_ops import KindKubernetesOps, RemoteKubernetesOps, SimKubernetesOps
+from scenarios import (
+    run_baseline_scenario,
+    run_new_variant_scenario,
+    run_scaling_scenario,
+)
+from utils import BaseLogger, parse_request_args, replace_repo_variables
+
+
+class DualPodsBenchmark:
+    """Benchmark class for dual-pod inference server readineness."""
+
+    def __init__(
+        self,
+        op_mode: str = "kind",
+        simulation_delays: Optional[Dict[str, float]] = None,
+        log_output_file: str = "metrics.log",
+        cluster_name: str = "fmabenchmark",
+        model_path: Optional[str] = None,
+    ):
+        """
+        Initialize the benchmark class.
+
+        :param op_mode: The operational mode for the benchmark (one of remote, kind, or
+                        simulated)
+        :param simulation_delays: Customized delays in secs for the simulated mode.
+        :param log_output_file: File path for logging output
+        :param cluster_name: Name of the cluster for kind mode
+        :param model_path: Path to JSON file containing models for new_variant scenario
+        """
+        logger = BaseLogger(log_output_file, self.__class__.__name__)
+        self.logger = logger.get_custom_logger()
+        self.logger.info("Logger Type: %s" % (self.logger.name))
+        self.op_mode = op_mode
+        if op_mode == "kind":  # Default
+            self.logger.info(f"Operating with kind cluster: {cluster_name}")
+            # Set context with a kind cluster.
+            self.k8_ops = KindKubernetesOps(self.logger, cluster_name)
+
+        elif op_mode == "remote":
+            self.logger.info("Operating with remote cluster.")
+            # Load config for the remote cluster.
+            self.k8_ops = RemoteKubernetesOps(self.logger)
+
+        elif op_mode == "simulated":
+            self.logger.info("Operating in simulated mode.")
+            # Load simulation parameters for the particular scenario.
+            self.k8_ops = SimKubernetesOps(self.logger)
+        else:
+            raise ValueError("Mode must be one of [kind, remote, simulated]")
+
+        self.results: List[Dict[str, Any]] = []
+        self.intermediate_files: List[str] = []
+        self.template_files: List[str] = []
+        self.provider_pods: List[str] = []
+
+        # Parse inputs and set as class properties
+        parsed_inputs = self.parse_inputs()
+        self.namespace = parsed_inputs[0]
+        self.yaml_template_file = parsed_inputs[1]
+        self.requester_img = parsed_inputs[2]
+        self.requester_img_tag = parsed_inputs[3]
+        self.cleanup_enabled = parsed_inputs[4]
+        self.iterations = parsed_inputs[5]
+        self.cluster_domain = parsed_inputs[6]
+        parsed_model_path = parsed_inputs[7]
+        self.scenario = parsed_inputs[8]
+        self.max_replicas = parsed_inputs[9]
+
+        # Use model_path from parameter if provided, otherwise from parsed args
+        self.model_path = model_path if model_path is not None else parsed_model_path
+
+        input_str = self.describe_inputs()
+        self.logger.info(input_str)
+
+    def describe_inputs(self):
+        """Get pretty print version of the user inputs"""
+        pretty_print_str = "Namespace: {} \n".format(self.namespace)
+        pretty_print_str += "Request YAML File: {}\n".format(self.yaml_template_file)
+        pretty_print_str += "Requester Pod Image: {} \n".format(self.requester_img)
+        pretty_print_str += "Cleanup all pods at end of run: {} \n".format(
+            self.cleanup_enabled
+        )
+        if self.iterations > 1:
+            pretty_print_str += "Requested Iterations: {} \n".format(self.iterations)
+        else:
+            pretty_print_str += "Default Iterations: {} \n".format(self.iterations)
+        pretty_print_str += "Cluster domain: {} \n".format(self.cluster_domain)
+        pretty_print_str += "Scenario: {}".format(self.scenario)
+
+        if self.model_path:
+            pretty_print_str += "\nModel Path: {}".format(self.model_path)
+
+        if self.max_replicas > 1:
+            pretty_print_str += "\nRequested Max Replicas: {}".format(self.max_replicas)
+
+        return pretty_print_str
+
+    def parse_inputs(self) -> tuple:
+        """Parse user inputs from the CLI."""
+        all_args = parse_request_args()
+        ns = all_args.namespace
+        yaml_template = all_args.yaml
+        requester_img = all_args.image
+        requester_img_tag = all_args.tag
+        cleanup = all_args.cleanup
+        iterations = all_args.iterations
+        cluster_domain = (
+            all_args.cluster_domain if hasattr(all_args, "cluster_domain") else None
+        )
+        model_path = getattr(all_args, "model_path", None)
+        scenario = getattr(all_args, "scenario", "scaling")
+        max_replicas = all_args.max_replicas
+
+        if scenario == "new_variant" and not model_path:
+            raise ValueError(
+                "The --model-path argument is required when scenario=new_variant"
+            )
+
+        # Generate the request YAML from template and image details.
+        request_yaml_template_file = replace_repo_variables(
+            requester_img, requester_img_tag, yaml_template
+        )
+
+        # Track the template file for cleanup
+        self.template_files.append(str(request_yaml_template_file))
+
+        return (
+            ns,
+            request_yaml_template_file,
+            requester_img,
+            requester_img_tag,
+            cleanup,
+            iterations,
+            cluster_domain,
+            model_path,
+            scenario,
+            max_replicas,
+        )
+
+    def create_request_yaml(self, rs_name: str, yaml_template_file: str) -> str:
+        """
+        Generate a request YAML file from the replicaset name.
+
+        :param rs_name: A unique name for the replicaset.
+        :param yaml_template_file: A "template" file with the container image registry
+                                   and tag already filled in.
+        :return: A string representing the path to the YAML file.
+        """
+        # Invoke the replacement with the unique replicaset name.
+        sed_cmd = "s#${REPLICASET_NAME}#" + rs_name + "#"
+        rs_name_yaml = rs_name + ".yaml"
+        with Path(rs_name_yaml).open(mode="wb") as rs_yaml_fd:
+            invoke_shell(
+                ["sed", "-e", sed_cmd, yaml_template_file],
+                stdout=rs_yaml_fd,
+                check=False,
+            )
+
+        return rs_name_yaml
+
+    def run_benchmark(
+        self,
+        timeout: int = 1000,
+        scenario: str = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Run the benchmark.
+
+        :param timeout: Timeout for each run in seconds.
+        :param scenario: Benchmark scenario ("baseline", "scaling", or "new_variant").
+                        If None, uses the scenario from command line arguments.
+        :return: List of result dictionaries.
+        """
+
+        # Use provided scenario or default to instance scenario
+        benchmark_scenario = scenario if scenario is not None else self.scenario
+
+        if benchmark_scenario == "scaling":
+            return run_scaling_scenario(self, timeout, self.yaml_template_file)
+        elif benchmark_scenario == "new_variant":
+            return run_new_variant_scenario(self, timeout, self.yaml_template_file)
+
+        return run_baseline_scenario(
+            self, timeout, benchmark_scenario, self.yaml_template_file
+        )
+
+    def get_results(self) -> Dict[str, Any]:
+        """
+        Aggregate and return the benchmark results.
+
+        :return: Dict with summary of stats (e.g., average, min, max, etc)
+        """
+        if not self.results:
+            return {}
+
+        success_runs = [run for run in self.results if run.success]
+        rq_times = [run.rq_time for run in success_runs if run.rq_time is not None]
+
+        # For scaling scenarios, only count hits from the
+        # only phase that can wake up sleeping provider pods
+        if any(run.scenario == "scaling" for run in self.results):
+            scale_up_again_runs = [
+                run for run in success_runs if run.phase == "up_again"
+            ]
+            hit_runs = [run for run in scale_up_again_runs if run.avail_mode == "Hit"]
+            hits = len(hit_runs)
+            hit_rq_times = [run.rq_time for run in hit_runs if run.rq_time is not None]
+            hit_percent_base = len(scale_up_again_runs)
+        else:
+            # For non-scaling scenarios, use all successful runs
+            hit_runs = [run for run in success_runs if run.avail_mode == "Hit"]
+            hits = len(hit_runs)
+            hit_rq_times = [run.rq_time for run in hit_runs if run.rq_time is not None]
+            hit_percent_base = len(success_runs)
+
+        summary = {
+            "total_runs": len(self.results),
+            "successful_runs": len(success_runs),
+            "failed_runs": len(self.results) - len(success_runs),
+            "hits": hits,
+            "total_hit_runs": hit_percent_base,
+            "hit_percent": (
+                int((hits / hit_percent_base) * 100) if hit_percent_base > 0 else 0
+            ),
+            "rq_min": min(rq_times) if rq_times else None,
+            "rq_max": max(rq_times) if rq_times else None,
+            "rq_avg": (sum(rq_times) / len(rq_times) if rq_times else None),
+            "rq_median": median(rq_times) if rq_times else None,
+            "hit_prv_min": min(hit_rq_times) if hit_rq_times else None,
+            "hit_prv_max": max(hit_rq_times) if hit_rq_times else None,
+            "hit_prv_avg": (
+                sum(hit_rq_times) / len(hit_rq_times) if hit_rq_times else None
+            ),
+            "all_results": self.results,
+        }
+
+        return summary
+
+    def pretty_print_results(self):
+        """Log the results in a human readable format."""
+        summary = self.get_results()
+        total_runs = summary["total_runs"]
+        success_runs = summary["successful_runs"]
+        failed_runs = summary["failed_runs"]
+        hits = summary["hits"]
+        total_hit_runs = summary["total_hit_runs"]
+        hit_percent = summary["hit_percent"]
+        rq_min = summary["rq_min"]
+        rq_max = summary["rq_max"]
+        rq_avg = summary["rq_avg"]
+        rq_median = summary["rq_median"]
+        hit_prv_min = summary["hit_prv_min"]
+        hit_prv_max = summary["hit_prv_max"]
+        hit_prv_avg = summary["hit_prv_avg"]
+
+        run_str = (
+            "---------------------------------------------------------------------"
+        )
+        run_str += (
+            f"\n\nTotal Runs: {total_runs}\n" + f"Successful Runs: {success_runs}\n"
+        )
+        run_str += f"Failed Runs: {failed_runs}\n"
+        rq_stats = f"Requester Pods \n\tMin: {rq_min}s, \n\tMax: {rq_max}s"
+        rq_stats += f"\n\tAverage: {rq_avg}s"
+        rq_stats += f"\n\tMedian: {rq_median}s\n"
+        avail_stats = f"Hits: {hits}/{total_hit_runs} ({hit_percent}%)\n"
+
+        if hits > 0:
+            hit_stats = (
+                f"Hit Wake-up Times \n\tMin: {hit_prv_min}s, \n\tMax: {hit_prv_max}s"
+            )
+            hit_stats += f"\n\tAverage: {hit_prv_avg}s\n"
+            avail_stats += hit_stats
+
+        summary_str = "".join([run_str, rq_stats, avail_stats])
+        self.logger.info(summary_str)
+
+    def cleanup_intermediate_files(self):
+        """Clean up intermediate YAML files created during benchmark iterations."""
+        for yaml_file in self.intermediate_files:
+            try:
+                Path(yaml_file).unlink(missing_ok=True)
+                self.logger.debug(f"Cleaned up intermediate file: {yaml_file}")
+            except Exception as e:
+                self.logger.warning(f"Failed to clean up {yaml_file}: {e}")
+
+        # Also clean up template files created during input parsing
+        for template_file in self.template_files:
+            try:
+                Path(template_file).unlink(missing_ok=True)
+                self.logger.debug(f"Cleaned up template file: {template_file}")
+            except Exception as e:
+                self.logger.warning(
+                    f"Failed to clean up template file {template_file}: {e}"
+                )
+
+    def cleanup_resources(self):
+        """Clean up any remaining resources in kind or remote cluster."""
+        if hasattr(self, "provider_pods"):
+            for provider_pod in self.provider_pods:
+                self.logger.debug(f"Cleaning up provider pod: {provider_pod}")
+                self.k8_ops.delete_pod(self.namespace, provider_pod)
+            self.provider_pods.clear()
+
+    def query_gpu_usage(self):
+        """Query GPU usage from Prometheus metrics in OpenShift cluster."""
+        cluster_domain = self.cluster_domain
+        if not cluster_domain:
+            self.logger.warning("cluster_domain not set, skipping GPU usage query")
+            return []
+
+        try:
+            token_result = invoke_shell(
+                ["oc", "whoami", "-t"], capture_output=True, text=True, check=True
+            )
+            token = token_result.stdout.strip()
+
+            prometheus_url = (
+                f"https://prometheus-k8s-openshift-monitoring.apps."
+                f"{cluster_domain}/api/v1/query"
+            )
+            query_result = invoke_shell(
+                [
+                    "curl",
+                    "-sSkG",
+                    "-H",
+                    f"Authorization: Bearer {token}",
+                    "--data-urlencode",
+                    "query=DCGM_FI_DEV_FB_USED",
+                    prometheus_url,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            self.logger.debug(f"Query Result: \n{query_result}\n")
+
+            gpu_data = loads(query_result.stdout)
+            gpu_list = []
+            for result in gpu_data.get("data", {}).get("result", []):
+                gpu_info = {
+                    "Hostname": result["metric"].get("Hostname"),
+                    "GPU": result["metric"].get("gpu"),
+                    "ID": result["metric"].get("UUID"),
+                    "Assoc": result["metric"].get("exported_namespace") is not None,
+                    "Mem": result["value"][1] if len(result["value"]) > 1 else None,
+                }
+                gpu_list.append(gpu_info)
+
+            gpu_list.sort(key=lambda x: (x["Hostname"] or "", x["GPU"] or ""))
+            for gpu in gpu_list:
+                if gpu["Mem"] and float(gpu["Mem"]) > 0:
+                    self.logger.info(f"GPU: {gpu}")
+
+            return gpu_list
+
+        except Exception as e:
+            self.logger.warning(f"Failed to query GPU usage: {e}")
+            return []
+
+
+if __name__ == "__main__":
+    # Create benchmark instance (automatically parses command line arguments)
+    date_stamp = datetime.now().isoformat(timespec="minutes")
+    log_output_file = f"benchmark-{date_stamp}.log"
+    benchmark = DualPodsBenchmark("remote", log_output_file=log_output_file)
+
+    # Run benchmark using scenario from command line args (defaults to "scaling")
+    results = benchmark.run_benchmark(timeout=1000)
+    benchmark.pretty_print_results()

--- a/inference_server/benchmark/benchmark_diagnostics.py
+++ b/inference_server/benchmark/benchmark_diagnostics.py
@@ -1,0 +1,116 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard imports
+from dataclasses import dataclass
+from enum import Enum
+from logging import Logger
+from pathlib import Path
+from subprocess import run as invoke_shell
+from typing import List
+
+
+class ScenarioStatus(Enum):
+    SUCCESS = 1
+    FAILURE = 2
+
+
+@dataclass
+class BoundProviderPodInfo:
+    """A datastore for information on server providing pod in ready state."""
+
+    requester: str
+    provider: str
+    rq_time: int
+    avail_mode: str
+    node: str
+    accelerator_info: str
+
+
+@dataclass
+class IterationResult:
+    """A datastore for the result of a benchmark iteration."""
+
+    success: bool
+    # Defaults to empty when all goes well.
+    error: str = ""
+    scenario: str = "scaling"
+    phase: str = ""
+    iteration: str = ""
+    rq_time: int = 0
+    avail_mode: str = ""
+
+
+@dataclass
+class ScenarioResult:
+    """A datastore for the status and results of a benchmark scenario."""
+
+    # Status is updated in case of failure, otherwise defaults to Success.
+    status: ScenarioStatus
+    # The list of bound provider pods.
+    provider_pods: List
+    # Empty set when all goes well.
+    unready_pods: set = ()
+    # Defaults to empty (no need to pass back) when all goes well.
+    namespace: str = ""
+    # Defaults to empty (no need to pass back) when all goes well.
+    dual_pod_controller: str = ""
+    # Defaults to empty string when all goes well.
+    failed_rs_name: str = ""
+
+
+class BenchmarkDiagnosis:
+    """A diagnostic class to collect info on a failing benchmark before exiting."""
+
+    def __init__(self, logger: Logger):
+        """
+        Initialize the diagnosis class.
+
+        :param logger: The inherited logger to use, if any.
+        """
+        self.logger = logger
+
+    def collect_diagnostics(self, result: ScenarioResult):
+        """
+        Collect logs on a failing pod and dual pod controller.
+        :param result: The data structure with details on the failed iteration.
+        """
+        # Create a directory to house the logs for a failed iteration.
+        rs_name = result.failed_rs_name
+        rs_dir_name = str(Path.cwd().absolute()) + "/" + rs_name + "-failure-logs"
+        Path(rs_dir_name).mkdir()
+        self.logger.info(f"Dumping error logs in {rs_dir_name}")
+
+        # Collect the logs of the dual pod controller pod.
+        dp_log_name = rs_dir_name + "/" + result.dual_pod_controller + ".log"
+        Path(dp_log_name).touch()
+        with Path(dp_log_name).open(mode="wb") as dp_log_fd:
+            invoke_shell(
+                ["kubectl", "logs", "-n", result.namespace, result.dual_pod_controller],
+                stdout=dp_log_fd,
+                check=False,
+            )
+        self.logger.info(f"Dumped DPC logs at {dp_log_name}")
+
+        # Collect the logs of all the pods that never reached ready status.
+        for unready_pod in result.unready_pods:
+            pod_log_name = rs_dir_name + "/" + unready_pod + ".log"
+            Path(pod_log_name).touch()
+            with Path(pod_log_name).open(mode="wb") as pod_log_fd:
+                invoke_shell(
+                    ["kubectl", "logs", "-n", result.namespace, unready_pod],
+                    stdout=pod_log_fd,
+                    check=False,
+                )
+            self.logger.info(f"Dumped Pod log for {unready_pod} at {pod_log_name}")

--- a/inference_server/benchmark/deploy/my_models.json
+++ b/inference_server/benchmark/deploy/my_models.json
@@ -1,0 +1,5 @@
+{
+  "models": ["ibm-granite/granite-3.3-2b-instruct",
+             "ibm-granite/granite-3.2-2b-instruct"
+            ]
+}

--- a/inference_server/benchmark/deploy/server-request-caching-pvc.yaml
+++ b/inference_server/benchmark/deploy/server-request-caching-pvc.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: ${REPLICASET_NAME}
+  labels:
+    app: dp-example
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: dp-example
+  template:
+    metadata:
+      labels:
+        app: dp-example
+      annotations:
+        dual-pod.llm-d.ai/admin-port: "8081"
+        dual-pod.llm-d.ai/server-patch: |
+          metadata:
+            labels: {
+              "model-reg": "ibm-granite",
+              "model-repo": "granite-3.3-2b-instruct",
+              "app": null}
+          spec:
+            containers:
+            - name: inference-server
+              image: docker.io/vllm/vllm-openai:v0.10.2
+              command:
+              - vllm
+              - serve
+              - --port=8000
+              - /pvcs/local/vcp/hf/models--ibm-granite--granite-3.3-2b-instruct/snapshots/707f574c62054322f6b5b04b6d075f0a8f05e0f0
+              - --enable-sleep-mode
+              - --max-model-len=32768
+              - --gpu-memory-utilization=0.8
+              env:
+              - name: VLLM_SERVER_DEV_MODE
+                value: "1"
+              - name: VLLM_CACHE_ROOT
+                value: /pvcs/shared/vcp/vllm
+              - name: FLASHINFER_WORKSPACE_BASE
+                value: /pvcs/shared/vcp/vllm
+              - name: XDG_CONFIG_HOME
+                value: /tmp
+              - name: TRITON_HOME
+                value: /tmp
+              resources:
+                limits:
+                  cpu: "2"
+                  memory: 6Gi
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                initialDelaySeconds: 60
+                periodSeconds: 5
+              volumeMounts:
+              - name: local
+                readOnly: true
+                mountPath: /pvcs/local
+                subPath: vcp-${LOGNAME}
+              - name: shared
+                mountPath: /pvcs/shared
+            volumes:
+            - name: local
+              persistentVolumeClaim:
+                claimName: vcp-local-{{ .NodeName }}
+    spec:
+      containers:
+        - name: inference-server
+          image: quay.io/aavarghese/fma/requester:v0.0.1
+          imagePullPolicy: Always
+          ports:
+          - name: probes
+            containerPort: 8080
+          - name: spi
+            containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              cpu: "1"
+              memory: 250Mi
+      volumes:
+      - name: shared
+        persistentVolumeClaim:
+          claimName: vcp-cephfs-shared

--- a/inference_server/benchmark/deploy/server-request-generic-model.yaml
+++ b/inference_server/benchmark/deploy/server-request-generic-model.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: ${REPLICASET_NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dp-example
+  template:
+    metadata:
+      labels:
+        app: dp-example
+      annotations:
+        dual-pod.llm-d.ai/admin-port: "8081"
+        dual-pod.llm-d.ai/server-patch: |
+          metadata:
+            labels: {
+              "model-reg": ${MODEL_REGISTRY},
+              "model-repo": ${MODEL_REPO},
+              "app": null}
+          spec:
+            containers:
+            - name: inference-server
+              image: docker.io/vllm/vllm-openai:v0.10.2
+              command:
+              - vllm
+              - serve
+              - --port=8000
+              - --model=${MODEL_REGISTRY}/${MODEL_REPO}
+              - --max-model-len=32768
+              - --kv-cache-memory=40974729216
+              env:
+              - name: VLLM_SERVER_DEV_MODE
+                value: "1"
+              - name: VLLM_CACHE_ROOT
+                value: /tmp
+              - name: FLASHINFER_WORKSPACE_BASE
+                value: /tmp
+              - name: XDG_CONFIG_HOME
+                value: /tmp
+              - name: XDG_CACHE_HOME
+                value: /tmp
+              - name: TRITON_HOME
+                value: /tmp
+              resources:
+                limits:
+                  cpu: "2"
+                  memory: 6Gi
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                initialDelaySeconds: 60
+                periodSeconds: 5
+    spec:
+      containers:
+        - name: inference-server
+          image: ${CONTAINER_IMG_REG}/requester:${CONTAINER_IMG_VERSION}
+          imagePullPolicy: Always
+          ports:
+          - name: probes
+            containerPort: 8080
+          - name: spi
+            containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              cpu: "1"
+              memory: 250Mi

--- a/inference_server/benchmark/deploy/server-request-minimal.yaml
+++ b/inference_server/benchmark/deploy/server-request-minimal.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: ${REPLICASET_NAME}
+  labels:
+    app: dp-example
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: dp-example
+  template:
+    metadata:
+      labels:
+        app: dp-example
+      annotations:
+        dual-pod.llm-d.ai/admin-port: "8081"
+        dual-pod.llm-d.ai/server-patch: |
+          metadata:
+            labels: {
+              "model-reg": "ibm-granite",
+              "model-repo": "granite-3.3-2b-instruct",
+              "app": null}
+          spec:
+            containers:
+            - name: inference-server
+              image: docker.io/vllm/vllm-openai:v0.10.2
+              command:
+              - vllm
+              - serve
+              - --port=8000
+              - --model=ibm-granite/granite-3.3-2b-instruct
+              - --enable-sleep-mode
+              - --max-model-len=32768
+              - --gpu-memory-utilization=0.8
+              env:
+              - name: VLLM_SERVER_DEV_MODE
+                value: "1"
+              - name: VLLM_CACHE_ROOT
+                value: /tmp
+              - name: FLASHINFER_WORKSPACE_BASE
+                value: /tmp
+              - name: XDG_CONFIG_HOME
+                value: /tmp
+              - name: XDG_CACHE_HOME
+                value: /tmp
+              - name: TRITON_HOME
+                value: /tmp
+              resources:
+                limits:
+                  cpu: "2"
+                  memory: 9Gi
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                initialDelaySeconds: 60
+                periodSeconds: 5
+    spec:
+      containers:
+        - name: inference-server
+          image: ${CONTAINER_IMG_REG}/requester:${CONTAINER_IMG_VERSION}
+          imagePullPolicy: Always
+          ports:
+          - name: probes
+            containerPort: 8080
+          - name: spi
+            containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              cpu: "1"
+              memory: 250Mi

--- a/inference_server/benchmark/kube_ops.py
+++ b/inference_server/benchmark/kube_ops.py
@@ -1,0 +1,514 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------- Logging setup ----------------
+import logging
+
+# Standard imports.
+from abc import ABC, abstractmethod
+from datetime import datetime
+from logging import Logger
+from random import randint
+from subprocess import CalledProcessError
+from subprocess import run as invoke_shell
+from time import perf_counter, sleep
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from benchmark_diagnostics import (
+    BenchmarkDiagnosis,
+    BoundProviderPodInfo,
+    ScenarioResult,
+    ScenarioStatus,
+)
+
+# Third party imports.
+from kubernetes import client, config, watch
+
+# Local imports
+from utils import delete_yaml_resources
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+file_handler = logging.FileHandler(f"metrics-{datetime.now()}.log")
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(formatter)
+
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.INFO)
+console_handler.setFormatter(formatter)
+
+logger.addHandler(file_handler)
+logger.addHandler(console_handler)
+
+
+# Constants for provider modes
+COLD_START_MODE = "Cold"
+HIT_MODE = "Hit"
+
+# Constants for pod counts
+DUAL_POD_TOTAL = 2
+DUAL_LABEL_KEY = "dual-pods.llm-d.ai/dual"
+REQUESTER_PATCH_ANNOTATION = "dual-pod.llm-d.ai/server-patch"
+ACCELERATOR_ANNOTATION = "dual-pods.llm-d.ai/accelerators"
+
+
+# ---------------- Helper functions ----------------
+def apply_yaml(yaml_file):
+    """Apply a YAML file to the cluster."""
+    invoke_shell(["kubectl", "apply", "-f", yaml_file], check=True)
+
+
+def delete_yaml(yaml_file):
+    """Delete resources from a YAML file."""
+    invoke_shell(
+        ["kubectl", "delete", "-f", yaml_file, "--ignore-not-found=true"],
+        check=False,
+    )
+
+
+def scale_replicaset(yaml_file: str, replicas: int):
+    """Scale the ReplicaSet in the YAML file to the specified number of replicas."""
+    invoke_shell(
+        ["kubectl", "scale", "--replicas", str(replicas), "-f", yaml_file],
+        check=True,
+    )
+
+
+def delete_pod(namespace: str, pod_name: str):
+    """Delete a pod by name in the specified namespace."""
+    invoke_shell(
+        [
+            "kubectl",
+            "delete",
+            "pod",
+            pod_name,
+            "-n",
+            namespace,
+            "--ignore-not-found=true",
+        ],
+        check=False,
+    )
+
+
+def wait_for_dual_pods_ready(
+    v1: client.CoreV1Api,
+    namespace: str,
+    rs_name,
+    timeout=600,
+    expected_replicas=1,
+):
+    """
+    Wait for both dual pods to be ready and return timing information.
+    :param v1: A reference to a CoreV1Api object for the REST calls.
+    :param namespace: The namespace where the replicaset is deployed.
+    :param rs_name: The name of the replicaset whose pods are to be waited.
+    :param timeout: The max time to wait for all the pods to be ready.
+    :param expected_replicas: The number of replicas expected for scaling.
+    """
+    start = perf_counter()
+    elapsed = 0
+    ready_pods = set()
+    provider_pods = []
+
+    # Track the set of pods that do not reach ready state in case of failure.
+    unready_pods = set()
+
+    # Track the dual pod controller pod in case of failure.
+    dual_pod_controller = None
+
+    logger.info(f"Waiting for pods of ReplicaSet: {rs_name}")
+
+    def check_ready(pod):
+        if pod.status.phase == "Running":
+            for cond in pod.status.conditions or []:
+                if cond.type == "Ready" and cond.status == "True":
+                    return True
+        return False
+
+    # Initialize the variables to be returned
+    node_name = None
+    accelerator_info = None
+
+    # Track pods that were already ready when we started watching
+    initial_ready_pods = set()
+    try:
+        # Get initial state of pods
+        pods = v1.list_namespaced_pod(namespace=namespace).items
+        for pod in pods:
+            ex_podname = pod.metadata.name
+
+            if dual_pod_controller is None and "dpctlr" in ex_podname:
+                dual_pod_controller = ex_podname
+
+            pod_annotations = pod.metadata.annotations
+            is_requester = REQUESTER_PATCH_ANNOTATION in pod_annotations
+            if rs_name in ex_podname and check_ready(pod) and is_requester:
+                initial_ready_pods.add(ex_podname)
+
+                # Add them to ready pods for total cardinality of expected replicas.
+                ready_pods.add(ex_podname)
+                logger.debug(f"Initially ready pod {ex_podname}")
+        logger.debug(f"Pods already ready at start: {initial_ready_pods}")
+    except Exception as e:
+        logger.warning(f"Could not get initial pod state: {e}")
+
+    while elapsed < timeout:
+        try:
+            w = watch.Watch()
+            for event in w.stream(
+                v1.list_namespaced_pod,
+                namespace=namespace,
+                timeout_seconds=30,  # Frequent checks to reduce interruption impact
+            ):
+                pod = event["object"]
+                podname = pod.metadata.name
+
+                # Skip any pods that were in the initial set of ready pods or new pods
+                # that have already been accounted for as ready.
+                if podname in initial_ready_pods:
+                    logger.debug(f"Skipping INITIALLY ready pod: {podname}")
+                    continue
+                elif podname in ready_pods:
+                    logger.debug(f"Skipping NEWLY ready pod: {podname}")
+                    continue
+
+                # Add pod if it is not already in the list of unready pods.
+                is_relevant_pod = podname not in ready_pods
+                if (
+                    (rs_name in podname)
+                    and is_relevant_pod
+                    and (podname not in unready_pods)
+                    and is_requester
+                ):
+                    unready_pods.add(podname)
+                    logger.debug(f"UNREADY pod added: {podname}")
+                    logger.debug(f"Updated UNREADY pods: {unready_pods}")
+
+                # Get the labels to filter out provider pods.
+                labels = pod.metadata.labels
+
+                # Filter the requester pods.
+                is_requester = REQUESTER_PATCH_ANNOTATION in pod.metadata.annotations
+                if (rs_name in podname) and is_requester:
+                    logger.info(f"Checking readiness of Requester Pod:{podname}")
+                    if check_ready(pod):
+                        rq_ready = int(perf_counter() - start)
+                        ready_pods.add(podname)
+                        logger.debug(f"\nUpdated ready pods {ready_pods}")
+
+                        # Capture node and accelerator info
+                        node_name = pod.spec.node_name if pod.spec else None
+                        accelerator_info = (
+                            pod.metadata.annotations.get(ACCELERATOR_ANNOTATION)
+                            if pod.metadata.annotations
+                            else None
+                        )
+
+                        logger.info(
+                            f"Requester Pod:{podname} ready after {rq_ready}s "
+                            f"on node:{node_name} using GPU:{accelerator_info}"
+                        )
+
+                        # Checking availability mode.
+                        dual_pod = labels[DUAL_LABEL_KEY]
+                        binding_match = podname in dual_pod
+                        if binding_match:
+                            ready_pods.add(podname)
+                            avail_mode = COLD_START_MODE
+                            logger.info(
+                                f"{dual_pod}:{podname} bound through a COLD START."
+                            )
+                        else:
+                            ready_pods.add(podname)
+                            avail_mode = HIT_MODE
+                            logger.info(f"{dual_pod}:{podname} bound through a HIT.")
+
+                        # Add the provider pod info to the list of bound pods.
+                        provider_info = BoundProviderPodInfo(
+                            podname,
+                            dual_pod,
+                            rq_ready,
+                            avail_mode,
+                            node_name,
+                            accelerator_info,
+                        )
+                        provider_pods.append(provider_info)
+
+                        # Remove the pod pair from the unready pods.
+                        unready_pods.remove(podname)
+                        unready_pods.discard(dual_pod)
+                        logger.debug(f"{podname}:{dual_pod} removed from UNREADY set")
+
+                if len(ready_pods) == expected_replicas:
+                    end = perf_counter()
+                    w.stop()
+                    logger.info(
+                        f"✅ All pods {ready_pods} Ready after {end - start:.2f}s"
+                    )
+                    return (
+                        ScenarioResult(
+                            status=ScenarioStatus.SUCCESS, provider_pods=provider_pods
+                        ),
+                        None,
+                    )
+
+            elapsed = perf_counter() - start
+
+        except Exception as e:
+            logger.warning(
+                f"⚠️ Watch interrupted ({type(e).__name__}: {e}), retrying..."
+            )
+            sleep(1)  # Quick retry
+            elapsed = perf_counter() - start
+
+    # Collect diagnostics data before raising the time out error.
+    logger.debug(f"Unready Pods: {unready_pods}, DPC: {dual_pod_controller}")
+    scenario_result = ScenarioResult(
+        status=ScenarioStatus.FAILURE,
+        provider_pods=provider_pods,
+        unready_pods=unready_pods,
+        namespace=namespace,
+        dual_pod_controller=dual_pod_controller,
+        failed_rs_name=rs_name,
+    )
+    BenchmarkDiagnosis(logger).collect_diagnostics(scenario_result)
+    err = TimeoutError(f"Timed out after {timeout}s waiting for both pods to be Ready.")
+    return scenario_result, err
+
+
+class KubernetesOps(ABC):
+    """Abstract base class for Kubernetes operations (kind vs remote vs sim)."""
+
+    def __init__(self, logger: Logger):
+        """Initiate the instance with a logger from the caller."""
+        self.logger = logger
+
+    @abstractmethod
+    def apply_yaml(self, yaml_file: str) -> None:
+        pass
+
+    @abstractmethod
+    def delete_yaml(self, yaml_file: str) -> None:
+        pass
+
+    @abstractmethod
+    def wait_for_dual_pods_ready(
+        self, ns: str, *args: Any, **kwargs: Dict[Any, Any]
+    ) -> tuple:
+        pass
+
+    @abstractmethod
+    def scale_replicaset(
+        self,
+        request_yaml: str,
+        expected_replicas: int,
+        *args: Any,
+        **kwargs: Dict[Any, Any],
+    ):
+        pass
+
+    @abstractmethod
+    def delete_pod(self, namespace: str, pod_name: str) -> None:
+        pass
+
+
+class KindKubernetesOps(KubernetesOps):
+    """Kubernetes operations using a local kind cluster for time logging functions."""
+
+    def __init__(self, logger: Logger, cluster_name: str):
+        super().__init__(logger)
+
+        self.v1_api = client.CoreV1Api()
+        self.cluster_name = cluster_name
+        self.setup_cluster()
+        config.load_kube_config()
+
+    def apply_yaml(self, yaml_file: str) -> None:
+        apply_yaml(yaml_file)
+
+    def delete_yaml(self, yaml_file: str) -> None:
+        delete_yaml_resources(yaml_file)
+
+    def wait_for_dual_pods_ready(
+        self, ns: str, podname: str, timeout: int, expected_replicas: int
+    ) -> tuple:
+        return wait_for_dual_pods_ready(
+            self.v1_api, ns, podname, timeout, expected_replicas
+        )
+
+    def delete_pod(self, namespace: str, pod_name: str) -> None:
+        delete_pod(namespace, pod_name)
+
+    def setup_cluster(
+        self,
+        dpc_controller_registry: str = "my-registry/my-namespace",
+        dpc_tag: str = "v0.2.0",
+    ):
+        """
+        Create cluster, build appropriate images, and load them into the cluster.
+        :param dpc_controller_registry: The registry for the dual-pod controller.
+        :param dpc_tag: The image tag to use for the dual-pod controller.
+        """
+        # Invoke the script for cluster creation and image build.
+        self.logger.info(f"Setting up cluster: {self.cluster_name}")
+        try:
+            invoke_shell(
+                [
+                    "./inference_server/benchmark/setup_kind_resources.sh",
+                    f"{self.cluster_name}",
+                    f"{dpc_tag}",
+                ],
+                check=True,
+            )
+        except CalledProcessError as cpe:
+            self.logger.debug("Kind Cluster set up errored")
+            self.logger.debug(f"Err: {cpe.stderr}, Output: {cpe.stdout}")
+            exit(1)
+
+        # Deploy the helm chart for the dual pod controller in the cluster.
+        full_registry = dpc_controller_registry + f"/dual-pods-controller:{dpc_tag}"
+        self.logger.info(f"Deploying DPC Image {full_registry} in Kind Cluster")
+        try:
+            invoke_shell(
+                [
+                    "helm",
+                    "upgrade",
+                    "--install",
+                    "dpctlr",
+                    "charts/dpctlr",
+                    "--set",
+                    f"Image={full_registry}",
+                    "--set",
+                    "NodeViewClusterRole=node-viewer",
+                    "--set",
+                    "SleeperLimit=2",
+                    "--set",
+                    "Local=true",
+                ]
+            )
+        except CalledProcessError as cpe:
+            self.logger.debug("Dual Pod Controller deployment in cluster errored")
+            self.logger.debug(f"Err: {cpe.stderr}, Output: {cpe.stdout}")
+            exit(1)
+
+    def clean_up_cluster(self):
+        """Remove the kind cluster and associated resources after benchmark is done."""
+        invoke_shell(
+            ["kind", "delete", "cluster", "--name", self.cluster_name], check=False
+        )
+
+
+class RemoteKubernetesOps(KubernetesOps):
+    """Kubernetes operations for testing with a live, remote cluster."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(logger)
+        config.load_kube_config()
+        self.v1_api = client.CoreV1Api()
+
+    def apply_yaml(self, yaml_file: str) -> None:
+        apply_yaml(yaml_file)
+
+    def delete_yaml(self, yaml_file: str) -> None:
+        delete_yaml(yaml_file)
+
+    def scale_replicaset(self, yaml_file: str, replicas: int) -> None:
+        scale_replicaset(yaml_file, replicas)
+
+    def wait_for_dual_pods_ready(
+        self, ns: str, rs_name: str, timeout: int, expected_replicas: int
+    ) -> tuple:
+        return wait_for_dual_pods_ready(
+            self.v1_api,
+            ns,
+            rs_name,
+            timeout,
+            expected_replicas=expected_replicas,
+        )
+
+    def delete_pod(self, namespace: str, pod_name: str) -> None:
+        delete_pod(namespace, pod_name)
+
+
+class SimKubernetesOps(KubernetesOps):
+    """Kubernetes operations for testing without a live cluster."""
+
+    def __init__(
+        self, logger: Logger, simulated_delays: Optional[Dict[str, float]] = None
+    ):
+        super().__init__(logger)
+        """Set default simulated delays for different setups based on prior data."""
+        self.simulated_delays = simulated_delays or {
+            "Cold Start": 400,
+            "Cached": 82,
+            "Hit": 6,
+        }
+
+    def apply_yaml(self, yaml_file: str) -> None:
+        self.logger.info(f"[SIMULATED] Applying {yaml_file}...")
+
+    def delete_yaml(self, yaml_file: str) -> None:
+        self.logger.info(f"[SIMULATED] Deleting resources from {yaml_file}")
+
+    def scale_replicaset(self, yaml_file: str, expected_replicas: int):
+        self.logger.info(f"[SIMULATED] Scaled for {yaml_file} to {expected_replicas}")
+
+    def wait_for_dual_pods_ready(
+        self,
+        ns: str,
+        rs_name: str,
+        timeout: int,
+        expected_replicas: int,
+        context: Dict[str, Any] = None,
+    ) -> tuple:
+
+        self.logger.info(f"[SIMULATED] Waiting on ReplicaSet: {rs_name}")
+
+        # Simulate readiness time based on contextual delay or defaults.
+        if context is not None and context["Delay"]:
+            rq_delay = context["Delay"]
+            mode = context["Mode"]
+        else:
+            # Randomly select from a cold start delay or provider pod hit.
+            possible_modes = ["Cold Start", "Hit"]
+            mode = possible_modes[randint(0, len(possible_modes) - 1)]
+            rq_delay = self.simulated_delays[mode]
+
+        # Set the provider pod delay to be close to the requester delay.
+        self.logger.info(
+            f"[SIMULATED] Waiting for pods in {ns}... Ready after {rq_delay}s"
+        )
+
+        # Sleep a tiny amount to simulate async behavior.
+        sleep(0.01)
+
+        # Generate random info for the assigned node and accelerator.
+        requester_pod_name = uuid4()
+        node_name = uuid4()
+        provider_pod_name = [uuid4()]
+        accelerator_info = uuid4()
+        provider_info = BoundProviderPodInfo(
+            requester_pod_name, provider_pod_name, mode, node_name, accelerator_info
+        )
+        provider_pods = [provider_info]
+
+        return rq_delay, mode, provider_pods
+
+    def delete_pod(self, namespace: str, pod_name: str) -> None:
+        self.logger.info(
+            f"[SIMULATED] Deleting pod {pod_name} in namespace {namespace}"
+        )

--- a/inference_server/benchmark/requirements.txt
+++ b/inference_server/benchmark/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes

--- a/inference_server/benchmark/scenarios.py
+++ b/inference_server/benchmark/scenarios.py
@@ -1,0 +1,333 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard imports.
+from json import loads
+from pathlib import Path
+from time import sleep, time
+from typing import Any, Dict, List
+
+# Local imports.
+from benchmark_diagnostics import IterationResult, ScenarioStatus
+from utils import replace_repo_variables
+
+
+def run_baseline_scenario(
+    benchmark: Any,
+    timeout: int,
+    yaml_file: str = None,
+    rs_name_prefix: str = "my-request",
+) -> List[Dict[str, Any]]:
+    """
+    Run the baseline benchmark scenario with multiple iterations.
+    :param benchmark: The benchmark instance to run the scenario on.
+    :param timeout: The max time to allocate for all pods to be checked.
+    :param rs_name_prefix: The externally defined prefix to attach to each
+    replicaset name
+
+    :return: A list of the results for each iteration of the scenario.
+    """
+    benchmark.results = []
+    cleanup = benchmark.cleanup_enabled
+    iterations = benchmark.iterations
+    scenario = benchmark.scenario
+    max_replicas = benchmark.max_replicas
+    yaml_template = yaml_file if yaml_file else benchmark.yaml_template_file
+    try:
+        for i in range(iterations):
+            iter_num = str(i + 1)
+            benchmark.logger.info(f"Running iteration {iter_num}")
+
+            # Generate a unique replicaset YAML for the iteration.
+            rs_name = rs_name_prefix + f"-{iter_num}-" + str(int(time()))
+            benchmark.logger.debug(f"ReplicaSet Name: {rs_name}")
+            request_yaml = benchmark.create_request_yaml(rs_name, yaml_template)
+            benchmark.intermediate_files.append(request_yaml)
+
+            try:
+                benchmark.logger.debug(f"Applying YAML: {request_yaml}")
+                benchmark.k8_ops.apply_yaml(request_yaml)
+
+                # Scale up
+                _run_scaling_phase(
+                    benchmark,
+                    request_yaml,
+                    rs_name,
+                    timeout,
+                    max_replicas,
+                    iter_num,
+                    scenario,
+                    "up",
+                )
+            except Exception as e:
+                benchmark.logger.error(f"Iteration {i+1} failed with error: {e}")
+                result = IterationResult(
+                    success=False,
+                    error=e.__str__(),
+                    scenario=scenario,
+                    phase="up",
+                    iteration=iter_num,
+                )
+                benchmark.results.append(result)
+            finally:
+                if cleanup:
+                    benchmark.logger.debug(
+                        f"Finally deleting YAML file: {request_yaml}"
+                    )
+                    benchmark.k8_ops.delete_yaml(request_yaml)
+                    benchmark.cleanup_resources()
+
+    finally:
+        # Clean up intermediate YAML files created during benchmark
+        benchmark.cleanup_intermediate_files()
+
+        # Delete the associated cluster for a kind benchmark.
+        if benchmark.op_mode == "kind":
+            benchmark.k8_ops.clean_up_cluster()
+
+    return benchmark.results
+
+
+def run_scaling_scenario(
+    benchmark: Any,
+    timeout: int,
+    yaml_file: str = None,
+    rs_name_prefix: str = "scale-request",
+) -> List[Dict[str, Any]]:
+
+    benchmark.results = []
+    cleanup = benchmark.cleanup_enabled
+    iterations = benchmark.iterations
+    scenario = benchmark.scenario
+    max_replicas = benchmark.max_replicas
+    yaml_template = yaml_file if yaml_file else benchmark.yaml_template_file
+
+    for i in range(iterations):
+        iter_num = str(i + 1)
+        benchmark.logger.info(f"Running iteration {iter_num}")
+
+        try:
+            rs_name = rs_name_prefix + f"-{iter_num}-" + str(int(time()))
+            benchmark.logger.debug(f"ReplicaSet Name: {rs_name}")
+            request_yaml = benchmark.create_request_yaml(rs_name, yaml_template)
+            benchmark.intermediate_files.append(request_yaml)
+
+            # Apply the initial deployment at 0 replicas
+            benchmark.logger.debug(f"Applying initial YAML: {request_yaml}")
+            benchmark.k8_ops.apply_yaml(request_yaml)
+
+            # Scale up
+            _run_scaling_phase(
+                benchmark,
+                request_yaml,
+                rs_name,
+                timeout,
+                max_replicas,
+                iter_num,
+                scenario,
+                "up",
+            )
+
+            # Scale down
+            benchmark.logger.debug("=== Scaling step down to 1 replica ===")
+            benchmark.k8_ops.scale_replicaset(request_yaml, 1)
+
+            # Slow down to ensure any goner requester pods do not taint number of
+            # initial ready pods for the scale up again.
+            if benchmark.op_mode != "simulated":
+                benchmark.logger.debug(
+                    "Slowing down by 10 secs for stale pods to go away"
+                )
+                sleep(10)
+
+            # Scale up again
+            _run_scaling_phase(
+                benchmark,
+                request_yaml,
+                rs_name,
+                timeout,
+                max_replicas,
+                iter_num,
+                scenario,
+                "up_again",
+            )
+
+        except Exception as e:
+            benchmark.logger.error(f"Iteration {iter_num} failed with error: {e}")
+            result = IterationResult(
+                success=False,
+                error=e.__str__(),
+                scenario=scenario,
+                iteration=iter_num,
+            )
+            benchmark.results.append(result)
+        finally:
+            # Delete the YAML resources from the cluster
+            if cleanup:
+                benchmark.logger.debug(f"Finally deleting YAML file: {request_yaml}")
+                benchmark.k8_ops.delete_yaml(request_yaml)
+                benchmark.cleanup_resources()
+
+    # Clean up intermediate YAML files created during scaling scenario
+    benchmark.cleanup_intermediate_files()
+
+    # Delete the associated cluster for a kind benchmark.
+    if benchmark.op_mode == "kind" and cleanup:
+        benchmark.k8_ops.clean_up_cluster()
+
+    return benchmark.results
+
+
+def _run_scaling_phase(
+    benchmark,
+    request_yaml: str,
+    rs_name: str,
+    timeout: int,
+    expected_pods: int,
+    iteration_num: str,
+    scenario: str,
+    phase: str,
+) -> None:
+    """
+    Scale the replicaset, wait for readiness,
+    track provider pods, and output a result dict.
+    """
+    benchmark.logger.debug(
+        f"=== Scaling step '{phase}' to {expected_pods} replicas ==="
+    )
+    benchmark.k8_ops.scale_replicaset(request_yaml, expected_pods)
+
+    # Query GPU usage only for emulated or real GPUs.
+    if benchmark.op_mode != "simulated":
+        benchmark.logger.info("=== Busy GPUs Before Iteration ===")
+        benchmark.query_gpu_usage()
+
+    readiness_result, err = benchmark.k8_ops.wait_for_dual_pods_ready(
+        benchmark.namespace,
+        rs_name,
+        timeout,
+        expected_pods,
+    )
+
+    # Track provider pods created in cold start mode for cleanup
+    for pod in readiness_result.provider_pods:
+        benchmark.logger.debug(f"Check Mode on Pod: {pod}")
+        if pod.avail_mode == "Cold":
+            if not hasattr(benchmark, "provider_pods"):
+                benchmark.provider_pods = []
+            provider_pod_name = pod.provider
+            benchmark.provider_pods.append(provider_pod_name)
+            benchmark.logger.debug(
+                f"Added provider pod {provider_pod_name} to cleanup list"
+            )
+        iter_result = IterationResult(
+            rq_time=pod.rq_time,
+            avail_mode=pod.avail_mode,
+            success=True,
+            iteration=iteration_num,
+            scenario=scenario,
+            phase=phase,
+        )
+        benchmark.results.append(iter_result)
+
+    # Check whether errors occured for any of the dual pods.
+    if readiness_result.status == ScenarioStatus.FAILURE:
+        benchmark.logger.warning(
+            f"Scaling step '{phase}' for request {rs_name} errored: {err}"
+        )
+
+        for pod in readiness_result.unready_pods:
+            if "dual" not in pod:
+                iter_result = IterationResult(
+                    success=False,
+                    error=err.__str__(),
+                    iteration=iteration_num,
+                    scenario=scenario,
+                    phase=phase,
+                )
+                benchmark.results.append(iter_result)
+
+        # Print the intermediate results before stopping benchmark.
+        if benchmark.results:
+            benchmark.pretty_print_results()
+
+        # Clean up intermediate YAML files created during scaling scenario
+        benchmark.cleanup_intermediate_files()
+
+        exit(1)
+
+
+def run_new_variant_scenario(
+    benchmark: Any,
+    timeout: int,
+    yaml_file: str = None,
+    rs_name_prefix: str = "model-request",
+) -> List[Dict[str, Any]]:
+    """
+    Run the scenario to introduce a new model variant.
+    :param benchmark: The benchmark instance to run the scenario on.
+    :param timeout: The timeout in seconds for the execution of the pod requests.
+    :param yaml_file: The YAML template file to use (optional, uses benchmark default
+        if None).
+
+    :return: A list with the results for the different models.
+    """
+    results = []
+
+    if not benchmark.model_path:
+        benchmark.logger.error("model_path not provided for new_variant scenario")
+        return results
+
+    yaml_template = yaml_file if yaml_file else benchmark.yaml_template_file
+
+    # Load the file with all the models.
+    all_models = None
+    models_abs_path = Path(benchmark.model_path).absolute()
+    if not Path(models_abs_path).exists():
+        benchmark.logger.info(f"Path to models {models_abs_path} does not exist!")
+        return results
+    else:
+        with Path(models_abs_path).open(mode="rb") as model_json_fd:
+            all_models = loads(model_json_fd.read())["models"]
+            benchmark.logger.info(f"All Models: {all_models}")
+
+    # Generate the general template with container image repository and tag.
+    for model in all_models:
+        model_parts = model.split("/")
+        model_registry = model_parts[0]
+        model_repo = model_parts[1]
+        model_info = f"Model Registry: {model_registry}, Model Repo: {model_repo}"
+        benchmark.logger.info(model_info)
+        model_template = replace_repo_variables(
+            benchmark.requester_img_tag.split(":")[0],  # image repo
+            benchmark.requester_img_tag,  # full image tag
+            yaml_template,
+            model_registry,
+            model_repo,
+        )
+
+        # Generate a unique replicaset YAML for a particular model.
+        benchmark.scenario = "variant-" + model_registry + "-" + model_repo
+        model_results = run_baseline_scenario(
+            benchmark,
+            timeout,
+            model_template,
+            rs_name_prefix,
+        )
+        results.extend(model_results)
+
+        # Print the results and remote intermediate files.
+        benchmark.pretty_print_results()
+
+    return results

--- a/inference_server/benchmark/setup_kind_resources.sh
+++ b/inference_server/benchmark/setup_kind_resources.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# This script draws most of its inspiration and content from: https://github.com/llm-d-incubation/llm-d-fast-model-actuation/blob/main/test/e2e/run.sh
+# It enables the launching of a kind cluster and loading of images within it
+# to run the benchmark for fast model actuation Go modules.
+
+# The Current working directory must be the root of the repo to take
+# advantage of the `make` commands and other automation.
+
+set -x
+
+
+# Set up the kind cluster.
+clusterName="$1"
+printf "Setting up cluster: %s\n" "$clusterName"
+requesterImageTag="$2"
+printf "RequesterImage Tag: %s\n" "$requesterImageTag"
+
+# Build the container images for local testing.
+make build-test-requester-local TEST_REQUESTER_IMG_TAG="$requesterImageTag"
+make build-test-server-local TEST_SERVER_IMG_TAG="$requesterImageTag"
+make build-controller-local CONTROLLER_IMG_TAG="$requesterImageTag"
+
+# Recreate the cluster if it already exists.
+kind delete cluster --name "$clusterName"
+kind create cluster --name "$clusterName" --config test/e2e/kind-config.yaml
+kubectl wait --for=create sa default
+kubectl wait --for condition=Ready node fmatest-control-plane
+kubectl wait --for condition=Ready node fmatest-worker
+kubectl wait --for condition=Ready node fmatest-worker2
+
+# Display health, prove we don't have https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
+kubectl get pods -A -o wide
+
+kubectl create clusterrole node-viewer --verb=get,list,watch --resource=nodes
+
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: testreq
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - gpu-map
+  - gpu-allocs
+  resources:
+  - configmaps
+  verbs:
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+EOF
+
+kubectl create rolebinding testreq --role=testreq --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
+kubectl create clusterrolebinding testreq-view --clusterrole=view --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
+
+kubectl create sa testreq
+kubectl create cm gpu-map
+kubectl get nodes -o name | sed 's%^node/%%' | while read node; do
+    kubectl label node $node nvidia.com/gpu.present=true nvidia.com/gpu.product=NVIDIA-L40S nvidia.com/gpu.count=2 --overwrite=true
+    kubectl patch node $node --subresource status -p '{"status": {"capacity": {"nvidia.com/gpu": 2}, "allocatable": {"nvidia.com/gpu": 2} }}'
+done
+
+# Load the container images into the kind cluster
+make load-test-requester-local CLUSTER_NAME="$clusterName" TEST_REQUESTER_IMG_TAG="$requesterImageTag"
+make load-test-server-local CLUSTER_NAME="$clusterName" TEST_SERVER_IMG_TAG="$requesterImageTag"
+make load-controller-local CLUSTER_NAME="$clusterName" CONTROLLER_IMG_TAG="$requesterImageTag"
+
+# Wait a few seconds for all machinery to come online before issuing requests.
+sleep 10

--- a/inference_server/benchmark/utils.py
+++ b/inference_server/benchmark/utils.py
@@ -1,0 +1,225 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+from datetime import datetime
+from logging import DEBUG, INFO, FileHandler, Formatter, StreamHandler, getLogger
+from os import getenv
+from pathlib import Path
+from subprocess import run as invoke_shell
+from uuid import uuid4
+
+# ---------------- Logging setup ----------------
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+date_stamp = str(datetime.now().isoformat(timespec="minutes"))
+file_handler = logging.FileHandler(f"metrics-log-utils-{date_stamp}.log")
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(formatter)
+
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.INFO)
+console_handler.setFormatter(formatter)
+
+logger.addHandler(file_handler)
+logger.addHandler(console_handler)
+
+
+def parse_request_args():
+    """
+    Retrieve the arguments for launching the inference server
+    request.
+    """
+    parser = argparse.ArgumentParser(
+        description="Benchmarking the Dual-pods readiness time"
+    )
+    parser.add_argument(
+        "--namespace",
+        type=str,
+        required=True,
+        help="Openshift namespace to run benchmark",
+    )
+    parser.add_argument(
+        "--yaml",
+        type=str,
+        required=True,
+        help="Path to the server-requesting YAML template file",
+    )
+    parser.add_argument(
+        "--cleanup",
+        type=bool,
+        default=True,
+        help="Whether to clean up provider pods after benchmark completion",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="The number of iterations to run for benchmark scenarios",
+    )
+    parser.add_argument(
+        "--cluster-domain",
+        type=str,
+        default="fmaas-platform-eval.fmaas.res.ibm.com",
+        help="Cluster domain for Prometheus GPU metrics query",
+    )
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        help="Path to JSON file containing models for new_variant scenario",
+    )
+    parser.add_argument(
+        "--scenario",
+        type=str,
+        default="scaling",
+        choices=["baseline", "scaling", "new_variant"],
+        help="Benchmark scenario to run (default: scaling)",
+    )
+    parser.add_argument(
+        "--max-replicas",
+        type=int,
+        default=2,
+        help="The number of replicas to scale up to (default: 1)",
+    )
+    parser.add_argument(
+        "--image",
+        type=str,
+        help="Repository for the requester image",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        help="Version tag for the requester image",
+    )
+
+    args = parser.parse_args()
+
+    # Check for a container image env variables.
+    requester_img = getenv("CONTAINER_IMG_REG")
+    img_tag = getenv("CONTAINER_IMG_VERSION")
+    if requester_img and img_tag:  # override input args
+        logger.info(f"Requester Image Loaded from ENV: {requester_img}:{img_tag}")
+        args.image = requester_img
+        args.tag = img_tag
+    else:
+        logger.debug("CONTAINER_IMG_REG/CONTAINER_IMG_VERSION not set locally")
+        if not args.image or not args.tag:  # Force user to pass both image and tag
+            raise ValueError(
+                "Must set container image via env vars "
+                "(CONTAINER_IMG_REG & CONTAINER_IMG_VERSION) "
+                "or provide input args --image and --tag."
+            )
+
+    # Validate the path for the YAML template.
+    yaml_template = args.yaml
+    yaml_template_path = Path(yaml_template)
+    if not (yaml_template_path).exists():
+        raise FileNotFoundError(f"{yaml_template} path does not exist!")
+
+    # Override the provided template path with the absolute version.
+    if not (yaml_template_path.is_absolute()):
+        args.yaml = yaml_template_path.absolute()
+    else:
+        args.yaml = yaml_template_path
+
+    return args
+
+
+def replace_repo_variables(
+    requester_image_repo: str,
+    image_tag: str,
+    request_yaml_template: str,
+    model_registry: str = "ibm-granite",
+    model_repo: str = "granite-3.3-2b-instruct",
+):
+    """
+    Replace the variable for the inference server container image.
+    :param requester_image_repo: The repository for the inference server
+                                 container images.
+    :param image_tag: The particular tag to use for the container image.
+    :param request_yaml_template: The local path for the inference server request
+                                  template YAML file.
+    :param model_registry: The name of the model registry to insert.
+    :param model_repo: The name of the model repository to insert.
+    """
+    # Check that yaml path exists before invoking sed.
+    request_yaml_path = Path(request_yaml_template)
+    if not (request_yaml_path).exists():
+        raise FileNotFoundError(f"{request_yaml_template} path does not exist!")
+
+    # Invoke the replacement in the template for redirection.
+    sed_script = "s#${MODEL_REGISTRY}#" + model_registry + "#\n"
+    sed_script += "s#${MODEL_REPO}#" + model_repo + "#\n"
+    sed_script += "s#${CONTAINER_IMG_REG}#" + requester_image_repo + "#\n"
+    sed_script += "s#${CONTAINER_IMG_REG}#" + requester_image_repo + "#\n"
+    sed_script += "s#${CONTAINER_IMG_VERSION}#" + image_tag + "#"
+    updated_request_file = "inf-server-request-template-" + str(uuid4()) + ".yaml"
+    updated_request_file_path = Path(updated_request_file)
+    with Path(updated_request_file_path).open(mode="wb") as yaml_fd:
+        invoke_shell(
+            ["sed", "-e", sed_script, request_yaml_template],
+            stdout=yaml_fd,
+            check=False,
+        )
+
+    return updated_request_file
+
+
+class BaseLogger:
+    """Base class for a single logger that all the classes inherit from."""
+
+    def __init__(self, log_output_file: str, owner: str = ""):
+        """
+        Initialize the base logger class.
+
+        :param owner: The class or invoker of the logger for easy tracing.
+        :param log_output_file: The path where to write logs if not the default.
+        """
+        self.logger = getLogger(owner + "Logger")
+        # Set default level and formatting.
+        self.logger.setLevel(DEBUG)
+        formatter = Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+        # Create the console and stream handler.
+        self.file_handler = FileHandler(log_output_file)
+        self.file_handler.setLevel(DEBUG)
+        self.file_handler.setFormatter(formatter)
+        self.console_handler = StreamHandler()
+        self.console_handler.setLevel(INFO)
+        self.console_handler.setFormatter(formatter)
+        self.logger.addHandler(self.file_handler)
+        self.logger.addHandler(self.console_handler)
+
+    def get_custom_logger(self):
+        """
+        Get the custom logger created by the class.
+        """
+        return self.logger
+
+
+def delete_yaml_resources(yaml_file):
+    """Delete the resources created with the YAML and delete the file itself."""
+    yaml_path = Path(yaml_file)
+    if not yaml_path.exists():
+        logger.warning(f"YAML file {yaml_file} does not exist, skipping cleanup")
+        return
+
+    logger.info(f"Cleaning up resources from {yaml_file}...")
+    invoke_shell(
+        ["kubectl", "delete", "-f", yaml_file, "--ignore-not-found=true"], check=False
+    )
+    invoke_shell(["rm", yaml_file], check=False)


### PR DESCRIPTION
A benchmarking tool that measures readiness latency and, focused primarily on hit rates (hit == waking up sleeping instance on scale up) in different scenarios...

The benchmarking tool will evolve to meet the needs of the launcher-based method of inference server start from https://github.com/llm-d-incubation/llm-d-fast-model-actuation/issues/154.

Previous PR https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/176 merged into [milestone-2](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/tree/milestone-2) branch.