### PR TITLE
ci: use literal Go build version instead of go.mod value

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -256,13 +256,10 @@ jobs:
         with:
           ref: ${{ needs.gate.outputs.pr_head_sha }}
 
-      - name: Extract Go version from go.mod
-        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
-
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "${{ env.GO_VERSION }}"
+          go-version: "1.25.7"
           cache-dependency-path: ./go.sum
 
       - name: Set up ko


### PR DESCRIPTION
The `go` directive in go.mod defines the minimum required Go version, not a build preference. Decouple the CI build Go version from go.mod by replacing the dynamic extraction step with a literal version (1.25.7).

Fixes #271