### PR TITLE
Configure launcher for ConfigMap-based GPU UUID-to-index translation

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -698,14 +698,19 @@ jobs:
                     image: ${TEST_LAUNCHER_IMAGE}
                     imagePullPolicy: Always
                     command:
-                    - /bin/bash
-                    - "-c"
-                    args:
-                    - |
-                      uvicorn launcher:app \
-                      --host 0.0.0.0 \
-                      --log-level info \
-                      --port 8001
+                    - /app/launcher.py
+                    - --host=0.0.0.0
+                    - --log-level=info
+                    - --port=8001
+                    - --mock-gpus
+                    env:
+                      - name: NODE_NAME
+                        valueFrom:
+                          fieldRef: { fieldPath: spec.nodeName }
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef: { fieldPath: metadata.namespace }
+                serviceAccount: testreq
           ---
           apiVersion: apps/v1
           kind: ReplicaSet
@@ -866,6 +871,20 @@ jobs:
       - name: List objects of category all
         if: always()
         run: kubectl get all -n "$FMA_NAMESPACE"
+
+      - name: Dump GPU ConfigMaps
+        if: always()
+        run: |
+          for cm in $(kubectl get configmaps -n "$FMA_NAMESPACE" -o 'jsonpath={.items[*].metadata.name} ') ; do
+            if ! [[ "$cm" =~ gpu ]]; then continue; fi
+            echo ""
+            echo "=== ConfigMap $cm ==="
+            kubectl get configmap -n "$FMA_NAMESPACE" $cm -o yaml || true
+          done
+
+      - name: Dump all Pods
+        if: always()
+        run: kubectl get pods -n "$FMA_NAMESPACE" -o yaml
 
       - name: List event objects
         if: always()

--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -15,6 +15,7 @@ FROM base-${TARGETARCH} AS final
 WORKDIR /app
 
 COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslator.py /app/
+RUN chmod a+x /app/launcher.py
 
 # Install uvicorn for serving the launcher API and nvidia-ml-py for gputranslator
 RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==31.0.0

--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2025 The llm-d Authors.
 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Summary
- Adds `--mock-gpus` flag to the launcher command in the OpenShift E2E workflow so the `GpuTranslator` reads GPU UUID-to-index mappings from the `gpu-map` ConfigMap
- Injects `NODE_NAME` and `NAMESPACE` env vars via the downward API so the launcher can locate its node's entry in the ConfigMap
- Sets the launcher pod's service account to `testreq` to grant read access to the `gpu-map` ConfigMap
- Changes `.github/workflows/ci-e2e-openshift.yaml` to directly invoke the launcher and let it launch uvicorn, rather than the other way around, so that the launcher does the argument parsing
- Adds dumping of the Pod YAML and GPU-related ConfigMap contents

Fixes #340
Fixes #342

Addresses part of #336

## Test plan
- [x] Verify the OpenShift E2E workflow passes with the launcher reading GPU mappings from the `gpu-map` ConfigMap

🤖 Some parts generated with [Claude Code](https://claude.com/claude-code)