### PR TITLE
Make vLLM port number explicit in InferenceServerConfig

### DIFF
--- a/api/fma/v1alpha1/inferenceserverconfig_types.go
+++ b/api/fma/v1alpha1/inferenceserverconfig_types.go
@@ -33,7 +33,11 @@ type InferenceServerConfigSpec struct {
 
 // ModelServerConfig defines the configuration for a model server
 type ModelServerConfig struct {
-	// Options are the vLLM startup options
+	// Port is the port on which the vLLM server will listen
+	// Particularly, management of vLLM instances' sleep state is done through this port
+	Port int32 `json:"port"`
+
+	// Options are the vLLM startup options, excluding Port
 	// +optional
 	Options string `json:"options,omitempty"`
 

--- a/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
+++ b/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
@@ -66,8 +66,16 @@ spec:
                       type: string
                     type: object
                   options:
-                    description: Options are the vLLM startup options
+                    description: Options are the vLLM startup options, excluding Port
                     type: string
+                  port:
+                    description: |-
+                      Port is the port on which the vLLM server will listen
+                      Particularly, management of vLLM instances' sleep state is done through this port
+                    format: int32
+                    type: integer
+                required:
+                - port
                 type: object
             required:
             - launcherConfigName

--- a/pkg/generated/applyconfiguration/fma/v1alpha1/modelserverconfig.go
+++ b/pkg/generated/applyconfiguration/fma/v1alpha1/modelserverconfig.go
@@ -20,6 +20,7 @@ package v1alpha1
 // ModelServerConfigApplyConfiguration represents a declarative configuration of the ModelServerConfig type for use
 // with apply.
 type ModelServerConfigApplyConfiguration struct {
+	Port        *int32            `json:"port,omitempty"`
 	Options     *string           `json:"options,omitempty"`
 	EnvVars     map[string]string `json:"env_vars,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
@@ -30,6 +31,14 @@ type ModelServerConfigApplyConfiguration struct {
 // apply.
 func ModelServerConfig() *ModelServerConfigApplyConfiguration {
 	return &ModelServerConfigApplyConfiguration{}
+}
+
+// WithPort sets the Port field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Port field is set to the value of the last call.
+func (b *ModelServerConfigApplyConfiguration) WithPort(value int32) *ModelServerConfigApplyConfiguration {
+	b.Port = &value
+	return b
 }
 
 // WithOptions sets the Options field in the declarative configuration to the given value


### PR DESCRIPTION
This PR makes the port number of vLLM's api server explicit in InferenceServerConfig's Spec. This way, the controllers have a safe and clean way to read it out, instead of having to parse the number from the `Options` string.