### PR TITLE
Bump actions/setup-python from 4 to 6.2.0

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12.11"
 


### PR DESCRIPTION
This is a more specific alternative to #248 