### PR TITLE
Github actions workflow to publish charts

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,43 @@
+name: Publish Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - charts/**
+  workflow_dispatch:
+
+jobs:
+  publish_helm_charts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            # Checks out the main branch
+            ref: main
+            fetch-depth: 0
+
+      - name: Install Helm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: azure/setup-helm@v3
+
+      - name: Login to Github Container Registry
+        run: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+                --username ${{ github.actor }} \
+                --password-stdin
+
+      - name: Package and push helm charts
+        run: |
+            for DIR in $(ls -d charts/*/); do
+                CHART_NAME=$(helm show chart "$DIR" | grep '^name:' | awk '{print $2}')
+                CHART_VERSION=$(helm show chart "$DIR" | grep '^version:' | awk '{print $2}')
+                helm package "$DIR" --destination .
+                helm push "$CHART_NAME-$CHART_VERSION.tgz" oci://ghcr.io/${{ github.repository }}/charts
+            done


### PR DESCRIPTION
Adds a github actions workflow that publishes all Helm charts existing under the `charts` folder.
This workflow will trigger when a push request is made to `main` and changes happened to the `charts` folder or can be run manually.

It publishes the following:
1. ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/charts/dual-pods-controller:0.1.0
2. ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/charts/launcher-populator:0.1.0

The published charts can then be used by other repositories like the `llm-d-benchmark`.

The workflow uses the repository auto-generated `secrets.GITHUB_TOKEN`. The first time it runs, when the packages don't yet exist, it may fail. In this case, a token with `package write` access should be created and added to the secrets in this repository with name `GITHUB_TOKEN`.

Run the workflow manually and after the packages are created, make them public and go to each one `package settings/Manage Actions access` and enter this repository with write access. Also each package can be linked to this repository so that they show in the main page.

Once this repository is added to the packages access, then the secrets `GITHUB_TOKEN` can be removed so that the workflow will be back at using the auto-generated token.
