### PR TITLE
Add gputranslator to launcher benchmark dockerfile

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -34,7 +34,7 @@ jobs:
           # install black isort flake
           pip install black==24.4.2 isort==5.13.2 flake8==7.0.0
           # install pytest and its dependencies
-          pip install pytest==9.0.2 fastapi==0.116.1 pydantic==2.11.7 uvicorn==0.35.0 uvloop==0.21.0 httpx==0.28.1 pynvml==13.0.1
+          pip install pytest==9.0.2 fastapi==0.116.1 pydantic==2.11.7 uvicorn==0.35.0 uvloop==0.21.0 httpx==0.28.1 nvidia-ml-py==13.590.48
 
       - name: Check for trailing whitespace
         run: |

--- a/dockerfiles/Dockerfile.launcher.benchmark
+++ b/dockerfiles/Dockerfile.launcher.benchmark
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslator.py /app/
 
-# Install uvicorn for serving the launcher API and pynvml for gputranslator
-RUN pip install --root-user-action=ignore --no-cache-dir uvicorn pynvml
+# Install uvicorn for serving the launcher API and nvidia-ml-py for gputranslator
+RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py
 
 ENTRYPOINT ["uvicorn", "--app-dir", "/app", "launcher:app"]

--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -14,12 +14,9 @@ FROM base-${TARGETARCH} AS final
 
 WORKDIR /app
 
-COPY inference_server/launcher/launcher.py .
-COPY inference_server/launcher/gputranslator.py .
+COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslator.py /app/
 
-# Install uvicorn for serving the launcher API
-RUN pip install --root-user-action=ignore --no-cache-dir uvicorn
-# Install pynvml for gputranslator
-RUN pip install --root-user-action=ignore --no-cache-dir pynvml
+# Install uvicorn for serving the launcher API and nvidia-ml-py for gputranslator
+RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py
 
 ENTRYPOINT ["uvicorn", "--app-dir", "/app", "launcher:app"]

--- a/inference_server/launcher/requirements.txt
+++ b/inference_server/launcher/requirements.txt
@@ -2,5 +2,6 @@ fastapi
 pydantic
 uvicorn
 uvloop
+nvidia-ml-py
 # WARNING: vllm must be built from source on a macOS Silicon
 vllm; sys_platform != "darwin" or platform_machine != "arm64"


### PR DESCRIPTION
`gputranslator.py` was added as a strong dependency to the launcher.py.
This caused the image created by Dockerfile.launcher.benchmark to crash. When adding a `gputranslator.py` another crash occurs on `pynvml` which is deprecated.
```
vllm_manager = VllmMultiProcessManager()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/launcher.py", line 136, in __init__
    self.gpu_translator = GpuTranslator()
                          ^^^^^^^^^^^^^^^
  File "/app/gputranslator.py", line 36, in __init__
    self._populate_mapping()
  File "/app/gputranslator.py", line 47, in _populate_mapping
    uuid = pynvml.nvmlDeviceGetUUID(handle).decode("utf-8")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```
This is because the call `pynvml.nvmlDeviceGetUUID(handle)` may already return a decoded string. I added check for that.

I changed the dockerfile to include  `gputranslator.py` and `nvidia-ml-py` which is the official version of 
the deprecated `pynvml`.