### PR TITLE
Fail collision E2E test early when GPU saturated

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -573,7 +573,7 @@ jobs:
 
           # Delete namespace
           kubectl delete namespace "$FMA_NAMESPACE" \
-            --ignore-not-found --timeout=120s || true
+            --ignore-not-found --timeout=180s || true
 
           # Delete cluster-scoped stuff for reading Node objects
           kubectl delete clusterrole        "${FMA_CHART_INSTANCE_NAME}-node-view" --ignore-not-found || true

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -462,6 +462,30 @@ jobs:
           MKOBJS_SCRIPT: ./test/e2e/mkobjs-openshift.sh
         run: ./test/e2e/test-cases.sh
 
+      - name: Dump GPU allocation per node
+        if: always()
+        run: |
+          echo "=== GPU allocation per node ==="
+          for nodename in $(kubectl get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.items[*].metadata.name}'); do
+            allocatable=$(kubectl get node "$nodename" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+            allocated=$(kubectl get pods --all-namespaces --field-selector spec.nodeName="$nodename" -o json \
+              | jq '[.items[]
+                    | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+                    | select(.metadata.deletionTimestamp == null)
+                    | .spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0"
+                    | tonumber] | add // 0')
+            echo "Node $nodename: allocatable=$allocatable allocated=$allocated available=$((allocatable - allocated))"
+            echo "  GPU-consuming pods in $FMA_NAMESPACE:"
+            kubectl get pods -n "$FMA_NAMESPACE" --field-selector spec.nodeName="$nodename" -o json \
+              | jq -r '.items[]
+                  | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+                  | select(.metadata.deletionTimestamp == null)
+                  | ([.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber] | add) as $gpu_total
+                  | select($gpu_total > 0)
+                  | "    \(.metadata.name) gpu=\($gpu_total)"'
+          done
+        continue-on-error: true
+
       - name: List objects of category all
         if: always()
         run: kubectl get all -n "$FMA_NAMESPACE"

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -222,57 +222,57 @@ if (( available_gpus < 1 )); then
     exit 1
 else
 
-collision_inst="${inst}-collision"
-collision_rs="my-request-collision-$inst"
+    collision_inst="${inst}-collision"
+    collision_rs="my-request-collision-$inst"
 
-kubectl get rs "$rs" -n "$NS" -o json \
-  | jq \
-      --arg collision_rs "$collision_rs" \
-      --arg collision_inst "$collision_inst" \
-      --arg testnode "$testnode" \
-      --arg isc "$isc" \
-      '
-      .metadata.name = $collision_rs |
-      del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.annotations, .metadata.ownerReferences, .status) |
-      .spec.replicas = 1 |
-      .spec.selector.matchLabels.instance = $collision_inst |
-      .spec.template.metadata.labels.instance = $collision_inst |
-      .spec.template.spec.nodeSelector = {"kubernetes.io/hostname": $testnode} |
-      .spec.template.metadata.annotations["dual-pods.llm-d.ai/inference-server-config"] = $isc
-    ' \
-  | kubectl apply -n "$NS" -f -
+    kubectl get rs "$rs" -n "$NS" -o json \
+      | jq \
+          --arg collision_rs "$collision_rs" \
+          --arg collision_inst "$collision_inst" \
+          --arg testnode "$testnode" \
+          --arg isc "$isc" \
+          '
+          .metadata.name = $collision_rs |
+          del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.annotations, .metadata.ownerReferences, .status) |
+          .spec.replicas = 1 |
+          .spec.selector.matchLabels.instance = $collision_inst |
+          .spec.template.metadata.labels.instance = $collision_inst |
+          .spec.template.spec.nodeSelector = {"kubernetes.io/hostname": $testnode} |
+          .spec.template.metadata.annotations["dual-pods.llm-d.ai/inference-server-config"] = $isc
+        ' \
+      | kubectl apply -n "$NS" -f -
 
-expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 1"
+    expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 1"
 
-collision_req=$(kubectl get pods -n "$NS" -o name -l app=dp-example,instance=$collision_inst | sed s%pod/%%)
-echo "Collision requester Pod is $collision_req"
+    collision_req=$(kubectl get pods -n "$NS" -o name -l app=dp-example,instance=$collision_inst | sed s%pod/%%)
+    echo "Collision requester Pod is $collision_req"
 
-expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.spec.nodeName})" == "'"$testnode"'" ]'
-expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/dual=$collision_req | wc -l | grep -w 1"
+    expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.spec.nodeName})" == "'"$testnode"'" ]'
+    expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/dual=$collision_req | wc -l | grep -w 1"
 
