### PR TITLE
fix: replace ClusterRoleBinding to view with namespace-scoped pods permission

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -578,6 +578,9 @@ jobs:
           - apiGroups: [""]
             resources: ["configmaps"]
             verbs: ["create"]
+          - apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["get", "list", "watch"]
           EOF
 
           kubectl create sa testreq -n "$FMA_NAMESPACE" || true
@@ -586,8 +589,6 @@ jobs:
           kubectl create rolebinding testreq \
             --role=testreq --serviceaccount="${FMA_NAMESPACE}:testreq" \
             -n "$FMA_NAMESPACE" || true
-          kubectl create clusterrolebinding "testreq-view-${FMA_NAMESPACE}" \
-            --clusterrole=view --serviceaccount="${FMA_NAMESPACE}:testreq" || true
 
           echo "Test RBAC created"
 
@@ -913,7 +914,6 @@ jobs:
           # Delete cluster-scoped resources
           kubectl delete clusterrole fma-node-viewer --ignore-not-found || true
           kubectl delete clusterrolebinding "$FMA_RELEASE_NAME-node-view" --ignore-not-found || true
-          kubectl delete clusterrolebinding "testreq-view-${FMA_NAMESPACE}" --ignore-not-found || true
 
           # Delete ValidatingAdmissionPolicy resources (cluster-scoped)
           kubectl delete validatingadmissionpolicy fma-bound-serverreqpod fma-immutable-fields --ignore-not-found 2>/dev/null || true

--- a/inference_server/benchmark/setup_kind_resources.sh
+++ b/inference_server/benchmark/setup_kind_resources.sh
@@ -59,10 +59,17 @@ rules:
   - configmaps
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 EOF
 
 kubectl create rolebinding testreq --role=testreq --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
-kubectl create clusterrolebinding testreq-view --clusterrole=view --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
 
 kubectl create sa testreq
 kubectl create cm gpu-map

--- a/test/e2e/run-launcher-based.sh
+++ b/test/e2e/run-launcher-based.sh
@@ -108,10 +108,17 @@ rules:
   - configmaps
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 EOF
 
 kubectl create rolebinding testreq --role=testreq --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
-kubectl create clusterrolebinding testreq-view --clusterrole=view --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
 
 kubectl create sa testreq
 kubectl create cm gpu-map

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -104,10 +104,17 @@ rules:
   - configmaps
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 EOF
 
 kubectl create rolebinding testreq --role=testreq --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
-kubectl create clusterrolebinding testreq-view --clusterrole=view --serviceaccount=$(kubectl get sa default -o jsonpath={.metadata.namespace}):testreq
 
 
 kubectl create sa testreq


### PR DESCRIPTION
## Summary

- Closes #309 (sub-issue of #276)
- The `test-requester` binary's `getPodUIDs()` lists pods in the test namespace to sweep stale GPU allocations; this permission was previously supplied via a `ClusterRoleBinding` to the built-in `view` ClusterRole
- Replace it with an explicit `get/list/watch` rule on `pods` in the existing namespace-scoped `testreq` `Role`
- Remove all creation and cleanup of the `testreq-view` `ClusterRoleBinding` from `test/e2e/run.sh`, `test/e2e/run-launcher-based.sh`, `inference_server/benchmark/setup_kind_resources.sh`, and `.github/workflows/ci-e2e-openshift.yaml`

## Test plan

- [x] Run `test/e2e/run.sh` against a kind cluster — all test assertions pass
- [x] Run `test/e2e/run-launcher-based.sh` against a kind cluster — all test assertions pass
- [ ] After a test run, confirm `kubectl get clusterrolebinding | grep testreq-view` returns nothing
- [ ] OpenShift e2e CI workflow completes successfully and leaves no `testreq-view-*` ClusterRoleBinding behind

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Sonnet 4.6