### PR TITLE
Revise type VllmConfig

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -26,7 +26,7 @@ import sys
 import uuid
 from contextlib import asynccontextmanager
 from http import HTTPStatus  # HTTP Status Codes
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import uvloop
 from fastapi import FastAPI, Header, HTTPException, Path
@@ -57,7 +57,7 @@ class LogRangeNotAvailable(Exception):
 class VllmConfig(BaseModel):
     options: str
     gpu_uuids: Optional[List[str]] = None
-    env_vars: Optional[Dict[str, Any]] = None
+    env_vars: Optional[Dict[str, str]] = None
 
 
 class VllmInstance:
@@ -595,15 +595,15 @@ def vllm_kickoff(vllm_config: VllmConfig, log_file_path: str):
 
 
 # Function to set env variables
-def set_env_vars(env_vars: Dict[str, Any]):
+def set_env_vars(env_vars: Dict[str, str]):
     """
     Set environment variables from a dictionary
-    :param env_vars: Dict with environment var name as keys and value as values
+    :param env_vars: Dict with environment var name as keys and string values
     """
 
     # Set environment variables from a dictionary
     for key, value in env_vars.items():
-        os.environ[key] = str(value)
+        os.environ[key] = value
 
 
 if __name__ == "__main__":

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -884,7 +884,11 @@ class TestVllmInstanceLogs:
 class TestHelperFunctions:
     def test_set_env_vars(self):
         """Test setting environment variables"""
-        test_vars = {"TEST_VAR_1": "value1", "TEST_VAR_2": 12345, "TEST_VAR_3": True}
+        test_vars = {
+            "TEST_VAR_1": "value1",
+            "TEST_VAR_2": "12345",
+            "TEST_VAR_3": "True",
+        }
 
         set_env_vars(test_vars)
 

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -648,7 +648,7 @@ func (ctl *controller) configInferenceServer(isc *fmav1alpha1.InferenceServerCon
 	vllmCfg := VllmConfig{
 		Options:  options,
 		GpuUUIDs: gpuUUIDs,
-		EnvVars:  make(map[string]interface{}, len(isc.Spec.ModelServerConfig.EnvVars)),
+		EnvVars:  make(map[string]string, len(isc.Spec.ModelServerConfig.EnvVars)),
 	}
 	for k, v := range isc.Spec.ModelServerConfig.EnvVars {
 		vllmCfg.EnvVars[k] = v

--- a/pkg/controller/dual-pods/launcherclient.go
+++ b/pkg/controller/dual-pods/launcherclient.go
@@ -50,9 +50,9 @@ func NewLauncherClient(baseURL string) (*LauncherClient, error) {
 
 // VllmConfig matches the launcher API schema.
 type VllmConfig struct {
-	Options  string                 `json:"options"`
-	GpuUUIDs []string               `json:"gpu_uuids,omitempty"`
-	EnvVars  map[string]interface{} `json:"env_vars,omitempty"`
+	Options  string            `json:"options"`
+	GpuUUIDs []string          `json:"gpu_uuids,omitempty"`
+	EnvVars  map[string]string `json:"env_vars,omitempty"`
 }
 
 // InstanceStatus returned by status APIs.


### PR DESCRIPTION
This PR tighten the types of `EnvVars` in `type VllmConfig`.

This PR addresses the comment from @MikeSpreitzer here https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/317#discussion_r2894297159