### PR TITLE
Add Dockerfile and Makefile targets for launcher container using CPU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ load-test-server-local:
 
 .PHONY: build-test-launcher-local
 build-test-launcher-local:
-	docker build -t ${TEST_LAUNCHER_IMG} -f dockerfiles/Dockerfile.launcher.cpu . --progress=plain --platform linux/$(TARGETARCH) --build-arg TARGETARCH=$(TARGETARCH)
+	docker build -t ${TEST_LAUNCHER_IMG} -f dockerfiles/Dockerfile.launcher.cpu . --progress=plain --platform linux/$(shell go env GOARCH)
 
 .PHONY: load-test-launcher-local
 load-test-launcher-local:

--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -1,5 +1,5 @@
 # Dockerfile for launcher using vLLM CPU images (for tests without GPU)
-# Supports both arm64 and x86_64 architectures
+# Supports both arm64 and amd64 architectures
 
 ARG TARGETARCH
 ARG VLLM_VERSION=v0.15.0


### PR DESCRIPTION
This PR adds a Dockerfile for the launcher container. This container uses CPU instead of GPU so it's handy and fast for dev/test.

closes #235 