### PR TITLE
handle LauncherConfig update events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ Desktop.ini
 *~
 /bin/
 /hack/tools/
+/vendor/

--- a/pkg/controller/launcher-populator/node-launcher-key.go
+++ b/pkg/controller/launcher-populator/node-launcher-key.go
@@ -19,6 +19,8 @@ package launcherpopulator
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 )
 
@@ -32,18 +34,16 @@ func (k NodeLauncherKey) String() string {
 	return fmt.Sprintf("%s/%s", k.LauncherConfigName, k.NodeName)
 }
 
-// DesiredStateEntry holds the desired count and corresponding LauncherConfig
+// DesiredStateEntry holds the desired count and the LauncherConfig spec
 // for a (Node, LauncherConfig) pair.
 type DesiredStateEntry struct {
-	Count          int32
-	LauncherConfig *fmav1alpha1.LauncherConfig
+	Count              int32
+	LauncherConfigSpec fmav1alpha1.LauncherConfigSpec
+	LauncherConfigOwnerRef metav1.OwnerReference
 }
 
 func (e DesiredStateEntry) String() string {
-	if e.LauncherConfig != nil {
-		return fmt.Sprintf("count=%d,config=%s", e.Count, e.LauncherConfig.Name)
-	}
-	return fmt.Sprintf("count=%d", e.Count)
+	return fmt.Sprintf("count=%d,config=%s", e.Count, e.LauncherConfigOwnerRef.Name)
 }
 
 // MapToLoggable converts a map of NodeLauncherKey to Val values into a string representation.

