### PR TITLE
🐛 Parameterize ClusterRoleBinding name in dpctlr Helm chart

### DIFF
--- a/charts/dpctlr/templates/role-binding.yaml
+++ b/charts/dpctlr/templates/role-binding.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dual-pods
     app.kubernetes.io/component: controller
-  name: dual-pods-controller-node-view
+  name: "{{ .Release.Name }}-node-view"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Summary
- Changes the hardcoded ClusterRoleBinding name `dual-pods-controller-node-view` to `{{ .Release.Name }}-node-view` in the dpctlr Helm chart
- Prevents conflicts when multiple Helm releases coexist (e.g., concurrent CI e2e test runs for different PRs)

## Test plan
- [ ] Verify `helm template` renders the ClusterRoleBinding name correctly with a custom release name
- [ ] Verify existing deployments using default release name still work