### PR TITLE
Add FYI instance label on server-requesting Pods

### DIFF
--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: show test pods with labels
         if: always()
-        run: kubectl get pods -L dual-pods.llm-d.ai/dual,dual-pods.llm-d.ai/sleeping,dual-pods.llm-d.ai/launcher-config-name
+        run: kubectl get pods -L dual-pods.llm-d.ai/dual,dual-pods.llm-d.ai/sleeping,dual-pods.llm-d.ai/instance,dual-pods.llm-d.ai/launcher-config-name
 
       - name: show ReplicaSets
         if: always()

--- a/docs/e2e-recipe.md
+++ b/docs/e2e-recipe.md
@@ -357,7 +357,7 @@ information tacked on by the dual-pods controller.
 kubectl get pods -o 'custom-columns=NAME:.metadata.name,PHASE:.status.phase,COND2:.status.conditions[2].type,VAL2:.status.conditions[2].status,DUAL:.metadata.labels.dual-pods\.llm-d\.ai/dual,GPUS:.metadata.annotations.dual-pods\.llm-d\.ai/accelerators,SLEEPING:.metadata.labels.dual-pods\.llm-d\.ai/sleeping'
 
 
-kubectl get pods -L dual-pods.llm-d.ai/dual,dual-pods.llm-d.ai/sleeping
+kubectl get pods -L dual-pods.llm-d.ai/dual,dual-pods.llm-d.ai/sleeping,dual-pods.llm-d.ai/instance
 ```
 
 The following command will query Prometheus metrics from the nvidia

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -108,6 +108,16 @@ const LauncherBasedAnnotationName string = "dual-pods.llm-d.ai/launcher-based"
 // (it does not rely on this label for anything).
 const DualLabelName string = "dual-pods.llm-d.ai/dual"
 
+// InstanceLabelName is the name of a label that the dual-pods controller
+// maintains on server-requesting Pods.
+// While bound to a launcher-based server-providing Pod, this label is present
+// and its value is the instance ID of the vLLM instance;
+// while unbound, or when the server-providing Pod is not launcher-based,
+// this label is absent.
+// This label is purely FYI emitted by the dual-pods controller
+// (it does not rely on this label for anything).
+const InstanceLabelName string = "dual-pods.llm-d.ai/instance"
+
 // SleepingLabelName is the name of a label that the dual-pods controller
 // maintains on server-providing Pods.
 // This value of this label is "true" or "false",

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -186,7 +186,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			// Reflect providingPod deletion to requestingPod deletion.
 			gonerRV := requesterRV
 			if shouldAddRequesterFinalizer { // don't let delete complete too quickly
-				gonerRV, err = ctl.addRequesterFinalizer(ctx, requestingPod, providingPod.Name)
+				gonerRV, err = ctl.addRequesterFinalizer(ctx, requestingPod, providingPod.Name, serverDat.InstanceID)
 				if err != nil {
 					return err, true
 				}
@@ -720,8 +720,10 @@ func (ctl *controller) configInferenceServer(isc *fmav1alpha1.InferenceServerCon
 	hasher.Write([]byte(strings.Join(gpuUUIDs, ",")))
 	var hash [sha256.Size]byte
 	hashSl := hasher.Sum(hash[:0])
-	// using Raw_URL_Encoding because this hash will be used in URLs to the launcher.
-	nominalHash := base64.RawURLEncoding.EncodeToString(hashSl)
+	// Using Raw_URL_Encoding because this hash will be used in URLs to the launcher.
+	// Wrapping with "I" prefix and "i" suffix to ensure the value is a valid Kubernetes
+	// label value (which must start and end with an alphanumeric character).
+	nominalHash := "I" + base64.RawURLEncoding.EncodeToString(hashSl) + "i"
 
 	return &vllmCfg, nominalHash, nil
 }
@@ -947,11 +949,14 @@ func (ctl *controller) maybeRemoveRequesterFinalizer(ctx context.Context, reques
 
 // addRequesterFinalizer does the API call to add the controller's finalizer to the server-requesting Pod.
 // Returns (newResourceVersion string, err error)
-func (ctl *controller) addRequesterFinalizer(ctx context.Context, requestingPod *corev1.Pod, providingPodName string) (string, error) {
+func (ctl *controller) addRequesterFinalizer(ctx context.Context, requestingPod *corev1.Pod, providingPodName, instanceID string) (string, error) {
 	podOps := ctl.coreclient.Pods(ctl.namespace)
 	requestingPod = requestingPod.DeepCopy()
 	if requestingPod.Labels[api.DualLabelName] != providingPodName {
 		requestingPod.Labels = utils.MapSet(requestingPod.Labels, api.DualLabelName, providingPodName)
+	}
+	if instanceID != "" {
+		requestingPod.Labels = utils.MapSet(requestingPod.Labels, api.InstanceLabelName, instanceID)
 	}
 	requestingPod.Finalizers = append(requestingPod.Finalizers, requesterFinalizer)
 	echo, err := podOps.Update(ctx, requestingPod, metav1.UpdateOptions{FieldManager: ControllerName})
@@ -1265,8 +1270,12 @@ func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1
 	}
 	desiredAccelerators := ptr.Deref(serverDat.GPUIDsStr, "")
 	currentAccelerators := requestingPod.Annotations[api.AcceleratorsAnnotationName]
-	if oldStatusStr == newStatusStr && desiredAccelerators == currentAccelerators && len(newFinalizers) == len(requestingPod.Finalizers) && serverDat.ProvidingPodName == requestingPod.Labels[api.DualLabelName] {
-		logger.V(5).Info("No need to update status, accelerators, boundName, or finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "finalizers", requestingPod.Finalizers)
+	desiredInstanceID := ""
+	if serverDat.ProvidingPodName != "" {
+		desiredInstanceID = serverDat.InstanceID
+	}
+	if oldStatusStr == newStatusStr && desiredAccelerators == currentAccelerators && len(newFinalizers) == len(requestingPod.Finalizers) && serverDat.ProvidingPodName == requestingPod.Labels[api.DualLabelName] && desiredInstanceID == requestingPod.Labels[api.InstanceLabelName] {
+		logger.V(5).Info("No need to update status, accelerators, boundName, instanceID, or finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "instanceID", desiredInstanceID, "finalizers", requestingPod.Finalizers)
 		return nil, false
 	}
 	requestingPod = requestingPod.DeepCopy()
@@ -1275,14 +1284,18 @@ func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1
 	requestingPod.Finalizers = newFinalizers
 	if serverDat.ProvidingPodName != "" {
 		requestingPod.Labels = utils.MapSet(requestingPod.Labels, api.DualLabelName, serverDat.ProvidingPodName)
+		if serverDat.InstanceID != "" {
+			requestingPod.Labels = utils.MapSet(requestingPod.Labels, api.InstanceLabelName, serverDat.InstanceID)
+		}
 	} else if requestingPod.Labels != nil {
 		delete(requestingPod.Labels, api.DualLabelName)
+		delete(requestingPod.Labels, api.InstanceLabelName)
 	}
 	echo, err := ctl.coreclient.Pods(requestingPod.Namespace).Update(ctx, requestingPod, metav1.UpdateOptions{FieldManager: ctl.ControllerName})
 	if err == nil {
-		logger.V(2).Info("Set status/finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "finalizers", requestingPod.Finalizers, "newResourceVersion", echo.ResourceVersion)
+		logger.V(2).Info("Set status/finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "instanceID", desiredInstanceID, "finalizers", requestingPod.Finalizers, "newResourceVersion", echo.ResourceVersion)
 	} else {
-		logger.V(3).Info("Failed to set status/finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "finalizers", requestingPod.Finalizers, "resourceVersion", requestingPod.ResourceVersion)
+		logger.V(3).Info("Failed to set status/finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "instanceID", desiredInstanceID, "finalizers", requestingPod.Finalizers, "resourceVersion", requestingPod.ResourceVersion)
 	}
 	return err, err != nil
 }


### PR DESCRIPTION
## Summary

- Add a purely-FYI label `dual-pods.llm-d.ai/instance` on server-requesting Pods carrying the launcher's vLLM instance ID, to aid debugging and observability
- The label is present while bound to a launcher-based server-providing Pod and absent otherwise
- Wrap the ISC hash with "I" prefix and "i" suffix so it is always a valid Kubernetes label value (must start/end with alphanumeric)

Resolves #398

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Existing unit tests pass
- [ ] Verify in a launcher-based e2e test that the requesting pod gets the `dual-pods.llm-d.ai/instance` label after binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)