### PR TITLE
🌱 Unify launcher unit testing

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -34,7 +34,7 @@ jobs:
           # install black isort flake
           pip install black==24.4.2 isort==5.13.2 flake8==7.0.0
           # install pytest and other dependencies
-          pip install pytest==9.0.2 fastapi==0.116.1 pydantic==2.11.7 uvicorn==0.35.0 uvloop==0.21.0 httpx==0.28.1 nvidia-ml-py==13.590.48 kubernetes==31.0.0
+          pip install pytest==9.0.2 -r inference_server/launcher/requirements-sans-vllm.txt
 
       - name: Check for trailing whitespace
         run: |

--- a/inference_server/launcher/howto.md
+++ b/inference_server/launcher/howto.md
@@ -1,13 +1,14 @@
 1- HOW TO RUN THE UNIT TEST:
 
-Install all the necessary packages:
+Install all the necessary packages (feel free to use a later version of pytest if you prefer):
 ```bash
-pip install -r requirements.txt
+pip install pytest==9.0.2 -r requirements-sans-vllm.txt
 ```
 
 Run the unit test doing:
 ```bash
-python -m pytest test_launcher.py -v
+python -m pytest tests/test_launcher.py -v
+python -m pytest tests/test_gputranslator.py -v
 ```
 
 2- RUN E2E TEST:

--- a/inference_server/launcher/requirements-sans-vllm.txt
+++ b/inference_server/launcher/requirements-sans-vllm.txt
@@ -1,0 +1,7 @@
+fastapi==0.135.1
+pydantic==2.12.5
+uvicorn==0.42.0
+uvloop==0.22.1
+httpx==0.28.1
+nvidia-ml-py==13.590.48
+kubernetes==31.0.0

--- a/inference_server/launcher/requirements.txt
+++ b/inference_server/launcher/requirements.txt
@@ -1,8 +1,3 @@
-fastapi
-pydantic
-uvicorn
-uvloop
-nvidia-ml-py
-kubernetes==31.0.0
+-r requirements-sans-vllm.txt
 # WARNING: vllm must be built from source on a macOS Silicon
 vllm; sys_platform != "darwin" or platform_machine != "arm64"


### PR DESCRIPTION
Make the GHA workflow use the requirements file.

Update the requirements file to versions that are more recent AND work on MacOS.

Make all the instructions about running the tests consistent.

Fixes #366 