### PR TITLE
✨ Add workflow summary step showing gate decision

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -235,6 +235,19 @@ jobs:
               }
             }
 
+      - name: Write workflow summary
+        if: always()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const shouldRun = '${{ steps.check.outputs.should_run }}';
+            if (shouldRun === 'true') {
+              core.summary.addRaw('**E2E tests will run** for this trigger.');
+            } else {
+              core.summary.addRaw('**E2E tests were skipped** (gate check did not pass for this trigger).');
+            }
+            await core.summary.write();
+
   # Build the FMA controller image on GitHub-hosted runner
   # Uses ko (Go-native image builder) and pushes to GHCR
   # Note: Skip for fork PRs on pull_request event (no secrets access).


### PR DESCRIPTION
This is part of Andy's work from PR 285. This particular piece makes the "gate" job in the E2E-on-OpenShift workflow post the job's decision in the job's "summary".

I think that this is intended to address #272, but IMO it does not actually do so.