### PR TITLE
ci: upgrade actions/cache to v5.0.3

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.12.11"
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4.2.4
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}


### PR DESCRIPTION
## Summary

- Pin `actions/cache` to the `v5.0.3` release commit hash (`cdf6c1fa76f9f475f3d7449005a359c84ca0f306`) with an inline comment holding the release number
- Follows the security best practice of pinning Actions to a full commit SHA rather than a mutable tag

## Test plan

- [ ] Verify the `python-code-quality` workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)