### PR TITLE
Reorg so that "spi" declares the _interface_

### DIFF
--- a/cmd/requester/main.go
+++ b/cmd/requester/main.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes"
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/spi"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"k8s.io/klog/v2"
@@ -56,7 +56,7 @@ func main() {
 	go func() {
 		defer wg.Done()
 
-		err := spi.Run(ctx, spiPort, &ready)
+		err := coordination.Run(ctx, spiPort, &ready)
 		if err != nil {
 			logger.Error(err, "failed to start requester SPI server")
 		}

--- a/cmd/test-requester/main.go
+++ b/cmd/test-requester/main.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes"
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/spi"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"k8s.io/klog/v2"
@@ -115,7 +115,7 @@ func main() {
 	go func() {
 		defer wg.Done()
 
-		err := spi.RunWithGPUUUIDs(ctx, strconv.FormatInt(int64(spiPort), 10), &ready, gpuUUIDs)
+		err := coordination.RunWithGPUUUIDs(ctx, strconv.FormatInt(int64(spiPort), 10), &ready, gpuUUIDs)
 		if err != nil {
 			logger.Error(err, "failed to start requester SPI server")
 		}

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -48,7 +48,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/api"
-	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/stub/api"
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
 type nodeItem struct {

--- a/pkg/server/requester/coordination/server.go
+++ b/pkg/server/requester/coordination/server.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package spi
+package coordination
 
 import (
 	"context"
@@ -29,7 +29,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/stub/api"
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
 // gpuHandler responds with the list of allocated GPU UUIDs

--- a/pkg/server/requester/coordination/server_test.go
+++ b/pkg/server/requester/coordination/server_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package spi
+package coordination
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/stub/api"
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
 func FuzzServer(f *testing.F) {

--- a/pkg/server/requester/probes/server.go
+++ b/pkg/server/requester/probes/server.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/stub/api"
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
 // Run runs an HTTP server managing the /ready endpoint.

--- a/pkg/server/requester/probes/server_test.go
+++ b/pkg/server/requester/probes/server_test.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/stub/api"
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
 func FuzzServer(f *testing.F) {

--- a/pkg/spi/interface.go
+++ b/pkg/spi/interface.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package spi
 
 // This file defines interface of the stub.
 


### PR DESCRIPTION
This PR changes the package hierarchy a little, so that the package named "spi" declares the _interface_ between the controller and the requester. This is good because the "i" in "spi" stands for "interface".

Prior to this PR, "spi" holds the _implementation_ of that interface. This PR moves that implementation to pkg/server/coordination. 