### PR TITLE
`is_running` deleted

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -99,13 +99,6 @@ class VllmInstance:
             "pid": pid,
         }
 
-    def is_running(self) -> bool:
-        """
-        Returns if the process in the manager is running or not.
-        :return: True is running, `False` otherwise.
-        """
-        return self.process is not None and self.process.is_alive()
-
     def get_status(self) -> dict:
         """
         Returns the status of the process and its PID or the no process

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -183,21 +183,6 @@ class TestVllmInstance:
         assert mock_process.killed is True
 
     @patch("launcher.multiprocessing.Process")
-    def test_instance_is_running(self, mock_process_class, vllm_config):
-        """Test checking if instance is running"""
-        mock_process = MockProcess()
-        mock_process_class.return_value = mock_process
-
-        instance = VllmInstance("test-id", vllm_config)
-        assert instance.is_running() is False
-
-        instance.start()
-        assert instance.is_running() is True
-
-        mock_process._is_alive = False
-        assert instance.is_running() is False
-
-    @patch("launcher.multiprocessing.Process")
     def test_instance_get_status(self, mock_process_class, vllm_config):
         """Test getting instance status"""
         mock_process = MockProcess()


### PR DESCRIPTION
**Description:**
https://github.com/llm-d-incubation/llm-d-fast-model-actuation/issues/152

**Test:**
Tests have passed:
```
======================================================================================================= test session starts =======================================================================================================
platform darwin -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /Users/diego/Documents/my_stuff/llm-d-fast-model-actuation/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/diego/Documents/my_stuff/llm-d-fast-model-actuation/inference_server/launcher
plugins: anyio-4.10.0, cov-7.0.0
collected 31 items                                                                                                                                                                                                                

tests/test_launcher.py::TestVllmConfig::test_vllm_config_with_env_vars PASSED                                                                                                                                               [  3%]
tests/test_launcher.py::TestVllmConfig::test_vllm_config_without_env_vars PASSED                                                                                                                                            [  6%]
tests/test_launcher.py::TestVllmInstance::test_instance_creation PASSED                                                                                                                                                     [  9%]
tests/test_launcher.py::TestVllmInstance::test_instance_start PASSED                                                                                                                                                        [ 12%]
tests/test_launcher.py::TestVllmInstance::test_instance_start_already_running PASSED                                                                                                                                        [ 16%]
tests/test_launcher.py::TestVllmInstance::test_instance_stop PASSED                                                                                                                                                         [ 19%]
tests/test_launcher.py::TestVllmInstance::test_instance_stop_not_running PASSED                                                                                                                                             [ 22%]
tests/test_launcher.py::TestVllmInstance::test_instance_force_kill PASSED                                                                                                                                                   [ 25%]
tests/test_launcher.py::TestVllmInstance::test_instance_get_status PASSED                                                                                                                                                   [ 29%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_create_instance_auto_id PASSED                                                                                                                                    [ 32%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_create_instance_custom_id PASSED                                                                                                                                  [ 35%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_create_instance_duplicate_id PASSED                                                                                                                               [ 38%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_stop_instance PASSED                                                                                                                                              [ 41%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_stop_nonexistent_instance PASSED                                                                                                                                  [ 45%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_stop_all_instances PASSED                                                                                                                                         [ 48%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_get_instance_status PASSED                                                                                                                                        [ 51%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_get_instance_status_nonexistent PASSED                                                                                                                            [ 54%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_get_all_instances_status PASSED                                                                                                                                   [ 58%]
tests/test_launcher.py::TestVllmMultiProcessManager::test_list_instances PASSED                                                                                                                                             [ 61%]
tests/test_launcher.py::TestAPIEndpoints::test_health_endpoint PASSED                                                                                                                                                       [ 64%]
tests/test_launcher.py::TestAPIEndpoints::test_index_endpoint PASSED                                                                                                                                                        [ 67%]
tests/test_launcher.py::TestAPIEndpoints::test_create_vllm_instance PASSED                                                                                                                                                  [ 70%]
tests/test_launcher.py::TestAPIEndpoints::test_create_id_vllm_instance PASSED                                                                                                                                               [ 74%]
tests/test_launcher.py::TestAPIEndpoints::test_create_duplicate_instance PASSED                                                                                                                                             [ 77%]
tests/test_launcher.py::TestAPIEndpoints::test_delete_vllm_instance PASSED                                                                                                                                                  [ 80%]
tests/test_launcher.py::TestAPIEndpoints::test_delete_nonexistent_instance PASSED                                                                                                                                           [ 83%]
tests/test_launcher.py::TestAPIEndpoints::test_delete_all_instances PASSED                                                                                                                                                  [ 87%]
tests/test_launcher.py::TestAPIEndpoints::test_list_instances PASSED                                                                                                                                                        [ 90%]
tests/test_launcher.py::TestAPIEndpoints::test_get_instance_status PASSED                                                                                                                                                   [ 93%]
tests/test_launcher.py::TestAPIEndpoints::test_get_nonexistent_instance_status PASSED                                                                                                                                       [ 96%]
tests/test_launcher.py::TestHelperFunctions::test_set_env_vars PASSED                                                                                                                                                       [100%]

======================================================================================================= 31 passed in 4.12s ========================================================================================================
```
Also, all the E2E tests have passed.