--- a/pkg/controller/launcher-populator/node-launcher-key.go
+++ b/pkg/controller/launcher-populator/node-launcher-key.go
@@ -37,13 +37,16 @@ func (k NodeLauncherKey) String() string {
 // DesiredStateEntry holds the desired count and the LauncherConfig spec
 // for a (Node, LauncherConfig) pair.
 type DesiredStateEntry struct {
-	Count              int32
-	LauncherConfigSpec fmav1alpha1.LauncherConfigSpec
+	Count                  int32
+	LauncherConfigSpec     *fmav1alpha1.LauncherConfigSpec
 	LauncherConfigOwnerRef metav1.OwnerReference
 }
 
 func (e DesiredStateEntry) String() string {
-	return fmt.Sprintf("count=%d,config=%s", e.Count, e.LauncherConfigOwnerRef.Name)
+	if e.LauncherConfigSpec == nil {
+		return fmt.Sprintf("count=%d,config=%s,spec=<nil>", e.Count, e.LauncherConfigOwnerRef.Name)
+	}
+	return fmt.Sprintf("count=%d,config=%s,spec=%+v", e.Count, e.LauncherConfigOwnerRef.Name, *e.LauncherConfigSpec)
 }
 
 // MapToLoggable converts a map of NodeLauncherKey to Val values into a string representation.

--- a/pkg/controller/launcher-populator/node-launcher-key.go
+++ b/pkg/controller/launcher-populator/node-launcher-key.go
@@ -18,6 +18,8 @@ package launcherpopulator
 
 import (
 	"fmt"
+
+	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 )
 
 // NodeLauncherKey defines the unique identifier for a (Node, LauncherConfig) pair
@@ -30,8 +32,22 @@ func (k NodeLauncherKey) String() string {
 	return fmt.Sprintf("%s/%s", k.LauncherConfigName, k.NodeName)
 }
 
-// MapToLoggable converts a map of NodeLauncherKey to int32 values into a string representation.
-// This function formats the map as a string with the format "{namespace/name/node:count, ...}"
+// DesiredStateEntry holds the desired count and corresponding LauncherConfig
+// for a (Node, LauncherConfig) pair.
+type DesiredStateEntry struct {
+	Count          int32
+	LauncherConfig *fmav1alpha1.LauncherConfig
+}
+
+func (e DesiredStateEntry) String() string {
+	if e.LauncherConfig != nil {
+		return fmt.Sprintf("count=%d,config=%s", e.Count, e.LauncherConfig.Name)
+	}
+	return fmt.Sprintf("count=%d", e.Count)
+}
+
+// MapToLoggable converts a map of NodeLauncherKey to Val values into a string representation.
+// This function formats the map as a string with the format "{namespace/name/node:val, ...}"
 // for debugging and logging purposes.
 func MapToLoggable[Key interface {
 	comparable

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -121,11 +121,19 @@ type lppItem struct {
 	cache.ObjectName
 }
 
+type lcItem struct {
+	cache.ObjectName
+}
+
 func (ctl *controller) OnAdd(obj any, isInInitialList bool) {
 	switch typed := obj.(type) {
 	case *fmav1alpha1.LauncherPopulationPolicy:
 		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to notification of add", "name", typed.Name)
 		item := lppItem{cache.MetaObjectToName(typed)}
+		ctl.Queue.Add(item)
+	case *fmav1alpha1.LauncherConfig:
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to notification of add", "name", typed.Name)
+		item := lcItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of add of type of ignored object", "type", fmt.Sprintf("%T", obj))
@@ -138,6 +146,10 @@ func (ctl *controller) OnUpdate(prev, obj any) {
 	case *fmav1alpha1.LauncherPopulationPolicy:
 		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to notification of update", "name", typed.Name)
 		item := lppItem{cache.MetaObjectToName(typed)}
+		ctl.Queue.Add(item)
+	case *fmav1alpha1.LauncherConfig:
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to notification of update", "name", typed.Name)
+		item := lcItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of update of type of ignored object", "type", fmt.Sprintf("%T", obj))
@@ -154,7 +166,10 @@ func (ctl *controller) OnDelete(obj any) {
 		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to notification of delete", "name", typed.Name)
 		item := lppItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
-
+	case *fmav1alpha1.LauncherConfig:
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to notification of delete", "name", typed.Name)
+		item := lcItem{cache.MetaObjectToName(typed)}
+		ctl.Queue.Add(item)
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of delete of type of ignored object", "type", fmt.Sprintf("%T", obj))
 		return
@@ -232,6 +247,63 @@ func (item lppItem) process(ctx context.Context, ctl *controller) (error, bool) 
 		logger.Error(err, "Failed to reconcile launchers")
 		return err, true
 	}
+	return nil, false
+}
+
+func (item lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
+	logger := klog.FromContext(ctx)
+
+	// Get the LauncherConfig
+	lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(item.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("LauncherConfig no longer exists, skipping reconciliation", "name", item.Name)
+			return nil, false
+		}
+		logger.Error(err, "Failed to get LauncherConfig", "name", item.Name)
+		return err, true
+	}
+
+	// Get all LauncherPopulationPolicies that reference this LauncherConfig
+	policies, err := ctl.lppLister.List(labels.Everything())
+	if err != nil {
+		logger.Error(err, "Failed to list LauncherPopulationPolicies")
+		return err, true
+	}
+
+	// Build desired state for this LauncherConfig across all nodes
+	desired := make(map[NodeLauncherKey]int32)
+	for _, lpp := range policies {
+		nodes, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
+		if err != nil {
+			logger.Error(err, "Failed to get matching nodes for policy", "policy", lpp.Name)
+			continue
+		}
+
+		for _, countRule := range lpp.Spec.CountForLauncher {
+			if countRule.LauncherConfigName != lc.Name {
+				continue
+			}
+			for _, node := range nodes {
+				key := NodeLauncherKey{
+					NodeName:           node.Name,
+					LauncherConfigName: lc.Name,
+				}
+				// Take the maximum count if multiple rules apply
+				if current, exists := desired[key]; !exists || countRule.LauncherCount > current {
+					desired[key] = countRule.LauncherCount
+				}
+			}
+		}
+	}
+
+	// Reconcile launchers for this LauncherConfig
+	if err := ctl.reconcileAllLaunchers(ctx, desired); err != nil {
+		logger.Error(err, "Failed to reconcile launchers for LauncherConfig", "name", lc.Name)
+		return err, true
+	}
+
+	logger.Info("Successfully reconciled launchers for LauncherConfig", "name", lc.Name)
 	return nil, false
 }
 

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -152,7 +152,7 @@ func (ctl *controller) OnUpdate(prev, obj any) {
 		item := lcItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
 	default:
-		ctl.enqueueLogger.V(5).Info("Notified of update of type of ignored object", "type", fmt.Sprintf("%T", obj))
+		ctl.enqueueLogger.V(5).Info("Notified of update of object of ignored type", "type", fmt.Sprintf("%T", obj))
 		return
 	}
 }
@@ -167,7 +167,7 @@ func (ctl *controller) OnDelete(obj any) {
 		item := lppItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
 	default:
-		ctl.enqueueLogger.V(5).Info("Notified of delete of type of ignored object", "type", fmt.Sprintf("%T", obj))
+		ctl.enqueueLogger.V(5).Info("Notified of delete of object of ignored type", "type", fmt.Sprintf("%T", obj))
 		return
 	}
 }
@@ -261,12 +261,18 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 					NodeName:           node.Name,
 					LauncherConfigName: countRule.LauncherConfigName,
 				}
-				ownerRef := *metav1.NewControllerRef(lc, fmav1alpha1.SchemeGroupVersion.WithKind("LauncherConfig"))
-				ownerRef.BlockOwnerDeletion = ptr.To(false)
+				ownerRef := metav1.OwnerReference{
+					APIVersion:         fmav1alpha1.SchemeGroupVersion.String(),
+					Kind:               "LauncherConfig",
+					Name:               lc.Name,
+					UID:                lc.UID,
+					Controller:         ptr.To(false),
+					BlockOwnerDeletion: ptr.To(false),
+				}
 				if entry, exists := desired[key]; !exists || countRule.LauncherCount > entry.Count {
 					desired[key] = DesiredStateEntry{
 						Count:                  countRule.LauncherCount,
-						LauncherConfigSpec:     lc.Spec,
+						LauncherConfigSpec:     &lc.Spec,
 						LauncherConfigOwnerRef: ownerRef,
 					}
 				}
@@ -347,10 +353,10 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 	deletionInProgress := false // tracks pods already being deleted (DeletionTimestamp set)
 
 	type creationInfo struct {
-		key    NodeLauncherKey
-		count  int
-		spec   fmav1alpha1.LauncherConfigSpec
-		owner  metav1.OwnerReference
+		key   NodeLauncherKey
+		count int
+		spec  *fmav1alpha1.LauncherConfigSpec
+		owner metav1.OwnerReference
 	}
 	var creations []creationInfo
 
@@ -371,15 +377,17 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 		// BuildLauncherPodFromTemplate computes a hash of the fully built pod spec
 		// and stores it as the LauncherConfigHashAnnotationKey annotation.
 		nominalHash := ""
-		nominalPod, err := utils.BuildLauncherPodFromTemplate(
-			entry.LauncherConfigSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
-		if err != nil {
-			// The only error possible here is that the PodTemplate lacks an inference server container.
-			// In that case we proceed without a nominal hash, so no stale-pod detection occurs for this config.
-			logger.Error(err, "Failed to build nominal pod for hash comparison",
-				"node", nodeName, "config", key.LauncherConfigName)
-		} else if nominalPod.Annotations != nil {
-			nominalHash = nominalPod.Annotations[string(common.LauncherConfigHashAnnotationKey)]
+		if entry.LauncherConfigSpec != nil {
+			nominalPod, err := utils.BuildLauncherPodFromTemplate(
+				entry.LauncherConfigSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
+			if err != nil {
+				// The only error possible here is that the PodTemplate lacks an inference server container.
+				// In that case we proceed without a nominal hash, so no stale-pod detection occurs for this config.
+				logger.Error(err, "Failed to build nominal pod for hash comparison",
+					"node", nodeName, "config", key.LauncherConfigName)
+			} else {
+				nominalHash = nominalPod.Annotations[string(common.LauncherConfigHashAnnotationKey)]
+			}
 		}
 
 		// Categorize current pods: separate live unbound current-spec pods from stale/unbound ones
@@ -432,7 +440,7 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 		effectiveRemaining := liveBoundCount + len(liveUnboundCurrentPods)
 		diff := entry.Count - int32(effectiveRemaining)
 
-		logger.Info("Analyzing config on node",
+		logger.Info("Analyzed config on node",
 			"node", nodeName,
 			"config", key.LauncherConfigName,
 			"current", effectiveRemaining,
@@ -525,7 +533,7 @@ func (ctl *controller) getCurrentLaunchersOnNode(ctx context.Context, key NodeLa
 
 // createLaunchers creates the specified number of launcher pods on a node
 // using the given LauncherConfig spec and owner reference directly (no additional lookup needed).
-func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, lcSpec fmav1alpha1.LauncherConfigSpec, lcOwnerRef metav1.OwnerReference) error {
+func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, lcSpec *fmav1alpha1.LauncherConfigSpec, lcOwnerRef metav1.OwnerReference) error {
 	logger := klog.FromContext(ctx)
 
 	// Create the specified number of launcher pods

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -261,10 +261,13 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 					NodeName:           node.Name,
 					LauncherConfigName: countRule.LauncherConfigName,
 				}
+				ownerRef := *metav1.NewControllerRef(lc, fmav1alpha1.SchemeGroupVersion.WithKind("LauncherConfig"))
+				ownerRef.BlockOwnerDeletion = ptr.To(false)
 				if entry, exists := desired[key]; !exists || countRule.LauncherCount > entry.Count {
 					desired[key] = DesiredStateEntry{
-						Count:          countRule.LauncherCount,
-						LauncherConfig: lc,
+						Count:                  countRule.LauncherCount,
+						LauncherConfigSpec:     lc.Spec,
+						LauncherConfigOwnerRef: ownerRef,
 					}
 				}
 			}
@@ -344,9 +347,10 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 	deletionInProgress := false // tracks pods already being deleted (DeletionTimestamp set)
 
 	type creationInfo struct {
-		key   NodeLauncherKey
-		count int
-		lc    *fmav1alpha1.LauncherConfig
+		key    NodeLauncherKey
+		count  int
+		spec   fmav1alpha1.LauncherConfigSpec
+		owner  metav1.OwnerReference
 	}
 	var creations []creationInfo
 
@@ -356,6 +360,8 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 
 		currentLaunchers, err := ctl.getCurrentLaunchersOnNode(ctx, key)
 		if err != nil {
+			// The only error possible here is from the lister, which should never fail in practice.
+			// Log and skip this config rather than aborting the entire reconciliation.
 			logger.Error(err, "Failed to get current launchers for config",
 				"node", nodeName, "config", key.LauncherConfigName)
 			continue
@@ -365,10 +371,12 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 		// BuildLauncherPodFromTemplate computes a hash of the fully built pod spec
 		// and stores it as the LauncherConfigHashAnnotationKey annotation.
 		nominalHash := ""
-		nominalPod, hashErr := utils.BuildLauncherPodFromTemplate(
-			entry.LauncherConfig.Spec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
-		if hashErr != nil {
-			logger.Error(hashErr, "Failed to build nominal pod for hash comparison",
+		nominalPod, err := utils.BuildLauncherPodFromTemplate(
+			entry.LauncherConfigSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
+		if err != nil {
+			// The only error possible here is that the PodTemplate lacks an inference server container.
+			// In that case we proceed without a nominal hash, so no stale-pod detection occurs for this config.
+			logger.Error(err, "Failed to build nominal pod for hash comparison",
 				"node", nodeName, "config", key.LauncherConfigName)
 		} else if nominalPod.Annotations != nil {
 			nominalHash = nominalPod.Annotations[string(common.LauncherConfigHashAnnotationKey)]
@@ -457,7 +465,8 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 			creations = append(creations, creationInfo{
 				key:   key,
 				count: int(diff),
-				lc:    entry.LauncherConfig,
+				spec:  entry.LauncherConfigSpec,
+				owner: entry.LauncherConfigOwnerRef,
 			})
 		}
 	}
@@ -476,7 +485,7 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 	// No deletions needed, proceed with planned creations
 	totalCreated := 0
 	for _, creation := range creations {
-		if err := ctl.createLaunchers(ctx, *node, creation.key, creation.count, creation.lc); err != nil {
+		if err := ctl.createLaunchers(ctx, *node, creation.key, creation.count, creation.spec, creation.owner); err != nil {
 			logger.Error(err, "Failed to create launchers for config",
 				"node", nodeName,
 				"config", creation.key.LauncherConfigName,
@@ -490,15 +499,10 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 			"created", creation.count)
 	}
 
-	if totalCreated > 0 {
-		logger.Info("Completed creation of launchers",
-			"node", nodeName,
-			"created", totalCreated)
-	}
-
 	logger.Info("Completed reconciliation for node",
 		"node", nodeName,
-		"configs_processed", len(keys))
+		"configs_processed", len(keys),
+		"created", totalCreated)
 
 	return false, nil
 }
@@ -520,23 +524,18 @@ func (ctl *controller) getCurrentLaunchersOnNode(ctx context.Context, key NodeLa
 }
 
 // createLaunchers creates the specified number of launcher pods on a node
-// using the given LauncherConfig directly (no additional lookup needed).
-func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, launcherConfig *fmav1alpha1.LauncherConfig) error {
+// using the given LauncherConfig spec and owner reference directly (no additional lookup needed).
+func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, lcSpec fmav1alpha1.LauncherConfigSpec, lcOwnerRef metav1.OwnerReference) error {
 	logger := klog.FromContext(ctx)
 
 	// Create the specified number of launcher pods
 	for i := 0; i < count; i++ {
-		pod, err := utils.BuildLauncherPodFromTemplate(launcherConfig.Spec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
+		pod, err := utils.BuildLauncherPodFromTemplate(lcSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
 		if err != nil {
 			return fmt.Errorf("failed to build launcher pod: %w", err)
 		}
-		pod.GenerateName = fmt.Sprintf("launcher-%s-", launcherConfig.Name)
-		// Set owner reference pointing to LauncherConfig
-		ownerRef := *metav1.NewControllerRef(launcherConfig, fmav1alpha1.SchemeGroupVersion.WithKind("LauncherConfig"))
-		ownerRef.BlockOwnerDeletion = ptr.To(false)
-		pod.OwnerReferences = []metav1.OwnerReference{
-			ownerRef,
-		}
+		pod.GenerateName = fmt.Sprintf("launcher-%s-", key.LauncherConfigName)
+		pod.OwnerReferences = []metav1.OwnerReference{lcOwnerRef}
 
 		if _, err := ctl.coreclient.Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create launcher pod: %w", err)

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -193,7 +193,7 @@ func (item lppItem) process(ctx context.Context, ctl *controller) (error, bool) 
 	logger := klog.FromContext(ctx)
 
 	// Build desired state from all policies
-	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx, nil)
+	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx)
 	if err != nil {
 		logger.Error(err, "Failed to build desired state from policies")
 		return err, true
@@ -202,9 +202,14 @@ func (item lppItem) process(ctx context.Context, ctl *controller) (error, bool) 
 	logger.Info("Final population policy", "policy", MapToLoggable(populationPolicy))
 
 	// Adjust launcher pods according to final requirements
-	if err := ctl.reconcileAllLaunchers(ctx, populationPolicy); err != nil {
+	needsRequeue, err := ctl.reconcileAllLaunchers(ctx, populationPolicy)
+	if err != nil {
 		logger.Error(err, "Failed to reconcile launchers")
 		return err, true
+	}
+
+	if needsRequeue {
+		return nil, true
 	}
 	return nil, false
 }
@@ -212,39 +217,34 @@ func (item lppItem) process(ctx context.Context, ctl *controller) (error, bool) 
 func (item lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
 	logger := klog.FromContext(ctx)
 
-	// Get the LauncherConfig
-	lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(item.Name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("LauncherConfig does not exist yet, skipping reconciliation", "name", item.Name)
-			return nil, false
-		}
-		logger.Error(err, "Failed to get LauncherConfig", "name", item.Name)
-		return err, true
-	}
-
-	// Build desired state only for policies that reference this LauncherConfig
-	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx, &item.Name)
+	// Build desired state from all policies.
+	// No special treatment for any particular LauncherConfig;
+	// missing LauncherConfigs are handled inside buildDesiredStateFromPolicies.
+	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx)
 	if err != nil {
 		logger.Error(err, "Failed to build desired state from policies")
 		return err, true
 	}
 
-	logger.Info("Final population policy for LauncherConfig", "config", item.Name, "policy", MapToLoggable(populationPolicy))
+	logger.Info("Final population policy", "policy", MapToLoggable(populationPolicy))
 
-	// Reconcile launchers for this LauncherConfig
-	if err := ctl.reconcileAllLaunchers(ctx, populationPolicy); err != nil {
-		logger.Error(err, "Failed to reconcile launchers for LauncherConfig", "name", lc.Name)
+	// Adjust launcher pods according to final requirements
+	needsRequeue, err := ctl.reconcileAllLaunchers(ctx, populationPolicy)
+	if err != nil {
+		logger.Error(err, "Failed to reconcile launchers")
 		return err, true
 	}
 
-	logger.Info("Successfully reconciled launchers for LauncherConfig", "name", lc.Name)
+	if needsRequeue {
+		return nil, true
+	}
 	return nil, false
 }
 
 // buildDesiredStateFromPolicies builds the desired state map from all policies.
-// If filterByConfig is provided, only policies referencing that config are considered.
-func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context, filterByConfig *string) (map[NodeLauncherKey]int32, error) {
+// It reads each LauncherConfig from the informer's local cache to verify existence
+// and obtain the current spec. LauncherConfigs that do not exist are skipped.
+func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[NodeLauncherKey]DesiredStateEntry, error) {
 	logger := klog.FromContext(ctx)
 
 	policies, err := ctl.lppLister.List(labels.Everything())
@@ -252,7 +252,7 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context, filter
 		return nil, fmt.Errorf("failed to list LauncherPopulationPolicies: %w", err)
 	}
 
-	desired := make(map[NodeLauncherKey]int32)
+	desired := make(map[NodeLauncherKey]DesiredStateEntry)
 	for _, lpp := range policies {
 		nodes, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
 		if err != nil {
@@ -261,16 +261,28 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context, filter
 		}
 
 		for _, countRule := range lpp.Spec.CountForLauncher {
-			if filterByConfig != nil && countRule.LauncherConfigName != *filterByConfig {
-				continue
+			// Read the LauncherConfig from informer's local cache to verify existence
+			// and get the current spec (needed for A3: spec-change detection)
+			lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(countRule.LauncherConfigName)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					logger.Info("LauncherConfig referenced in policy does not exist, skipping",
+						"config", countRule.LauncherConfigName, "policy", lpp.Name)
+					continue
+				}
+				return nil, fmt.Errorf("failed to get LauncherConfig %s: %w", countRule.LauncherConfigName, err)
 			}
+
 			for _, node := range nodes {
 				key := NodeLauncherKey{
 					NodeName:           node.Name,
 					LauncherConfigName: countRule.LauncherConfigName,
 				}
-				if current, exists := desired[key]; !exists || countRule.LauncherCount > current {
-					desired[key] = countRule.LauncherCount
+				if entry, exists := desired[key]; !exists || countRule.LauncherCount > entry.Count {
+					desired[key] = DesiredStateEntry{
+						Count:          countRule.LauncherCount,
+						LauncherConfig: lc,
+					}
 				}
 			}
 		}
@@ -301,62 +313,65 @@ func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha
 }
 
 // reconcileAllLaunchers adjusts all launcher pods according to final requirements.
-// It processes each node separately to ensure deletions happen before creations,
-// minimizing peak memory consumption on each node.
-func (ctl *controller) reconcileAllLaunchers(ctx context.Context, desired map[NodeLauncherKey]int32) error {
+// It returns true if a requeue is needed (deletions were performed or are in progress),
+// so that creations happen only after deletions have taken effect.
+func (ctl *controller) reconcileAllLaunchers(ctx context.Context, desired map[NodeLauncherKey]DesiredStateEntry) (bool, error) {
 	logger := klog.FromContext(ctx)
 
-	// Group by node to optimize resource usage across all LauncherConfigs on each node
+	// Group by node to process each node separately
 	nodeGroups := make(map[string][]NodeLauncherKey)
 	for key := range desired {
 		nodeGroups[key.NodeName] = append(nodeGroups[key.NodeName], key)
 	}
 
-	// Process each node separately to ensure deletions happen before creations
-	// at the node level, minimizing peak memory consumption
+	anyRequeueNeeded := false
 	for nodeName, keys := range nodeGroups {
-		if err := ctl.reconcileLaunchersOnSingleNode(ctx, nodeName, keys, desired); err != nil {
+		needsRequeue, err := ctl.reconcileLaunchersOnSingleNode(ctx, nodeName, keys, desired)
+		if err != nil {
 			logger.Error(err, "Failed to reconcile launchers on node", "node", nodeName)
 			continue
 		}
+		if needsRequeue {
+			anyRequeueNeeded = true
+		}
 	}
 
-	return nil
+	return anyRequeueNeeded, nil
 }
 
 // reconcileLaunchersOnSingleNode handles all LauncherConfigs for a single node.
-// It ensures that ALL deletions happen BEFORE ANY creations on this node,
-// optimizing memory usage by freeing resources before allocating new ones.
-func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeName string, keys []NodeLauncherKey, desired map[NodeLauncherKey]int32) error {
+// For each LauncherConfig, it does deletions immediately as they are identified
+// and remembers creations called for. If any deletions were performed (or are in
+// progress from a previous cycle), it returns true to request a requeue so that
+// creations happen only after deletions have taken effect, minimizing peak resource
+// consumption on the node.
+// So that when a LauncherConfig changes, each corresponding launcher Pod that is
+// not bound to a server-requesting Pod is deleted and replaced.
+func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeName string, keys []NodeLauncherKey, desired map[NodeLauncherKey]DesiredStateEntry) (bool, error) {
 	logger := klog.FromContext(ctx)
 
 	node, err := ctl.nodeLister.Get(nodeName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Node no longer exists, skipping reconciliation", "node", nodeName)
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		return false, fmt.Errorf("failed to get node %s: %w", nodeName, err)
 	}
 
-	// Phase 1: Collect all pods that need to be deleted across all configs on this node
-	type deletionInfo struct {
-		key    NodeLauncherKey
-		pod    *corev1.Pod
-		reason string
-	}
-	var allDeletions []deletionInfo
+	didDelete := false
+	deletionInProgress := false // tracks pods already being deleted (DeletionTimestamp set)
 
-	// Phase 2: Collect all pods that need to be created across all configs on this node
 	type creationInfo struct {
 		key   NodeLauncherKey
 		count int
+		lc    *fmav1alpha1.LauncherConfig
 	}
-	var allCreations []creationInfo
+	var creations []creationInfo
 
-	// Analyze each LauncherConfig on this node
+	// Process each LauncherConfig on this node
 	for _, key := range keys {
-		desiredCount := desired[key]
+		entry := desired[key]
 
 		currentLaunchers, err := ctl.getCurrentLaunchersOnNode(ctx, key)
 		if err != nil {
@@ -365,119 +380,146 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 			continue
 		}
 
-		currentCount := int32(len(currentLaunchers))
-		diff := desiredCount - currentCount
+		// Compute the nominal hash for spec-change detection.
+		// BuildLauncherPodFromTemplate computes a hash of the fully built pod spec
+		// and stores it as the LauncherConfigHashAnnotationKey annotation.
+		nominalHash := ""
+		nominalPod, hashErr := utils.BuildLauncherPodFromTemplate(
+			entry.LauncherConfig.Spec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
+		if hashErr != nil {
+			logger.Error(hashErr, "Failed to build nominal pod for hash comparison",
+				"node", nodeName, "config", key.LauncherConfigName)
+		} else if nominalPod.Annotations != nil {
+			nominalHash = nominalPod.Annotations[string(common.LauncherConfigHashAnnotationKey)]
+		}
+
+		// Categorize current pods: separate live unbound current-spec pods from stale/unbound ones
+		var liveBoundCount int
+		var liveUnboundCurrentPods []*corev1.Pod // live, unbound, spec matches current LauncherConfig
+		var staleUnboundPods []*corev1.Pod       // live, unbound, spec is stale
+
+		for _, pod := range currentLaunchers {
+			// Skip pods already being deleted
+			if pod.DeletionTimestamp != nil {
+				deletionInProgress = true
+				continue
+			}
+
+			isBound, _ := ctl.isLauncherBoundToServerRequestingPod(pod)
+			if isBound {
+				liveBoundCount++
+				continue
+			}
+
+			// Check if pod spec is stale (LauncherConfig changed)
+			if nominalHash != "" {
+				podHash := pod.Annotations[string(common.LauncherConfigHashAnnotationKey)]
+				if podHash != nominalHash {
+					staleUnboundPods = append(staleUnboundPods, pod)
+					continue
+				}
+			}
+
+			liveUnboundCurrentPods = append(liveUnboundCurrentPods, pod)
+		}
+
+		// Delete stale pods immediately (spec changed → delete and replace)
+		for _, pod := range staleUnboundPods {
+			if err := ctl.coreclient.Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					logger.Info("Stale launcher pod already deleted", "pod", pod.Name)
+					continue
+				}
+				return false, fmt.Errorf("failed to delete stale launcher pod %s: %w", pod.Name, err)
+			}
+			logger.Info("Deleted stale launcher pod (spec changed)",
+				"pod", pod.Name,
+				"node", nodeName,
+				"config", key.LauncherConfigName)
+			didDelete = true
+		}
+
+		// Calculate diff based on effective remaining pods after stale deletion
+		effectiveRemaining := liveBoundCount + len(liveUnboundCurrentPods)
+		diff := entry.Count - int32(effectiveRemaining)
 
 		logger.Info("Analyzing config on node",
 			"node", nodeName,
 			"config", key.LauncherConfigName,
-			"current", currentCount,
-			"desired", desiredCount,
+			"current", effectiveRemaining,
+			"stale", len(staleUnboundPods),
+			"desired", entry.Count,
 			"diff", diff)
 
 		if diff < 0 {
-			// Need to delete some pods for this config
+			// Need to delete excess pods from live unbound current pods
 			numToDelete := int(-diff)
-			collectedForDeletion := 0
-			for i := 0; i < len(currentLaunchers) && collectedForDeletion < numToDelete; i++ {
-				pod := currentLaunchers[len(currentLaunchers)-1-i]
-				isBound, requesterPodName := ctl.isLauncherBoundToServerRequestingPod(pod)
-				if isBound {
-					logger.V(5).Info("Skipping deletion of bound pod",
-						"pod", pod.Name, "server-requesting pod", requesterPodName)
-					continue
+			for i := len(liveUnboundCurrentPods) - 1; i >= 0 && numToDelete > 0; i-- {
+				pod := liveUnboundCurrentPods[i]
+				if err := ctl.coreclient.Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+					if apierrors.IsNotFound(err) {
+						logger.Info("Launcher pod already deleted", "pod", pod.Name)
+						numToDelete--
+						continue
+					}
+					return false, fmt.Errorf("failed to delete launcher pod %s: %w", pod.Name, err)
 				}
-				allDeletions = append(allDeletions, deletionInfo{
-					key:    key,
-					pod:    pod,
-					reason: "excess launcher",
-				})
-				collectedForDeletion++
+				logger.Info("Deleted excess launcher pod",
+					"pod", pod.Name,
+					"node", nodeName,
+					"config", key.LauncherConfigName)
+				didDelete = true
+				numToDelete--
 			}
 		} else if diff > 0 {
-			// Need to create some pods for this config
-			allCreations = append(allCreations, creationInfo{
+			// Remember creations called for (will be executed only if no deletions)
+			creations = append(creations, creationInfo{
 				key:   key,
 				count: int(diff),
+				lc:    entry.LauncherConfig,
 			})
 		}
 	}
 
-	// Execute Phase 1: Delete all marked pods FIRST (across all configs on this node)
-	deletedCount := 0
-	var conflictErrors []string
-	for _, del := range allDeletions {
-		if err := ctl.coreclient.Pods(del.pod.Namespace).Delete(ctx, del.pod.Name, metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				ResourceVersion: &del.pod.ResourceVersion,
-			},
-		}); err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("Launcher pod already deleted", "pod", del.pod.Name)
-				deletedCount++
-				continue
-			}
-			if apierrors.IsConflict(err) {
-				logger.Info("Launcher pod version conflict, skipping deletion",
-					"pod", del.pod.Name, "error", err)
-				conflictErrors = append(conflictErrors, del.pod.Name)
-				continue
-			}
-			return fmt.Errorf("failed to delete launcher pod %s: %w", del.pod.Name, err)
-		}
-		logger.Info("Deleted launcher pod (Phase 1)",
-			"pod", del.pod.Name,
+	// If any deletions were performed or are in progress, requeue for later.
+	// This ensures that deletions take effect before any creations happen,
+	// so that freed resources are available for newly created pods.
+	if didDelete || deletionInProgress {
+		logger.Info("Deletions performed or in progress, requeuing for creation later",
 			"node", nodeName,
-			"config", del.key.LauncherConfigName,
-			"reason", del.reason)
-		deletedCount++
+			"didDelete", didDelete,
+			"deletionInProgress", deletionInProgress)
+		return true, nil
 	}
 
-	if len(conflictErrors) > 0 {
-		return fmt.Errorf("encountered %d version conflicts during deletion (pods: %v), will retry",
-			len(conflictErrors), conflictErrors)
-	}
-
-	if deletedCount < len(allDeletions) {
-		logger.Info("Fewer pods deleted than planned",
-			"planned", len(allDeletions),
-			"actual", deletedCount)
-	} else if deletedCount > 0 {
-		logger.Info("Completed Phase 1: Deletions",
-			"node", nodeName,
-			"deleted", deletedCount)
-	}
-
-	// Execute Phase 2: Create all needed pods AFTER deletions complete
+	// No deletions needed, proceed with planned creations
 	totalCreated := 0
-	for _, creation := range allCreations {
-		if err := ctl.createLaunchers(ctx, *node, creation.key, creation.count); err != nil {
+	for _, creation := range creations {
+		if err := ctl.createLaunchers(ctx, *node, creation.key, creation.count, creation.lc); err != nil {
 			logger.Error(err, "Failed to create launchers for config",
 				"node", nodeName,
 				"config", creation.key.LauncherConfigName,
 				"count", creation.count)
-			return err
+			return false, err
 		}
 		totalCreated += creation.count
-		logger.Info("Created launchers for config (Phase 2)",
+		logger.Info("Created launchers for config",
 			"node", nodeName,
 			"config", creation.key.LauncherConfigName,
 			"created", creation.count)
 	}
 
 	if totalCreated > 0 {
-		logger.Info("Completed Phase 2: Creations",
+		logger.Info("Completed creation of launchers",
 			"node", nodeName,
 			"created", totalCreated)
 	}
 
 	logger.Info("Completed reconciliation for node",
 		"node", nodeName,
-		"configs_processed", len(keys),
-		"pods_deleted", deletedCount,
-		"pods_created", totalCreated)
+		"configs_processed", len(keys))
 
-	return nil
+	return false, nil
 }
 
 // getCurrentLaunchersOnNode returns launcher pods for a specific config on a specific node
@@ -497,15 +539,9 @@ func (ctl *controller) getCurrentLaunchersOnNode(ctx context.Context, key NodeLa
 }
 
 // createLaunchers creates the specified number of launcher pods on a node
-func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int) error {
+// using the given LauncherConfig directly (no additional lookup needed).
+func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, launcherConfig *fmav1alpha1.LauncherConfig) error {
 	logger := klog.FromContext(ctx)
-	// Fetch the LauncherConfig
-	var launcherConfig *fmav1alpha1.LauncherConfig
-	launcherConfigName := key.LauncherConfigName
-	launcherConfig, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(launcherConfigName)
-	if err != nil {
-		return fmt.Errorf("failed to get LauncherConfig %s/%s: %+v", ctl.namespace, launcherConfigName, err)
-	}
 
 	// Create the specified number of launcher pods
 	for i := 0; i < count; i++ {

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -405,6 +405,7 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 
 	// Execute Phase 1: Delete all marked pods FIRST (across all configs on this node)
 	deletedCount := 0
+	var conflictErrors []string
 	for _, del := range allDeletions {
 		if err := ctl.coreclient.Pods(del.pod.Namespace).Delete(ctx, del.pod.Name, metav1.DeleteOptions{
 			Preconditions: &metav1.Preconditions{
@@ -419,6 +420,7 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 			if apierrors.IsConflict(err) {
 				logger.Info("Launcher pod version conflict, skipping deletion",
 					"pod", del.pod.Name, "error", err)
+				conflictErrors = append(conflictErrors, del.pod.Name)
 				continue
 			}
 			return fmt.Errorf("failed to delete launcher pod %s: %w", del.pod.Name, err)
@@ -429,6 +431,11 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 			"config", del.key.LauncherConfigName,
 			"reason", del.reason)
 		deletedCount++
+	}
+
+	if len(conflictErrors) > 0 {
+		return fmt.Errorf("encountered %d version conflicts during deletion (pods: %v), will retry",
+			len(conflictErrors), conflictErrors)
 	}
 
 	if deletedCount < len(allDeletions) {

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -542,7 +542,6 @@ func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, ke
 		if err != nil {
 			return fmt.Errorf("failed to build launcher pod: %w", err)
 		}
-		pod.GenerateName = fmt.Sprintf("launcher-%s-", key.LauncherConfigName)
 		pod.OwnerReferences = []metav1.OwnerReference{lcOwnerRef}
 
 		if _, err := ctl.coreclient.Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -378,7 +378,8 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 		if diff < 0 {
 			// Need to delete some pods for this config
 			numToDelete := int(-diff)
-			for i := 0; i < numToDelete && i < len(currentLaunchers); i++ {
+			collectedForDeletion := 0
+			for i := 0; i < len(currentLaunchers) && collectedForDeletion < numToDelete; i++ {
 				pod := currentLaunchers[len(currentLaunchers)-1-i]
 				isBound, requesterPodName := ctl.isLauncherBoundToServerRequestingPod(pod)
 				if isBound {
@@ -391,6 +392,7 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 					pod:    pod,
 					reason: "excess launcher",
 				})
+				collectedForDeletion++
 			}
 		} else if diff > 0 {
 			// Need to create some pods for this config

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -166,10 +166,6 @@ func (ctl *controller) OnDelete(obj any) {
 		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to notification of delete", "name", typed.Name)
 		item := lppItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
-	case *fmav1alpha1.LauncherConfig:
-		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to notification of delete", "name", typed.Name)
-		item := lcItem{cache.MetaObjectToName(typed)}
-		ctl.Queue.Add(item)
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of delete of type of ignored object", "type", fmt.Sprintf("%T", obj))
 		return
@@ -195,53 +191,16 @@ func (ctl *controller) process(ctx context.Context, item queueItem) (error, bool
 
 func (item lppItem) process(ctx context.Context, ctl *controller) (error, bool) {
 	logger := klog.FromContext(ctx)
-	// Get the list of LauncherPopulationPolicies
-	policies, err := ctl.lppLister.List(labels.Everything())
+
+	// Build desired state from all policies
+	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx, nil)
 	if err != nil {
-		logger.Error(err, "Failed to list LauncherPopulationPolicies")
-		return err, true // Return error and retry
-	}
-
-	// If needed, process the retrieved policies here
-	// For example: iterate through policies to perform corresponding business logic
-
-	logger.Info("Successfully listed LauncherPopulationPolicies", "count", len(policies))
-
-	// Build the PopulationPolicy map, storing the maximum count for each (Node, LauncherConfig) pair
-	populationPolicy := make(map[NodeLauncherKey]int32)
-	for _, lpp := range policies {
-		// Get matching nodes
-		nodes, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
-		if err != nil {
-			logger.Error(err, "Failed to get matching nodes for policy", "policy", lpp.Name)
-			return err, true
-		}
-		logger.Info("Found matching nodes", "count", len(nodes), "policy", lpp.Name)
-		// For each CountForLauncher rule
-		for _, countRule := range lpp.Spec.CountForLauncher {
-			for _, node := range nodes {
-				key := NodeLauncherKey{
-					NodeName:           node.Name,
-					LauncherConfigName: countRule.LauncherConfigName,
-				}
-				currentCount, exists := populationPolicy[key]
-				logger.Info("Current count for node", "node", node.Name, "launcherConfigName",
-					countRule.LauncherConfigName, "launcherCount", countRule.LauncherCount, "currentCount", currentCount, "exists", exists)
-
-				// Take the maximum value (rule: when multiple CountForLauncher apply to the same pair, take the maximum)
-				if !exists || countRule.LauncherCount > currentCount {
-					populationPolicy[key] = countRule.LauncherCount
-					logger.Info("Updated population policy",
-						"node", node.Name,
-						"config", countRule.LauncherConfigName,
-						"count", countRule.LauncherCount,
-						"policy", lpp.Name)
-				}
-			}
-		}
+		logger.Error(err, "Failed to build desired state from policies")
+		return err, true
 	}
 
 	logger.Info("Final population policy", "policy", MapToLoggable(populationPolicy))
+
 	// Adjust launcher pods according to final requirements
 	if err := ctl.reconcileAllLaunchers(ctx, populationPolicy); err != nil {
 		logger.Error(err, "Failed to reconcile launchers")
@@ -257,21 +216,42 @@ func (item lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
 	lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(item.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("LauncherConfig no longer exists, skipping reconciliation", "name", item.Name)
+			logger.Info("LauncherConfig does not exist yet, skipping reconciliation", "name", item.Name)
 			return nil, false
 		}
 		logger.Error(err, "Failed to get LauncherConfig", "name", item.Name)
 		return err, true
 	}
 
-	// Get all LauncherPopulationPolicies that reference this LauncherConfig
-	policies, err := ctl.lppLister.List(labels.Everything())
+	// Build desired state only for policies that reference this LauncherConfig
+	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx, &item.Name)
 	if err != nil {
-		logger.Error(err, "Failed to list LauncherPopulationPolicies")
+		logger.Error(err, "Failed to build desired state from policies")
 		return err, true
 	}
 
-	// Build desired state for this LauncherConfig across all nodes
+	logger.Info("Final population policy for LauncherConfig", "config", item.Name, "policy", MapToLoggable(populationPolicy))
+
+	// Reconcile launchers for this LauncherConfig
+	if err := ctl.reconcileAllLaunchers(ctx, populationPolicy); err != nil {
+		logger.Error(err, "Failed to reconcile launchers for LauncherConfig", "name", lc.Name)
+		return err, true
+	}
+
+	logger.Info("Successfully reconciled launchers for LauncherConfig", "name", lc.Name)
+	return nil, false
+}
+
+// buildDesiredStateFromPolicies builds the desired state map from all policies.
+// If filterByConfig is provided, only policies referencing that config are considered.
+func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context, filterByConfig *string) (map[NodeLauncherKey]int32, error) {
+	logger := klog.FromContext(ctx)
+
+	policies, err := ctl.lppLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list LauncherPopulationPolicies: %w", err)
+	}
+
 	desired := make(map[NodeLauncherKey]int32)
 	for _, lpp := range policies {
 		nodes, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
@@ -281,15 +261,14 @@ func (item lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
 		}
 
 		for _, countRule := range lpp.Spec.CountForLauncher {
-			if countRule.LauncherConfigName != lc.Name {
+			if filterByConfig != nil && countRule.LauncherConfigName != *filterByConfig {
 				continue
 			}
 			for _, node := range nodes {
 				key := NodeLauncherKey{
 					NodeName:           node.Name,
-					LauncherConfigName: lc.Name,
+					LauncherConfigName: countRule.LauncherConfigName,
 				}
-				// Take the maximum count if multiple rules apply
 				if current, exists := desired[key]; !exists || countRule.LauncherCount > current {
 					desired[key] = countRule.LauncherCount
 				}
@@ -297,14 +276,7 @@ func (item lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
 		}
 	}
 
-	// Reconcile launchers for this LauncherConfig
-	if err := ctl.reconcileAllLaunchers(ctx, desired); err != nil {
-		logger.Error(err, "Failed to reconcile launchers for LauncherConfig", "name", lc.Name)
-		return err, true
-	}
-
-	logger.Info("Successfully reconciled launchers for LauncherConfig", "name", lc.Name)
-	return nil, false
+	return desired, nil
 }
 
 // getMatchingNodes returns nodes that match the EnhancedNodeSelector
@@ -328,29 +300,36 @@ func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha
 	return matchedNodes, nil
 }
 
-// reconcileAllLaunchers adjusts all launcher pods according to final requirements
+// reconcileAllLaunchers adjusts all launcher pods according to final requirements.
+// It processes each node separately to ensure deletions happen before creations,
+// minimizing peak memory consumption on each node.
 func (ctl *controller) reconcileAllLaunchers(ctx context.Context, desired map[NodeLauncherKey]int32) error {
 	logger := klog.FromContext(ctx)
-	// Reconcile for each (Node, LauncherConfig) pair
-	for key, desiredCount := range desired {
-		if err := ctl.reconcileLaunchersOnNode(ctx, key, desiredCount); err != nil {
-			logger.Error(err, "Failed to reconcile launchers on node",
-				"node", key.NodeName,
-				"config", key.LauncherConfigName)
-			// Continue processing other combinations
+
+	// Group by node to optimize resource usage across all LauncherConfigs on each node
+	nodeGroups := make(map[string][]NodeLauncherKey)
+	for key := range desired {
+		nodeGroups[key.NodeName] = append(nodeGroups[key.NodeName], key)
+	}
+
+	// Process each node separately to ensure deletions happen before creations
+	// at the node level, minimizing peak memory consumption
+	for nodeName, keys := range nodeGroups {
+		if err := ctl.reconcileLaunchersOnSingleNode(ctx, nodeName, keys, desired); err != nil {
+			logger.Error(err, "Failed to reconcile launchers on node", "node", nodeName)
+			continue
 		}
 	}
-	// TODO: Clean up unnecessary launcher pods (those that exist in the cluster but not in desired)
-	// This requires tracking which launcher pods were created by us
+
 	return nil
 }
 
-// reconcileLaunchersOnNode ensures the number of launchers with a specific launcher config on a node matches the requirement
-func (ctl *controller) reconcileLaunchersOnNode(ctx context.Context, key NodeLauncherKey, desiredCount int32) error {
+// reconcileLaunchersOnSingleNode handles all LauncherConfigs for a single node.
+// It ensures that ALL deletions happen BEFORE ANY creations on this node,
+// optimizing memory usage by freeing resources before allocating new ones.
+func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeName string, keys []NodeLauncherKey, desired map[NodeLauncherKey]int32) error {
 	logger := klog.FromContext(ctx)
-	// Get node object
-	nodeName := key.NodeName
-	launcherConfigName := key.LauncherConfigName
+
 	node, err := ctl.nodeLister.Get(nodeName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -359,32 +338,136 @@ func (ctl *controller) reconcileLaunchersOnNode(ctx context.Context, key NodeLau
 		}
 		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
 	}
-	// Get current launchers
-	currentLaunchers, err := ctl.getCurrentLaunchersOnNode(ctx, key)
-	if err != nil {
-		return fmt.Errorf("failed to get current launchers: %w", err)
+
+	// Phase 1: Collect all pods that need to be deleted across all configs on this node
+	type deletionInfo struct {
+		key    NodeLauncherKey
+		pod    *corev1.Pod
+		reason string
 	}
-	currentCount := int32(len(currentLaunchers))
-	diff := desiredCount - currentCount
-	logger.Info("Reconciling launchers on node",
+	var allDeletions []deletionInfo
+
+	// Phase 2: Collect all pods that need to be created across all configs on this node
+	type creationInfo struct {
+		key   NodeLauncherKey
+		count int
+	}
+	var allCreations []creationInfo
+
+	// Analyze each LauncherConfig on this node
+	for _, key := range keys {
+		desiredCount := desired[key]
+
+		currentLaunchers, err := ctl.getCurrentLaunchersOnNode(ctx, key)
+		if err != nil {
+			logger.Error(err, "Failed to get current launchers for config",
+				"node", nodeName, "config", key.LauncherConfigName)
+			continue
+		}
+
+		currentCount := int32(len(currentLaunchers))
+		diff := desiredCount - currentCount
+
+		logger.Info("Analyzing config on node",
+			"node", nodeName,
+			"config", key.LauncherConfigName,
+			"current", currentCount,
+			"desired", desiredCount,
+			"diff", diff)
+
+		if diff < 0 {
+			// Need to delete some pods for this config
+			numToDelete := int(-diff)
+			for i := 0; i < numToDelete && i < len(currentLaunchers); i++ {
+				pod := currentLaunchers[len(currentLaunchers)-1-i]
+				isBound, requesterPodName := ctl.isLauncherBoundToServerRequestingPod(pod)
+				if isBound {
+					logger.V(5).Info("Skipping deletion of bound pod",
+						"pod", pod.Name, "server-requesting pod", requesterPodName)
+					continue
+				}
+				allDeletions = append(allDeletions, deletionInfo{
+					key:    key,
+					pod:    pod,
+					reason: "excess launcher",
+				})
+			}
+		} else if diff > 0 {
+			// Need to create some pods for this config
+			allCreations = append(allCreations, creationInfo{
+				key:   key,
+				count: int(diff),
+			})
+		}
+	}
+
+	// Execute Phase 1: Delete all marked pods FIRST (across all configs on this node)
+	deletedCount := 0
+	for _, del := range allDeletions {
+		if err := ctl.coreclient.Pods(del.pod.Namespace).Delete(ctx, del.pod.Name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{
+				ResourceVersion: &del.pod.ResourceVersion,
+			},
+		}); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Info("Launcher pod already deleted", "pod", del.pod.Name)
+				deletedCount++
+				continue
+			}
+			if apierrors.IsConflict(err) {
+				logger.Info("Launcher pod version conflict, skipping deletion",
+					"pod", del.pod.Name, "error", err)
+				continue
+			}
+			return fmt.Errorf("failed to delete launcher pod %s: %w", del.pod.Name, err)
+		}
+		logger.Info("Deleted launcher pod (Phase 1)",
+			"pod", del.pod.Name,
+			"node", nodeName,
+			"config", del.key.LauncherConfigName,
+			"reason", del.reason)
+		deletedCount++
+	}
+
+	if deletedCount < len(allDeletions) {
+		logger.Info("Fewer pods deleted than planned",
+			"planned", len(allDeletions),
+			"actual", deletedCount)
+	} else if deletedCount > 0 {
+		logger.Info("Completed Phase 1: Deletions",
+			"node", nodeName,
+			"deleted", deletedCount)
+	}
+
+	// Execute Phase 2: Create all needed pods AFTER deletions complete
+	totalCreated := 0
+	for _, creation := range allCreations {
+		if err := ctl.createLaunchers(ctx, *node, creation.key, creation.count); err != nil {
+			logger.Error(err, "Failed to create launchers for config",
+				"node", nodeName,
+				"config", creation.key.LauncherConfigName,
+				"count", creation.count)
+			return err
+		}
+		totalCreated += creation.count
+		logger.Info("Created launchers for config (Phase 2)",
+			"node", nodeName,
+			"config", creation.key.LauncherConfigName,
+			"created", creation.count)
+	}
+
+	if totalCreated > 0 {
+		logger.Info("Completed Phase 2: Creations",
+			"node", nodeName,
+			"created", totalCreated)
+	}
+
+	logger.Info("Completed reconciliation for node",
 		"node", nodeName,
-		"config", launcherConfigName,
-		"current", currentCount,
-		"desired", desiredCount,
-		"diff", diff)
-	if diff > 0 {
-		// Need to create more launchers
-		err := ctl.createLaunchers(ctx, *node, key, int(diff))
-		if err != nil {
-			return fmt.Errorf("failed to create launchers: %w", err)
-		}
-	} else if diff < 0 {
-		// Need to delete excess launchers
-		err := ctl.deleteExcessLaunchers(ctx, currentLaunchers, int(-diff))
-		if err != nil {
-			return fmt.Errorf("failed to delete excess launchers: %w", err)
-		}
-	}
+		"configs_processed", len(keys),
+		"pods_deleted", deletedCount,
+		"pods_created", totalCreated)
+
 	return nil
 }
 
@@ -434,54 +517,6 @@ func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, ke
 		}
 		logger.Info("Created launcher pod", "pod", pod.GenerateName, "node", node.Name)
 	}
-	return nil
-}
-
-// deleteExcessLaunchers deletes the specified number of launcher pods
-func (ctl *controller) deleteExcessLaunchers(ctx context.Context, launchers []*corev1.Pod, count int) error {
-	logger := klog.FromContext(ctx)
-
-	deletedCount := 0
-	for i := 0; i < count && i < len(launchers); i++ {
-		pod := launchers[len(launchers)-1-i]
-		isBound, requesterPodName := ctl.isLauncherBoundToServerRequestingPod(pod)
-		if isBound {
-			logger.V(5).Info("Skipping deletion of launcher pod as it is bound to a server-requesting pod",
-				"pod", pod.Name, "server-requesting pod", requesterPodName)
-			continue
-		}
-
-		if err := ctl.coreclient.Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				ResourceVersion: &pod.ResourceVersion,
-			},
-		}); err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("Launcher pod already deleted", "pod", pod.Name)
-				deletedCount++ // Count as deletion target achieved
-				continue
-			}
-			if apierrors.IsConflict(err) {
-				logger.Info("Launcher pod version conflict, skipping deletion",
-					"pod", pod.Name, "error", err)
-				continue
-			}
-			return fmt.Errorf("failed to delete launcher pod %s: %w", pod.Name, err)
-		}
-		logger.Info("Deleted launcher pod", "pod", pod.Name)
-		deletedCount++
-	}
-
-	if deletedCount < count {
-		logger.Info("Fewer launcher pods were deleted than requested due to bound pods or concurrent changes",
-			"requested", count,
-			"deleted", deletedCount,
-			"skipped", count-deletedCount)
-	} else {
-		logger.Info("Deleted unbound launcher pods",
-			"deleted", deletedCount)
-	}
-
 	return nil
 }
 

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -136,7 +136,7 @@ func (ctl *controller) OnAdd(obj any, isInInitialList bool) {
 		item := lcItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
 	default:
-		ctl.enqueueLogger.V(5).Info("Notified of add of ignored object", "type", fmt.Sprintf("%T", obj))
+		ctl.enqueueLogger.V(5).Info("Notified of add of object of ignored type", "type", fmt.Sprintf("%T", obj))
 		return
 	}
 }
@@ -190,6 +190,19 @@ func (ctl *controller) process(ctx context.Context, item queueItem) (error, bool
 }
 
 func (item lppItem) process(ctx context.Context, ctl *controller) (error, bool) {
+	return ctl.reconcileFromPolicies(ctx)
+}
+
+func (item lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
+	// No special treatment for any particular LauncherConfig;
+	// missing LauncherConfigs are handled inside buildDesiredStateFromPolicies.
+	return ctl.reconcileFromPolicies(ctx)
+}
+
+// reconcileFromPolicies builds the desired state from all policies and reconciles
+// all launcher pods accordingly. It is the common implementation shared by
+// lppItem.process and lcItem.process.
+func (ctl *controller) reconcileFromPolicies(ctx context.Context) (error, bool) {
 	logger := klog.FromContext(ctx)
 
 	// Build desired state from all policies
@@ -208,37 +221,7 @@ func (item lppItem) process(ctx context.Context, ctl *controller) (error, bool) 
 		return err, true
 	}
 
-	if needsRequeue {
-		return nil, true
-	}
-	return nil, false
-}
-
-func (item lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
-	logger := klog.FromContext(ctx)
-
-	// Build desired state from all policies.
-	// No special treatment for any particular LauncherConfig;
-	// missing LauncherConfigs are handled inside buildDesiredStateFromPolicies.
-	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx)
-	if err != nil {
-		logger.Error(err, "Failed to build desired state from policies")
-		return err, true
-	}
-
-	logger.Info("Final population policy", "policy", MapToLoggable(populationPolicy))
-
-	// Adjust launcher pods according to final requirements
-	needsRequeue, err := ctl.reconcileAllLaunchers(ctx, populationPolicy)
-	if err != nil {
-		logger.Error(err, "Failed to reconcile launchers")
-		return err, true
-	}
-
-	if needsRequeue {
-		return nil, true
-	}
-	return nil, false
+	return nil, needsRequeue
 }
 
 // buildDesiredStateFromPolicies builds the desired state map from all policies.
@@ -331,9 +314,7 @@ func (ctl *controller) reconcileAllLaunchers(ctx context.Context, desired map[No
 			logger.Error(err, "Failed to reconcile launchers on node", "node", nodeName)
 			continue
 		}
-		if needsRequeue {
-			anyRequeueNeeded = true
-		}
+		anyRequeueNeeded = anyRequeueNeeded || needsRequeue
 	}
 
 	return anyRequeueNeeded, nil

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -136,7 +136,7 @@ func (ctl *controller) OnAdd(obj any, isInInitialList bool) {
 		item := lcItem{cache.MetaObjectToName(typed)}
 		ctl.Queue.Add(item)
 	default:
-		ctl.enqueueLogger.V(5).Info("Notified of add of type of ignored object", "type", fmt.Sprintf("%T", obj))
+		ctl.enqueueLogger.V(5).Info("Notified of add of ignored object", "type", fmt.Sprintf("%T", obj))
 		return
 	}
 }

--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -147,7 +147,7 @@ func BuildLauncherPodFromTemplate(template corev1.PodTemplateSpec, ns, nodeName,
 		Spec:       *DeIndividualize(template.Spec.DeepCopy()),
 	}
 	pod.Namespace = ns
-	pod.GenerateName = "launcher-"
+	pod.GenerateName = fmt.Sprintf("launcher-%s-", launcherConfigName)
 	// Ensure labels are set
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)


### PR DESCRIPTION
Previously, when a `LauncherConfig` object was updated:
- The `launcher-populator` controller only processed `LauncherPopulationPolicy` events

## This Solution
Added `LauncherConfig` event handling to the controller to ensure:
1. When a `LauncherConfig` changes, all affected server-requesting pods are not affected
2. New launcher pods are created with the updated configuration
3. Old launcher pods (not bound to any requester) are eventually cleaned up