### PR TITLE
🌱 Pin E2E-on-OpenShift test to vllm-d cluster

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -329,7 +329,7 @@ jobs:
 
   # Run e2e tests on OpenShift self-hosted runner
   e2e-openshift:
-    runs-on: [self-hosted, openshift]
+    runs-on: [self-hosted, openshift, vllm-d]
     needs: [gate, build-image]
     if: needs.gate.outputs.should_run == 'true'
     env:


### PR DESCRIPTION
This PR updates `.github/workflows/ci-e2e-openshift.yaml` so that the Job that runs the test necessarily uses a runner that accesses the vllm-d cluster, which is the one and only intended for use in testing PRs.

Fixes #345