### PR TITLE
Dynamic port allocation with reverse proxy on server-requesting pod

### DIFF
--- a/api/fma/v1alpha1/inferenceserverconfig_types.go
+++ b/api/fma/v1alpha1/inferenceserverconfig_types.go
@@ -35,7 +35,10 @@ type InferenceServerConfigSpec struct {
 type ModelServerConfig struct {
 	// Port is the port on which the vLLM server will listen
 	// Particularly, management of vLLM instances' sleep state is done through this port
-	Port int32 `json:"port"`
+	// If not specified, the dual-pods controller will automatically assign an available port
+	// from a predefined port pool based on the LauncherConfig's maxSleepingInstances.
+	// +optional
+	Port int32 `json:"port,omitempty"`
 
 	// Options are the vLLM startup options, excluding Port
 	// +optional

--- a/cmd/requester/main.go
+++ b/cmd/requester/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/proxy"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"k8s.io/klog/v2"
@@ -48,10 +49,15 @@ func main() {
 		spiPort = "8081"
 	}
 
+	proxyPort := os.Getenv("PROXY_PORT")
+	if proxyPort == "" {
+		proxyPort = "8082"
+	}
+
 	var ready atomic.Bool
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()
@@ -69,6 +75,15 @@ func main() {
 		err := probes.Run(ctx, probesPort, &ready)
 		if err != nil {
 			logger.Error(err, "failed to start requester probes server")
+		}
+	}()
+
+	// Start the reverse proxy server
+	go func() {
+		defer wg.Done()
+		err := proxy.Run(ctx, proxyPort)
+		if err != nil {
+			logger.Error(err, "failed to start requester proxy server")
 		}
 	}()
 

--- a/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
+++ b/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
@@ -72,10 +72,10 @@ spec:
                     description: |-
                       Port is the port on which the vLLM server will listen
                       Particularly, management of vLLM instances' sleep state is done through this port
+                      If not specified, the dual-pods controller will automatically assign an available port
+                      from a predefined port pool based on the LauncherConfig's maxSleepingInstances.
                     format: int32
                     type: integer
-                required:
-                - port
                 type: object
             required:
             - launcherConfigName

--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -125,6 +125,74 @@ assigned to the server-requesting Pod) for running `vllm serve`. To
 swap a model out, the controller issues a request that does not
 include those details.
 
+### Dynamic Port Allocation and Reverse Proxy
+
+In launcher-based model swapping (milestone 3), the dual-pods
+controller supports dynamic port allocation for vLLM instances and
+uses a reverse proxy in the requester container to route inference
+requests.
+
+#### Dynamic Port Allocation
+
+When the launcher manages multiple vLLM instances on a single node,
+each instance needs to listen on a different port. The dual-pods
+controller can allocate ports dynamically from a configurable pool
+(default: ports 8005-8012) instead of requiring a fixed port in the
+`InferenceServerConfig`.
+
+The port allocation works as follows:
+
+1. **Explicit port specification**: If the user specifies a port in
+   `InferenceServerConfig.Spec.ModelServerConfig.Port`, that port is
+   used directly.
+
+2. **Dynamic allocation for new instances**: When no port is specified
+   and a new vLLM instance needs to be created, the controller queries
+   the launcher for existing port allocations and assigns the next
+   available port from the pool.
+
+3. **Port retrieval for existing instances**: When waking a sleeping
+   vLLM instance, the controller retrieves the previously allocated
+   port from the launcher's instance state.
+
+The controller communicates with the launcher's API to discover which
+ports are already in use and allocates unused ports. The allocated
+port is then used in the vLLM command-line arguments (e.g.,
+`--port 8005`).
+
+#### Requester Reverse Proxy
+
+The requester container includes a reverse proxy server that forwards
+inference requests to the actual vLLM instance running in the
+server-providing Pod (typically managed by the launcher). This
+abstraction allows clients to send requests to the server-requesting
+Pod without needing to know the dynamically allocated port.
+
+The reverse proxy operates as follows:
+
+1. **Initialization**: When the dual-pods controller binds a
+   server-requesting Pod to a server-providing Pod, it sends an HTTP
+   POST request to the requester's proxy initialization endpoint
+   (`/v1/proxy/init`). The request body contains the target address
+   (launcher Pod IP) and the dynamically allocated port:
+
+   ```json
+   {"address": "10.244.1.5", "port": 8005}
+   ```
+
+2. **Request forwarding**: Once initialized, the reverse proxy
+   forwards all incoming HTTP requests to the configured vLLM
+   instance. This includes OpenAI-compatible API endpoints like
+   `/v1/chat/completions`, `/v1/completions`, etc.
+
+3. **Status checking**: The proxy's initialization status can be
+   queried via an HTTP GET request to `/v1/proxy/init`.
+
+This design decouples the client-facing endpoint (server-requesting
+Pod) from the actual inference server location (server-providing Pod
+with dynamic port), enabling flexible resource management and model
+swapping without disrupting inference clients.
+
 ### Scenarios
 
 The outer product of

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -551,6 +551,13 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				return fmt.Errorf("failed to configure inference server with port allocation: %w", err), true
 			}
 
