### PR TITLE
Rework `GetInferenceServerPort`

### DIFF
--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -104,7 +104,7 @@ func GPUIndexFunc(obj any) ([]string, error) {
 	if len(pod.Annotations[nominalHashAnnotationKey]) == 0 || pod.Spec.NodeName == "" {
 		return []string{}, nil
 	}
-	isIdx, _, err := utils.GetInferenceServerPort(pod, false)
+	isIdx, err := utils.GetInferenceServerContainerIndex(pod)
 	if err != nil {
 		return []string{}, nil
 	}

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -323,7 +323,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		if launcherBased {
 			serverPort = int16(isc.Spec.ModelServerConfig.Port)
 		} else {
-			_, serverPort, err = utils.GetInferenceServerPort(providingPod, false)
+			_, serverPort, err = utils.GetInferenceServerContainerIndexAndPort(providingPod)
 			if err != nil { // Impossible, because such a providingPod would never be created by this controller
 				return fmt.Errorf("unable to wake up server because port not known: %w", err), true
 			}
@@ -792,7 +792,7 @@ func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requesti
 	if launcherBased {
 		serverPort = instPort
 	} else {
-		_, serverPort, err = utils.GetInferenceServerPort(providingPod, false)
+		_, serverPort, err = utils.GetInferenceServerContainerIndexAndPort(providingPod)
 		if err != nil { // Impossible, because such a providingPod would never be created by this controller
 			return fmt.Errorf("unable to wake up server because port not known: %w", err), true
 		}
@@ -837,7 +837,7 @@ func (ctl *controller) maybeRemoveRequesterFinalizer(ctx context.Context, reques
 	// First, determine whether finalizer should be present
 	var wantFinalizer bool
 	if providingPod != nil {
-		isIdx, _, err := utils.GetInferenceServerPort(providingPod, false)
+		isIdx, err := utils.GetInferenceServerContainerIndex(providingPod)
 		if err == nil {
 			isCtr := &providingPod.Spec.Containers[isIdx]
 			statIdx := slices.IndexFunc(providingPod.Status.ContainerStatuses,
@@ -922,7 +922,7 @@ func (ctl *controller) ensureUnbound(ctx context.Context, serverDat *serverData,
 		if !launcherBased {
 			if serverDat.NominalProvidingPod == nil {
 				var err error
-				_, serverPort, err = utils.GetInferenceServerPort(providingPod, false)
+				_, serverPort, err = utils.GetInferenceServerContainerIndexAndPort(providingPod)
 				if err != nil { // Impossible, because such a providingPod would never be created by this controller
 					return fmt.Errorf("unable to put server to sleep because port not known: %w", err)
 				}
@@ -1043,7 +1043,7 @@ func (serverDat *serverData) getNominalServerProvidingPod(ctx context.Context, r
 		}
 		nodeSelector["kubernetes.io/hostname"] = reqPod.Spec.NodeName
 
-		cIdx, serverPort, err := utils.GetInferenceServerPort(pod, false)
+		cIdx, serverPort, err := utils.GetInferenceServerContainerIndexAndPort(pod)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -85,26 +85,17 @@ func removeVolumeMount(ctr *corev1.Container, volumeName string) {
 	}
 }
 
-// GetInferenceServerPort, given a server-providing Pod and whether it is launcher-based,
-// returns (containerIndex int, inferenceServerPort int16, err error)
-// For direct server-providing pods, the inference server port is identified from readinessProbe.
-// For launcher-based server-providing pods, the inference server port can't be identified from the launcher pod,
-// so we return a dummy value -1.
-func GetInferenceServerPort(pod *corev1.Pod, launcherBased bool) (int, int16, error) {
-	// identify the inference server container
-	cIdx := slices.IndexFunc(pod.Spec.Containers, func(c corev1.Container) bool {
-		return c.Name == api.InferenceServerContainerName
-	})
-	if cIdx == -1 {
-		return 0, 0, fmt.Errorf("container %q not found", api.InferenceServerContainerName)
+// GetInferenceServerContainerIndexAndPort returns the index of the inference server container
+// and the port for a server-providing Pod.
+// This function is for direct (non-launcher-based) server-providing Pods.
+// The port is identified from the readinessProbe.
+// Returns (containerIndex int, inferenceServerPort int16, err error).
+func GetInferenceServerContainerIndexAndPort(pod *corev1.Pod) (int, int16, error) {
+	cIdx, err := GetInferenceServerContainerIndex(pod)
+	if err != nil {
+		return 0, 0, err
 	}
 
-	// for launcher-based server-providing pod, return a dummy value
-	if launcherBased {
-		return cIdx, -1, nil
-	}
-
-	// for direct server-providing pod, identify the port from readinessProbe
 	isCtr := &pod.Spec.Containers[cIdx]
 	if isCtr.ReadinessProbe == nil {
 		return 0, 0, errors.New("the inference server container has no readinessProbe")
@@ -124,6 +115,19 @@ func GetInferenceServerPort(pod *corev1.Pod, launcherBased bool) (int, int16, er
 	default:
 		return 0, 0, fmt.Errorf("the readinessProbe port has unexpected type %q", portIOS.Type)
 	}
+}
+
+// GetInferenceServerContainerIndex returns the index of the inference server container
+// in the given Pod's container list.
+// This function is for both direct (non-launcher-based) and launcher-based server-providing Pods.
+func GetInferenceServerContainerIndex(pod *corev1.Pod) (int, error) {
+	cIdx := slices.IndexFunc(pod.Spec.Containers, func(c corev1.Container) bool {
+		return c.Name == api.InferenceServerContainerName
+	})
+	if cIdx == -1 {
+		return 0, fmt.Errorf("container %q not found", api.InferenceServerContainerName)
+	}
+	return cIdx, nil
 }
 
 func IsPodReady(pod *corev1.Pod) bool {
@@ -170,7 +174,7 @@ func BuildLauncherPodFromTemplate(template corev1.PodTemplateSpec, ns, nodeName,
 	}
 	pod.Annotations = MapSet(pod.Annotations, string(common.LauncherConfigHashAnnotationKey), nominalHash)
 
-	cIdx, _, err := GetInferenceServerPort(pod, true)
+	cIdx, err := GetInferenceServerContainerIndex(pod)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR reworked the GetInferenceServerPort function in utils, thus addresses a previous review comment https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/231#discussion_r2765690401