### PR TITLE
⚠️ Improve E2E workflow reliability and observability

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -866,8 +866,9 @@ jobs:
           kubectl delete namespace "$FMA_NAMESPACE" \
             --ignore-not-found --timeout=120s || true
 
-          # NOTE: CRDs are NOT deleted here because they are cluster-scoped and shared
-          # across multiple concurrent test runs. The apply --server-side in setup is idempotent.
+          # NOTE: CRDs are intentionally NOT deleted here.
+          # They are cluster-scoped and shared across test runs. Deleting them
+          # would disrupt other concurrent E2E tests on the same cluster.
 
           # Delete cluster-scoped resources
           kubectl delete clusterrole fma-node-viewer --ignore-not-found || true


### PR DESCRIPTION
Addresses several issues filed against the OpenShift E2E workflow:

**Changes:**
- **Go version** (#271): Use hardcoded `1.24.x` build preference instead of extracting minimum from `go.mod`. The `go` directive in `go.mod` states the minimum required version, not the preferred build version.
- **CRD readiness** (#277): Replace `kubectl get crd` (redundant after successful `apply`) with `kubectl wait --for=condition=Established` to ensure API servers have digested the CRD definitions before proceeding.
- **State dump** (#273): Dump cluster state unconditionally (`if: always()`) instead of only on failure. Provides baseline diagnostics for comparison when investigating failures. Scale-down on failure remains separate.
- **Workflow summary** (#272): Add a summary annotation in the gate job so the Actions UI clearly shows whether E2E tests were skipped or actually ran.

Fixes #271, #272, #273, #277