### PR TITLE
🐛 Stop the E2E on OpenShift workflow from deleting the CRDs

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -885,8 +885,8 @@ jobs:
           kubectl delete namespace "$FMA_NAMESPACE" \
             --ignore-not-found --timeout=120s || true
 
-          # Delete CRDs
-          kubectl delete -f config/crd/ --ignore-not-found || true
+          # Delete CRDs --- NOT (TODO: more complete solution)
+          # kubectl delete -f config/crd/ --ignore-not-found || true
 
           # Delete cluster-scoped resources
           kubectl delete clusterrole fma-node-viewer --ignore-not-found || true


### PR DESCRIPTION
This is a temporary stop-gap until we develop a more comprehensive solution.