### PR TITLE
fix: upgrade vllm CPU build from v0.15.0 to v0.15.1

### DIFF
--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -2,7 +2,7 @@
 # Supports both arm64 and amd64 architectures
 
 ARG TARGETARCH
-ARG VLLM_VERSION=v0.15.0
+ARG VLLM_VERSION=v0.15.1
 
 # Define base images for each architecture
 FROM public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:${VLLM_VERSION} AS base-arm64

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -13,5 +13,5 @@
 | **k8s.io/client-go** | `v0.34.0` | tag | `go.mod` line 9 | [kubernetes/client-go](https://github.com/kubernetes/client-go) |
 | **sigs.k8s.io/controller-runtime** | `v0.22.1` | tag | `go.mod` line 12 | [kubernetes-sigs/controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) |
 | **vllm/vllm-openai** | `v0.10.2` | tag | `cmd/requester/README.md` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
-| **vllm (CPU build)** | `v0.15.0` | tag | `dockerfiles/Dockerfile.launcher.cpu` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
+| **vllm (CPU build)** | `v0.15.1` | tag | `dockerfiles/Dockerfile.launcher.cpu` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
 | **nvidia/cuda** | `12.8.0-base-ubuntu22.04` | tag | `dockerfiles/Dockerfile.requester` | [NVIDIA CUDA](https://hub.docker.com/r/nvidia/cuda) |


### PR DESCRIPTION
## Summary

- Bumps `ARG VLLM_VERSION` in `dockerfiles/Dockerfile.launcher.cpu` from `v0.15.0` to `v0.15.1`
- Updates the tracked pin in `docs/upstream-versions.md` to match

## Security

v0.15.1 is a patch release that addresses two CVEs:
- **CVE-2025-69223** — updated `aiohttp` dependency
- **CVE-2026-0994** — updated `protobuf` dependency

## Test plan

- [x] Confirm `Dockerfile.launcher.cpu` line 5 reads `ARG VLLM_VERSION=v0.15.1`
- [x] Confirm `docs/upstream-versions.md` row for `vllm (CPU build)` shows `v0.15.1`
- [x] Optionally run a local Docker build to verify the new base image resolves:
  ```bash
  docker buildx build --platform linux/amd64 \
    -f dockerfiles/Dockerfile.launcher.cpu \
    --build-arg TARGETARCH=amd64 .
  ```

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)