### PR TITLE
🐛 Stop the E2E on OpenShift workflow from deleting the CRDs

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -885,7 +885,9 @@ jobs:
           kubectl delete namespace "$FMA_NAMESPACE" \
             --ignore-not-found --timeout=120s || true
 
-          # Delete CRDs --- NOT (TODO: more complete solution)
+          # Delete CRDs
+          # TODO: Implement safe CRD lifecycle management for tests (e.g., handle shared clusters,
+          #       concurrent test runs, and version upgrades/downgrades) before enabling CRD deletion.
           # kubectl delete -f config/crd/ --ignore-not-found || true
 
           # Delete cluster-scoped resources


### PR DESCRIPTION
This is a temporary stop-gap until we develop a more comprehensive solution.