-collision_launcher=$(kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/dual=$collision_req | sed s%pod/%%)
-echo "Collision launcher Pod is $collision_launcher"
+    collision_launcher=$(kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/dual=$collision_req | sed s%pod/%%)
+    echo "Collision launcher Pod is $collision_launcher"
 
-[ "$collision_launcher" != "$launcher1" ]
+    [ "$collision_launcher" != "$launcher1" ]
 
-expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "'"$collision_launcher"'" ]'
+    expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "'"$collision_launcher"'" ]'
 
-date
-kubectl wait --for condition=Ready pod/$collision_req -n "$NS" --timeout=120s
-[ "$(kubectl get pod $collision_launcher -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
+    date
+    kubectl wait --for condition=Ready pod/$collision_req -n "$NS" --timeout=120s
+    [ "$(kubectl get pod $collision_launcher -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-req_gpus=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
-collision_gpus=$(kubectl get pod "$collision_req" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
-[ -n "$req_gpus" ]
-[ -n "$collision_gpus" ]
-[ "$req_gpus" != "$collision_gpus" ]
+    req_gpus=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
+    collision_gpus=$(kubectl get pod "$collision_req" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
+    [ -n "$req_gpus" ]
+    [ -n "$collision_gpus" ]
+    [ "$req_gpus" != "$collision_gpus" ]
 
-kubectl delete rs "$collision_rs" -n "$NS" --wait=true
-expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 0"
-kubectl delete pod "$collision_launcher" -n "$NS" --wait=true
-expect '! kubectl get pods -n '"$NS"' -o name | grep -qw pod/'"$collision_launcher"
+    kubectl delete rs "$collision_rs" -n "$NS" --wait=true
+    expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 0"
+    kubectl delete pod "$collision_launcher" -n "$NS" --wait=true
+    expect '! kubectl get pods -n '"$NS"' -o name | grep -qw pod/'"$collision_launcher"
 
-cheer Successful same-node collision handling
+    cheer Successful same-node collision handling
 
 fi # available_gpus check
 

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -203,6 +203,25 @@ fi
 
 intro_case Same-Node Port Collision Creates New Launcher
 
+# Check whether the test node has a free GPU for the collision requester.
+# req1 already holds 1 GPU; the collision requester needs 1 more on the same node.
+allocatable_gpus=$(kubectl get node "$testnode" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+allocated_gpus=$(kubectl get pods --all-namespaces --field-selector spec.nodeName="$testnode" -o json \
+  | jq '[.items[]
+         | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+         | select(.metadata.deletionTimestamp == null)
+         | .spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0"
+         | tonumber] | add // 0')
+available_gpus=$(( allocatable_gpus - allocated_gpus ))
+echo "Node $testnode: allocatable_gpus=$allocatable_gpus allocated_gpus=$allocated_gpus available_gpus=$available_gpus"
+
+if (( available_gpus < 1 )); then
+    echo "FAIL: Node $testnode has no free GPUs ($allocatable_gpus allocatable, $allocated_gpus allocated)." >&2
+    echo "The Same-Node Port Collision test needs 1 free GPU for the collision requester." >&2
+    echo "This is likely due to GPU saturation on the shared cluster." >&2
+    exit 1
+else
+
 collision_inst="${inst}-collision"
 collision_rs="my-request-collision-$inst"
 
@@ -254,6 +273,8 @@ kubectl delete pod "$collision_launcher" -n "$NS" --wait=true
 expect '! kubectl get pods -n '"$NS"' -o name | grep -qw pod/'"$collision_launcher"
 
 cheer Successful same-node collision handling
+
+fi # available_gpus check
 
 # ---------------------------------------------------------------------------
 # Instance Wake-up Fast Path


### PR DESCRIPTION
## Summary
- Before the "Same-Node Port Collision" test, check whether the test node has a free GPU available for the collision requester (req1 already holds one)
- If no GPU is free, fail immediately with an explanatory message instead of timing out after 10 minutes
- Add a "Dump GPU allocation per node" debug step to the CI workflow so GPU saturation state is visible in every run's logs

Fixes #422

## Test plan
- [ ] Verify the E2E test passes on a cluster with sufficient GPUs (existing behavior unchanged)
- [ ] Verify the test fails fast with a clear message when GPUs are saturated on the test node
- [ ] Verify the new CI debug step shows allocatable/allocated/available GPU counts per node

🤖 Generated with [Claude Code](https://claude.com/claude-code)