### PR TITLE
✨ Initial commit of AI agent instruction files

### DIFF
--- a/.agents/skills/our-git-commits/SKILL.md
+++ b/.agents/skills/our-git-commits/SKILL.md
@@ -1,0 +1,9 @@
+name: our-git-commits
+description: Things to do when making a Git commit
+trigger: When the user asks to commit changes, create a commit, make a git commit, amend a commit, revise a commit, reword a commit message, or any other action that results in running a `git commit` command
+---
+
+When creating a Git commit:
+
+1. Before committing, run `typos` on the changed files to find and fix any typographical errors. Ask the user about any findings you are unsure about.
+2. Include a DCO sign-off and a cryptographic signature.

--- a/.agents/skills/pr-security-review/SKILL.md
+++ b/.agents/skills/pr-security-review/SKILL.md
@@ -1,0 +1,11 @@
+name: pr-security-review
+description: When reviewing PRs that bump dependencies or GitHub Actions, actively search for known vulnerabilities rather than reasoning abstractly
+---
+
+When reviewing dependency bump PRs, verify security by actually checking external sources — don't just reason about it in the abstract.
+
+Checklist:
+1. Verify the pinned SHA matches the upstream tag
+2. Search github.com/advisories for the dependency
+3. Web search for CVEs/vulnerabilities in the specific new version being introduced
+4. Check the release notes for any security-relevant changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Instructions for coding agents
+
+## Workflow Preferences
+- Always use the `our-git-commits` skill when making git commits.
+- Always use the `pr-security-review` skill when reviewing PRs that bump dependencies or GitHub Actions.


### PR DESCRIPTION
Added two skills and `AGENTS.md` saying when to use those skills.

Skills:
- our-git-commits
- pr-security-review

These are my attempt to extract into AAIF files what I have accumulated in my personal Claude instructions. The explicit direction to use the skills was added to my Claude instructions because I found Claude Code not using the skills some times and asked Claude how to make it not make that mistake.