### PR TITLE
Remove Node viewing ClusterRole from E2E-on-OCP workflow

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -396,7 +396,6 @@ jobs:
           # Clean up cluster-scoped resources from previous runs
           echo "Cleaning up cluster-scoped resources..."
           kubectl delete clusterrolebinding -l app.kubernetes.io/name=fma-controllers --ignore-not-found 2>/dev/null || true
-          kubectl delete clusterrole fma-node-viewer --ignore-not-found || true
 
           echo "Cleanup complete"
 
@@ -460,12 +459,6 @@ jobs:
           kubectl create configmap gpu-allocs -n "$FMA_NAMESPACE"
           echo "ConfigMaps created"
 
-      - name: Create node-viewer ClusterRole
-        run: |
-          echo "Creating node-viewer ClusterRole..."
-          kubectl create clusterrole fma-node-viewer --verb=get,list,watch --resource=nodes
-          echo "ClusterRole created"
-
       - name: Detect ValidatingAdmissionPolicy support
         id: detect-vap
         run: |
@@ -499,7 +492,6 @@ jobs:
             -n "$FMA_NAMESPACE" \
             --set global.imageRegistry="${CONTROLLER_IMAGE%/dual-pods-controller:*}" \
             --set global.imageTag="${CONTROLLER_IMAGE##*:}" \
-            --set global.nodeViewClusterRole=fma-node-viewer \
             --set dualPodsController.sleeperLimit=2 \
             --set global.local=false \
             --set dualPodsController.debugAcceleratorMemory=false \
@@ -920,10 +912,6 @@ jobs:
           # TODO: Implement safe CRD lifecycle management for tests (e.g., handle shared clusters,
           #       concurrent test runs, and version upgrades/downgrades) before enabling CRD deletion.
           # kubectl delete -f config/crd/ --ignore-not-found || true
-
-          # Delete cluster-scoped resources
-          kubectl delete clusterrole fma-node-viewer --ignore-not-found || true
-          kubectl delete clusterrolebinding "$FMA_RELEASE_NAME-node-view" --ignore-not-found || true
 
           echo "Cleanup complete"
 


### PR DESCRIPTION
Modify the GHA workflow that does E2E test in our shared OpenShift cluster so that it does not create, delete, nor use a ClusterRole for reading Nodes.

This is, at the moment, a test; not to be merged as is.