### PR TITLE
✨ Add OpenShift E2E CI workflow for FMA controller

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -477,9 +477,14 @@ jobs:
           echo "=== Controller Logs (last 50 lines) ==="
           kubectl logs "$POD_NAME" -n "$FMA_NAMESPACE" --tail=50
 
-          # Check for fatal/panic in logs (klog FATAL lines start with F followed by digits)
-          if kubectl logs "$POD_NAME" -n "$FMA_NAMESPACE" 2>&1 | grep -iE "^F[0-9]|panic:" | head -5; then
-            echo "::error::Controller logs contain FATAL or panic messages"
+          # Check for fatal/panic in logs
+          # klog FATAL lines: F followed by 4 digits (MMDD), e.g. "F0210 19:21:..."
+          # Go panics: line starting with "panic:" (case sensitive)
+          FATAL_LINES=$(kubectl logs "$POD_NAME" -n "$FMA_NAMESPACE" 2>&1 \
+            | grep -E "^F[0-9]{4} |^panic:" | head -5) || true
+          if [ -n "$FATAL_LINES" ]; then
+            echo "::error::Controller logs contain FATAL or panic messages:"
+            echo "$FATAL_LINES"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`ci-e2e-openshift.yaml`) that deploys the dual-pods controller to an OpenShift cluster and verifies it starts without errors
- Modeled after the [WVA openshift-e2e workflow](https://github.com/llm-d-incubation/workload-variant-autoscaler/blob/main/.github/workflows/ci-e2e-openshift.yaml) with the same gate/build/test/report pattern, simplified for FMA's current scope
- Depends on the chart fix in #240 (already merged) to parameterize the ClusterRoleBinding name

### Workflow structure (4 jobs)
1. **gate** — Permission checks, fork PR `/ok-to-test` approval flow
2. **build-image** — Build controller image with `ko`, push to GHCR
3. **e2e-openshift** — Deploy to PR-specific namespace, verify health
4. **report-status** — Report commit status for fork PR runs

### Key features
- PR-specific namespace (`fma-e2e-pr-{PR_NUMBER}`) for test isolation
- Full cleanup on success, scale-down on failure (preserves for debugging)
- Concurrency control (cancel-in-progress per PR)
- Fork PR security via `/ok-to-test` maintainer approval
- Validates CRDs, ConfigMaps, Helm deployment, controller health

### Requires
- `CR_USER` and `CR_TOKEN` secrets configured for GHCR access
- Self-hosted runner with `[self-hosted, openshift]` labels (llm-d runner)

## Test plan
- [ ] Verify workflow triggers on PR open
- [ ] Verify gate job correctly identifies maintainer vs external contributors
- [ ] Verify controller image builds and pushes to GHCR
- [ ] Verify controller deploys and passes health check on OpenShift cluster
- [ ] Verify cleanup removes all resources on success
- [ ] Verify scale-down preserves namespace on failure