### PR TITLE
Fix typos and add typos config

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,10 @@
+[default.extend-words]
+ded = "ded"
+
+[default.extend-identifiers]
+ist = "ist"
+nd = "nd"
+
+[type.drawio_svg]
+extend-glob = ["*.drawio.svg"]
+check-file = false

--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -20,7 +20,7 @@ server-requesting Pods that clients/users create to describe the
 desired inference servers and (2) the server-providing Pods that
 actually run the inference servers.
 
-The dual pods technnique takes advantage of something that we have
+The dual pods technique takes advantage of something that we have
 observed: for nodes that run inference servers, just one resource
 determines what Pods can run, when and where: the accelerators (GPUs);
 CPU and main memory are always sufficient when the constraints on

--- a/inference_server/benchmark/scenarios.py
+++ b/inference_server/benchmark/scenarios.py
@@ -241,7 +241,7 @@ def _run_scaling_phase(
         )
         benchmark.results.append(iter_result)
 
-    # Check whether errors occured for any of the dual pods.
+    # Check whether errors occurred for any of the dual pods.
     if readiness_result.status == ScenarioStatus.FAILURE:
         benchmark.logger.warning(
             f"Scaling step '{phase}' for request {rs_name} errored: {err}"

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -128,7 +128,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			pod := podAny.(*corev1.Pod)
 			return pod.Name, nil
 		})
-		return fmt.Errorf("found multiple bound server-runninng Pods: %v", providerNames), false
+		return fmt.Errorf("found multiple bound server-running Pods: %v", providerNames), false
 	}
 
 	logger.V(5).Info("Processing inference server",
@@ -830,7 +830,7 @@ func (ctl *controller) wakeSleeper(ctx context.Context, serverDat *serverData, r
 }
 
 // maybeRemoveRequesterFinalizer removes the requesterFinalizer if necessary,
-// and detemines whether the finalizer needs to be added.
+// and determines whether the finalizer needs to be added.
 // requestingPod != nil; providingPod might be nil.
 // Returns (removed, shouldAdd bool, err error, retry bool).
 func (ctl *controller) maybeRemoveRequesterFinalizer(ctx context.Context, requestingPod, providingPod *corev1.Pod) (bool, bool, error, bool) {

--- a/pkg/controller/generic/queue-work.go
+++ b/pkg/controller/generic/queue-work.go
@@ -84,7 +84,7 @@ func (ctl *QueueAndWorkers[Item]) StartWorkers(ctx context.Context) error {
 		workLogger.V(3).Info("Launching worker")
 		go func() {
 			wait.UntilWithContext(workCtx, func(ctx context.Context) { ctl.runWorker(ctx) }, time.Second)
-			workLogger.V(3).Info("Fnished worker")
+			workLogger.V(3).Info("Finished worker")
 		}()
 	}
 	logger.V(1).Info("Started workers", "numWorkers", ctl.NumWorkers)

--- a/pkg/controller/utils/generics.go
+++ b/pkg/controller/utils/generics.go
@@ -34,7 +34,7 @@ func SliceMap[Domain, Range any](slice []Domain, mapFn func(Domain) (Range, erro
 	return mapped, errors
 }
 
-// SliceRemoveOnce removes the first occurence of the given element from the given slice.
+// SliceRemoveOnce removes the first occurrence of the given element from the given slice.
 // This returns a new slice rather than side-effecting the given one.
 func SliceRemoveOnce[Elt comparable](slice []Elt, goner Elt) ([]Elt, bool) {
 	idx := slices.Index(slice, goner)

--- a/pkg/spi/interface.go
+++ b/pkg/spi/interface.go
@@ -29,7 +29,7 @@ package spi
 const AcceleratorQueryPath = "/v1/dual-pods/accelerators"
 
 // AcceleratorMemoryQueryPath is the path part of the URL that
-// responds to an HTTP GET rquest with a response body that is
+// responds to an HTTP GET request with a response body that is
 // the JSON for a JSON "object" whose keys are accelerator IDs
 // and whose values are integers, the number of bytes of accelerator
 // memory in use.


### PR DESCRIPTION
## Summary
- Fix 7 typographic errors in comments, docs, log messages, and error strings found by the `typos` tool
- Add `_typos.toml` config to handle false positives (`ded` as a word; `ist`, `nd` as identifiers; disable checking of `*.drawio.svg` files)

## Typos fixed
- `rquest` → `request` (pkg/spi/interface.go)
- `Fnished` → `Finished` (pkg/controller/generic/queue-work.go)
- `technnique` → `technique` (docs/dual-pods.md)
- `occurence` → `occurrence` (pkg/controller/utils/generics.go)
- `runninng` → `running` (pkg/controller/dual-pods/inference-server.go)
- `detemines` → `determines` (pkg/controller/dual-pods/inference-server.go)
- `occured` → `occurred` (inference_server/benchmark/scenarios.py)

## Test plan
- [x] Verified `typos` reports only the known `GPU-ful` false positive after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #347 