+			url := fmt.Sprintf("http://%s:%s%s", requestingPod.Status.PodIP, adminPort, stubapi.InitProxy)
+			if err := doPostWithData(url, bytes.NewReader([]byte(fmt.Sprintf("{\"address\":\"%s\",\"port\":%d}",
+				launcherIP, allocatedPort)))); err != nil {
+				logger.Error(err, "Failed to init requester proxy")
+				return err, true
+			}
+
 			if hasSleepingInstance {
 				// Fast path: wake up existing sleeping instance
 				// allocatedPort is already retrieved from launcherDat.AllocatedPorts
@@ -1317,11 +1324,15 @@ func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1
 
 // doPost does the HTTP POST request/response to the given URL.
 func doPost(url string) error {
+	return doPostWithData(url, nil)
+}
+
+func doPostWithData(url string, data io.Reader) error {
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}
 
-	resp, err := client.Post(url, "application/json", nil)
+	resp, err := client.Post(url, "application/json", data)
 	if err != nil {
 		return fmt.Errorf("http post %q: %w", url, err)
 	}

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -343,7 +343,21 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 	if providingPod != nil {
 		var serverPort int16
 		if launcherBased {
-			serverPort = int16(isc.Spec.ModelServerConfig.Port)
+			// If port is not specified in InferenceServerConfig, retrieve the allocated port
+			// from launcherData.AllocatedPorts using the instance ID (iscHash)
+			if isc.Spec.ModelServerConfig.Port != 0 {
+				serverPort = int16(isc.Spec.ModelServerConfig.Port)
+			} else {
+				// Dynamically allocated port: need to retrieve from launcher API
+				iscHash, err := ctl.computeInferenceServerHash(isc, serverDat.GPUIDs)
+				if err != nil {
+					return fmt.Errorf("failed to compute InferenceServer hash for port lookup: %w", err), true
+				}
+				serverPort, err = getInstancePort(ctx, providingPod.Status.PodIP, iscHash)
+				if err != nil {
+					return fmt.Errorf("failed to get port for instance %q: %w", iscHash, err), true
+				}
+			}
 		} else {
 			_, serverPort, err = utils.GetInferenceServerContainerIndexAndPort(providingPod)
 			if err != nil { // Impossible, because such a providingPod would never be created by this controller
@@ -486,9 +500,10 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		return err, false
 	}
 
-	cfg, iscHash, err := ctl.configInferenceServer(isc, serverDat.GPUIDs)
+	// Compute the nominal hash for the InferenceServerConfig
+	iscHash, err := ctl.computeInferenceServerHash(isc, serverDat.GPUIDs)
 	if err != nil {
-		return fmt.Errorf("failed to configure inference server config: %w", err), true
+		return fmt.Errorf("failed to compute inference server hash: %w", err), true
 	}
 	logger.V(5).Info("Nominal hash of InferenceServerConfig", "hash", iscHash)
 
@@ -524,16 +539,29 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 
 			launcherDat := ctl.getLauncherData(nodeDat, launcherPod.Name)
 
+			// Configure inference server with port allocation
+			// This handles both new instance creation and existing instance wake-up
+			// Note: iscHash is used as instanceID here because it uniquely identifies
+			// the inference server config + GPU combination. For hasSleepingInstance=true,
+			// we need iscHash to look up the allocated port; for false, we use it to
+			// register the new instance. serverDat.InstanceID may be empty if the
+			// requesting Pod was recreated with a different UID.
+			cfg, allocatedPort, err := ctl.configInferenceServerWithPort(ctx, isc, launcherIP, serverDat.GPUIDs, iscHash, hasSleepingInstance)
+			if err != nil {
+				return fmt.Errorf("failed to configure inference server with port allocation: %w", err), true
+			}
+
 			if hasSleepingInstance {
 				// Fast path: wake up existing sleeping instance
-				logger.V(5).Info("Waking up existing vLLM instance", "iscHash", iscHash)
-				err := ctl.wakeupInstance(ctx, lClient, iscHash, isc.Spec.ModelServerConfig.Port)
+				// allocatedPort is already retrieved from launcherDat.AllocatedPorts
+				logger.V(5).Info("Waking up existing vLLM instance", "iscHash", iscHash, "port", allocatedPort)
+				err := ctl.wakeupInstance(ctx, lClient, iscHash, int32(allocatedPort))
 				if err != nil {
 					return fmt.Errorf("wake up vLLM instance: %w", err), true
 				}
 				launcherDat.Instances[iscHash] = time.Now()
 				// TODO(waltforme): the bind method may need more revision to fully handle launcher-based server providing Pods
-				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(isc.Spec.ModelServerConfig.Port))
+				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(allocatedPort))
 			} else {
 				// Slower path: create new instance in launcher with capacity
 				logger.V(5).Info("Creating new vLLM instance", "iscHash", iscHash)
@@ -547,7 +575,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				)
 				launcherDat.Instances[iscHash] = time.Now()
 				// TODO(waltforme): the bind method may need more revision to fully handle launcher-based server providing Pods
-				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(isc.Spec.ModelServerConfig.Port))
+				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(allocatedPort))
 			}
 		}
 	}
