### PR TITLE
Update howto.md for the launcher

### DIFF
--- a/inference_server/launcher/howto.md
+++ b/inference_server/launcher/howto.md
@@ -17,18 +17,30 @@ Start the service:
 uvicorn --port 8001 --log-level info launcher:app
 ```
 
-Send commands (sung HTTPie or cURL):
+Send commands (using HTTPie or cURL) with the following payload:
 ```json
 {
   "options": "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --port 8005",
-  "env_var": {
+  "env_vars": {
     "VLLM_USE_V1": "1",
     "VLLM_LOGGING_LEVEL": "DEBUG"
   }
 }
 ```
+For example, if using cURL, the command will be something like
+```shell
+curl -X POST http://localhost:8001/v2/vllm/instances \
+  -H "Content-Type: application/json" \
+  -d '{
+    "options": "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --port 8005",
+    "env_vars": {
+      "VLLM_USE_V1": "1",
+      "VLLM_LOGGING_LEVEL": "DEBUG"
+    }
+  }'
+```
 
-The vLLM will start serving and you can request generations:
+The vLLM will start serving and you can request generations with the following payload:
 ```json
 {
   "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -39,4 +51,18 @@ The vLLM will start serving and you can request generations:
   "temperature": 0.7,
   "max_tokens": 100
 }
+```
+For example, if using cURL, the command will be something like
+```shell
+curl -X POST http://localhost:8005/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Tell me a joke about AI."}
+    ],
+    "temperature": 0.7,
+    "max_tokens": 100
+  }'
 ```


### PR DESCRIPTION
This PR tries to improve the launcher's how-to doc a little bit by
- fixing `env_var` in the json payload that differs from its schema;
- writing down the literal commands to make curl users' life easier;
- typo fix.


