### PR TITLE
Upgrade chainguard/static base image pin

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: cgr.dev/chainguard/static@sha256:2fdfacc8d61164aa9e20909dceec7cc28b9feb66580e8e1a65b9f2443c53b61b
+defaultBaseImage: cgr.dev/chainguard/static@sha256:d6d54da1c5bf5d9cecb231786adca86934607763067c8d7d9d22057abe6d5dbc


### PR DESCRIPTION
## Summary
- Upgrade `cgr.dev/chainguard/static` digest pin in `.ko.yaml` to the current `latest`
- No CVEs found via Chainguard vulnerabilities page and web search

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)