@@ -666,20 +694,12 @@ func (ctl *controller) selectBestLauncherPod(
 	return nil, false, false, nil
 }
 
-func (ctl *controller) configInferenceServer(isc *fmav1alpha1.InferenceServerConfig, gpuUUIDs []string) (*VllmConfig, string, error) {
-	options := isc.Spec.ModelServerConfig.Options + " --port " + strconv.Itoa(int(isc.Spec.ModelServerConfig.Port))
-	vllmCfg := VllmConfig{
-		Options:  options,
-		GpuUUIDs: gpuUUIDs,
-		EnvVars:  make(map[string]string, len(isc.Spec.ModelServerConfig.EnvVars)),
-	}
-	for k, v := range isc.Spec.ModelServerConfig.EnvVars {
-		vllmCfg.EnvVars[k] = v
-	}
-
+// computeInferenceServerHash computes the nominal hash for an InferenceServerConfig.
+// The hash is used as the instance ID when creating vLLM instances in the launcher.
+func (ctl *controller) computeInferenceServerHash(isc *fmav1alpha1.InferenceServerConfig, gpuUUIDs []string) (string, error) {
 	iscBytes, err := yaml.Marshal(isc.Spec.ModelServerConfig)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to marshal InferenceServerConfig %q: %w", isc.Name, err)
+		return "", fmt.Errorf("failed to marshal InferenceServerConfig %q: %w", isc.Name, err)
 	}
 	hasher := sha256.New()
 	hasher.Write(iscBytes)
@@ -690,7 +710,59 @@ func (ctl *controller) configInferenceServer(isc *fmav1alpha1.InferenceServerCon
 	// using Raw_URL_Encoding because this hash will be used in URLs to the launcher.
 	nominalHash := base64.RawURLEncoding.EncodeToString(hashSl)
 
-	return &vllmCfg, nominalHash, nil
+	return nominalHash, nil
+}
+
+// configInferenceServerWithPort builds the vLLM configuration with the specified or dynamically allocated port.
+// It handles three cases:
+// 1. User explicitly specified a port in InferenceServerConfig
+// 2. Instance already exists (hasSleepingInstance=true), retrieve the allocated port
+// 3. New instance, allocate a port from the pool
+func (ctl *controller) configInferenceServerWithPort(
+	ctx context.Context,
+	isc *fmav1alpha1.InferenceServerConfig,
+	launcherAddress string,
+	gpuUUIDs []string,
+	instanceID string,
+	hasSleepingInstance bool,
+) (*VllmConfig, int16, error) {
+	// Determine the port to use
+	var port int16
+	if isc.Spec.ModelServerConfig.Port != 0 {
+		// Case 1: User specified a port, use it
+		port = int16(isc.Spec.ModelServerConfig.Port)
+	} else {
+		portsOnLauncher, err := getInstancePorts(ctx, launcherAddress)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to retrieve ports from launcher: %w", err)
+		}
+		if hasSleepingInstance {
+			// Case 2: Instance already exists, retrieve the allocated port
+			port = portsOnLauncher[instanceID]
+			if port == 0 {
+				// Should not happen
+				return nil, 0, fmt.Errorf("instance %q has no port allocated", instanceID)
+			}
+		} else {
+			// Case 3: New instance, allocate a port from the pool
+			port, err = allocatePort(portsOnLauncher)
+			if err != nil {
+				return nil, 0, fmt.Errorf("failed to allocate port: %w", err)
+			}
+		}
+	}
+
+	options := isc.Spec.ModelServerConfig.Options + " --port " + strconv.Itoa(int(port))
+	vllmCfg := VllmConfig{
+		Options:  options,
+		GpuUUIDs: gpuUUIDs,
+		EnvVars:  make(map[string]string, len(isc.Spec.ModelServerConfig.EnvVars)),
+	}
+	for k, v := range isc.Spec.ModelServerConfig.EnvVars {
+		vllmCfg.EnvVars[k] = v
+	}
+
+	return &vllmCfg, port, nil
 }
 
 func (ctl *controller) wakeupInstance(ctx context.Context, lClient *LauncherClient, instanceID string, instancePort int32) error {
@@ -1382,4 +1454,64 @@ func TimePtrToStringPtr(tp *metav1.Time) *string {
 	}
 	str := tp.String()
 	return &str
+}
+
+func getInstancePorts(ctx context.Context, launcherAddress string) (map[string]int16, error) {
+	launcherBaseURL := fmt.Sprintf("http://%s:%d", launcherAddress, ctlrcommon.LauncherServicePort)
+	lClient, err := NewLauncherClient(launcherBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	// Query all instances to find the port for this iscHash
+	allInstances, err := lClient.ListInstances(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list instances: %w", err)
+	}
+
+	// Find the instance with matching ID and get its port
+	portMap := make(map[string]int16, len(allInstances.Instances))
+	for _, inst := range allInstances.Instances {
+		re := regexp.MustCompile(`--port\s+(\d+)`)
+		matches := re.FindStringSubmatch(inst.Options)
+		if len(matches) > 1 {
+			portNum, err := strconv.ParseInt(matches[1], 10, 16)
+			if err == nil {
+				port := int16(portNum)
+				portMap[inst.InstanceID] = port
+			} else {
+				return nil, fmt.Errorf("failed to parse port number from options: %w", err)
+			}
+		}
+	}
+	return portMap, nil
+}
+
+func getInstancePort(ctx context.Context, launcherAddress string, iscHash string) (int16, error) {
+	portsOnLauncher, err := getInstancePorts(ctx, launcherAddress)
+	if err != nil {
+		return 0, err
+	}
+	port, found := portsOnLauncher[iscHash]
+	if !found {
+		return 0, fmt.Errorf("instance %q not found or has no port %q", iscHash, port)
+	}
+	return port, nil
+}
+
+// Port pool configuration
+// PortPoolBase is the starting port number for the dynamic port allocation pool
+const PortPoolBase int16 = 8005
+
+// allocatePort allocates a port from the port pool for a new vLLM instance.
+func allocatePort(existingPorts map[string]int16) (int16, error) {
+	ports := sets.New[int16]()
+	for _, port := range existingPorts {
+		ports.Insert(port)
+	}
+	for port := PortPoolBase; port < PortPoolBase+8; port++ {
+		if !ports.Has(port) {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available port found")
 }

--- a/pkg/server/requester/coordination/server.go
+++ b/pkg/server/requester/coordination/server.go
@@ -31,6 +31,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/proxy"
 	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
@@ -212,6 +213,7 @@ func RunWithGPUUUIDs(ctx context.Context, port string, ready *atomic.Bool, logWr
 	mux.HandleFunc("POST "+stubapi.BecomeReadyPath, newSetReadyHandler(logger, ready, true))
 	mux.HandleFunc("POST "+stubapi.BecomeUnreadyPath, newSetReadyHandler(logger, ready, false))
 	mux.HandleFunc("POST "+stubapi.SetLogPath, newSetLogHandler(logger, logWriter))
+	mux.HandleFunc(stubapi.InitProxy, proxy.Initialize)
 
 	server := &http.Server{
 		Addr:    ":" + port,

--- a/pkg/server/requester/proxy/server.go
+++ b/pkg/server/requester/proxy/server.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// ConfigRequest is the request body to configure the proxy target
+type ConfigRequest struct {
+	Address string `json:"address"`
+	Port    int    `json:"port"`
+}
+
+// proxy is a lazy HTTP reverse proxy that only starts after receiving
+// the first configuration request
+type proxy struct {
+	mu          sync.RWMutex
+	targetURL   *url.URL
+	proxy       *httputil.ReverseProxy
+	initialized atomic.Bool
+}
+
+// singleton instance initialized once at startup
+var instance = &proxy{}
+
+// Run starts the proxy server on the given port
+func Run(ctx context.Context, port string) error {
+	logger := klog.FromContext(ctx).WithName("proxy-server")
+	logger.Info("starting proxy server")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", serveProxy)
+
+	server := &http.Server{
+		Addr:         fmt.Sprintf(":%s", port),
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 5 * time.Minute, // Long timeout for inference requests
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		logger.Info("shutting down")
+
+		ctx, cancelFn := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancelFn()
+		if err := server.Shutdown(ctx); err != nil {
+			logger.Error(err, "failed to gracefully shutdown")
+		}
+	}()
+
+	logger.Info("starting server", "port", port)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("listen and serve error: %w", err)
+	}
+
+	logger.Info("server stopped")
+	return nil
+}
+
+// serveProxy proxies requests to the target server
+func serveProxy(w http.ResponseWriter, r *http.Request) {
+	if !instance.initialized.Load() {
+		http.Error(w, "proxy not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Proxy the request
+	instance.proxy.ServeHTTP(w, r)
+}
+
+// Initialize handles proxy initialization and configuration
+func Initialize(w http.ResponseWriter, r *http.Request) {
+	// Get proxy status
+	if r.Method == http.MethodGet {
+		if instance.initialized.Load() {
+			targetURL := instance.targetURL
+			w.WriteHeader(http.StatusOK)
+			if targetURL != nil {
+				_, _ = fmt.Fprintf(w, "proxying to %s", targetURL)
+			} else {
+				_, _ = w.Write([]byte("proxy initialized but targetURL is nil"))
+			}
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("proxy not initialized"))
+		}
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "invalid method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Try initialize server
+	if instance.initialized.Load() {
+		http.Error(w, "proxy already intialized", http.StatusConflict)
+		return
+	}
+
+	// Need to initialize - acquire write lock
+	instance.mu.Lock()
+	defer instance.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if instance.initialized.Load() {
+		http.Error(w, "proxy already intialized", http.StatusConflict)
+		return
+	}
+
+	// Parse configuration from request body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	var config ConfigRequest
+	if err := json.Unmarshal(body, &config); err != nil {
+		http.Error(w, fmt.Sprintf("failed to parse JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if config.Address == "" {
+		http.Error(w, "address is required", http.StatusBadRequest)
+		return
+	}
+
+	if config.Port <= 0 || config.Port > 65535 {
+		http.Error(w, "invalid port", http.StatusBadRequest)
+		return
+	}
+
+	// Create target URL
+	targetURL := &url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(config.Address, fmt.Sprintf("%d", config.Port)),
+	}
+
+	// Create the reverse proxy
+	instance.targetURL = targetURL
+	instance.proxy = httputil.NewSingleHostReverseProxy(targetURL)
+
+	// Customize error handling
+	originalErrorHandler := instance.proxy.ErrorHandler
+	instance.proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		if originalErrorHandler != nil {
+			originalErrorHandler(w, r, err)
+		} else {
+			http.Error(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
+		}
+	}
+
+	instance.initialized.Store(true)
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, "initialized proxy to: %s", targetURL)
+}

--- a/pkg/spi/interface.go
+++ b/pkg/spi/interface.go
@@ -59,3 +59,15 @@ const SetLogPath = "/v1/set-log"
 // LogStartPosParam is the name of the query parameter that
 // holds that starting position of a log chunk.
 const LogStartPosParam = "startPos"
+
+// InitProxy is the path for initializing the HTTP reverse proxy。
+// The proxy is used to forward requests from the server-requesting
+// pod to the server-providing pod.
+// Supports two HTTP methods:
+//   - GET: retrieves the initialization status of the proxy.
+//     Returns  status info.
+//   - POST: initializes the proxy with a target address and port.
+//     The request body should contain a JSON object with "address"
+//     and "port" fields. After successful initialization,
+//     the proxy will forward requests to the configured target server.
+const InitProxy = "/v1/proxy/init"


### PR DESCRIPTION
This PR makes `InferenceServerConfig.spec.modelServerConfig.Port` optional, implementing the approach discussed in the following Slack conversation to enable integration with InferencePool. Currently, when no port is specified, the dual-pods controller can dynamically allocate a port and record it in the launcher pod’s `inference.networking.k8s.io/active-ports` annotation.

https://llm-d.slack.com/archives/C09TNPEFJUD/p1769183239461429

A current issue indeed exists: users of InferencePool and maintainers of the dual-pods controller must mutually agree upon a predefined list of available ports. Currently, this port range is hardcoded—from `8005` to `8005 + N - 1`—which ironically increases complexity .

I am seriously considering the alternative options proposed earlier: adding TCP proxy functionality to the requester, enabling direct access to the vLLM service via the requester—this should also align all ports. Maybe it will be better.

I would greatly appreciate your comments. @MikeSpreitzer @lionelvillard 