### PR TITLE
E2E: probe for a 2-GPU node before running test cases

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -573,7 +573,7 @@ jobs:
 
           # Delete namespace
           kubectl delete namespace "$FMA_NAMESPACE" \
-            --ignore-not-found --timeout=120s || true
+            --ignore-not-found --timeout=180s || true
 
           # Delete cluster-scoped stuff for reading Node objects
           kubectl delete clusterrole        "${FMA_CHART_INSTANCE_NAME}-node-view" --ignore-not-found || true

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -462,6 +462,30 @@ jobs:
           MKOBJS_SCRIPT: ./test/e2e/mkobjs-openshift.sh
         run: ./test/e2e/test-cases.sh
 
+      - name: Dump GPU allocation per node
+        if: always()
+        run: |
+          echo "=== GPU allocation per node ==="
+          for nodename in $(kubectl get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.items[*].metadata.name}'); do
+            allocatable=$(kubectl get node "$nodename" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+            allocated=$(kubectl get pods --all-namespaces --field-selector spec.nodeName="$nodename" -o json \
+              | jq '[.items[]
+                    | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+                    | select(.metadata.deletionTimestamp == null)
+                    | .spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0"
+                    | tonumber] | add // 0')
+            echo "Node $nodename: allocatable=$allocatable allocated=$allocated available=$((allocatable - allocated))"
+            echo "  GPU-consuming pods in $FMA_NAMESPACE:"
+            kubectl get pods -n "$FMA_NAMESPACE" --field-selector spec.nodeName="$nodename" -o json \
+              | jq -r '.items[]
+                  | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+                  | select(.metadata.deletionTimestamp == null)
+                  | ([.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber] | add) as $gpu_total
+                  | select($gpu_total > 0)
+                  | "    \(.metadata.name) gpu=\($gpu_total)"'
+          done
+        continue-on-error: true
+
       - name: List objects of category all
         if: always()
         run: kubectl get all -n "$FMA_NAMESPACE"

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -2,7 +2,7 @@
 
 # Creates test Kubernetes objects for the OpenShift / real-cluster E2E path.
 #
-# Usage: mkobjs-openshift.sh [-n <namespace>]
+# Usage: mkobjs-openshift.sh [-n <namespace>] [--node <node-name>]
 #
 # Required environment variables:
 #   LAUNCHER_IMAGE   - container image for the launcher pod
@@ -17,8 +17,9 @@
 
 set -euo pipefail
 
-# Parse optional -n / --namespace flag
+# Parse optional flags
 ns_flag=()
+node_name=""
 while [ $# -gt 0 ]; do
     case "$1" in
         -n|--namespace)
@@ -27,6 +28,15 @@ while [ $# -gt 0 ]; do
                 shift 2
             else
                 echo "Missing --namespace argument" >&2
+                exit 1
+            fi
+            ;;
+        --node)
+            if [ $# -gt 1 ] ; then
+                node_name="$2"
+                shift 2
+            else
+                echo "Missing --node argument" >&2
                 exit 1
             fi
             ;;
@@ -46,6 +56,14 @@ inst=$(date +%d-%H-%M-%S)
 runtime_class=""
 if [ -n "${RUNTIME_CLASS_NAME:-}" ]; then
     runtime_class="runtimeClassName: ${RUNTIME_CLASS_NAME}"
+fi
+
+# When a node is specified, pin the ReplicaSet's pods to it.
+if [ -n "$node_name" ]; then
+    node_selector="nodeSelector:
+        kubernetes.io/hostname: \"$node_name\""
+else
+    node_selector=""
 fi
 
 if out=$(kubectl apply "${ns_flag[@]}" -f - 2>&1 <<EOF
@@ -218,6 +236,7 @@ spec:
         dual-pods.llm-d.ai/inference-server-config: "inference-server-config-smol-$inst"
     spec:
       ${runtime_class}
+      ${node_selector}
       containers:
         - name: inference-server
           image: ${REQUESTER_IMAGE}

--- a/test/e2e/mkobjs.sh
+++ b/test/e2e/mkobjs.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Parse optional -n / --namespace flag
+# Parse optional flags
 ns_flag=()
+node_name=""
 while [ $# -gt 0 ]; do
     case "$1" in
         -n|--namespace)
@@ -13,12 +14,29 @@ while [ $# -gt 0 ]; do
                 exit 1
             fi
             ;;
+        --node)
+            if [ $# -gt 1 ] ; then
+                node_name="$2"
+                shift 2
+            else
+                echo "Missing --node argument" >&2
+                exit 1
+            fi
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
             ;;
     esac
 done
+
+# When a node is specified, pin the ReplicaSet's pods to it.
+if [ -n "$node_name" ]; then
+    node_selector="nodeSelector:
+        kubernetes.io/hostname: \"$node_name\""
+else
+    node_selector=""
+fi
 
 inst=$(date +%d-%H-%M-%S)
 requester_img=$(make echo-var VAR=TEST_REQUESTER_IMG)
@@ -194,8 +212,8 @@ spec:
               nvidia.com/gpu: "1"
               cpu: "200m"
               memory: 250Mi
+      ${node_selector}
       serviceAccount: testreq
-      # nodeName: fmatest-worker # try fixed node for the consistency of value of dual-pods.llm-d.ai/launcher-config-hash annotation
 EOF
         )
 then

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -64,7 +64,7 @@ expect() {
         if eval "$1"; then return; fi
         if (( elapsed > limit )); then
             echo "Did not become true (from $start to $(date)): $1" >&2
-            exit 99
+            return 99
         fi
         sleep 5
         elapsed=$(( elapsed+5 ))
@@ -103,12 +103,63 @@ check_gpu_pin() {
 }
 
 # ---------------------------------------------------------------------------
+# Probe for a node with 2 free GPUs
+# ---------------------------------------------------------------------------
+# Create a throwaway Pod that requests 2 GPUs.  The scheduler will place it
+# on a node that actually has 2 GPUs available right now.  Once it is running
+# we record the node, delete the probe Pod, and pin every subsequent test
+# workload to that node.  This avoids spurious failures on shared clusters
+# where GPU availability is dynamic (Issue #422).
+
+intro_case GPU Probe
+
+probe_pod="gpu-probe-$(date +%d-%H-%M-%S)"
+
+if [ -n "${RUNTIME_CLASS_NAME:-}" ]; then
+    probe_runtime_class="runtimeClassName: ${RUNTIME_CLASS_NAME}"
+else
+    probe_runtime_class=""
+fi
+
+kubectl apply -n "$NS" -f - <<PROBE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${probe_pod}
+  labels:
+    app: gpu-probe
+spec:
+  ${probe_runtime_class}
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.10.2
+    resources:
+      limits:
+        nvidia.com/gpu: "2"
+  terminationGracePeriodSeconds: 0
+PROBE
+
+if ! expect '[ "$(kubectl get pod '"$probe_pod"' -n '"$NS"' -o jsonpath={.status.phase})" = "Running" ]'; then
+    echo "FAIL: GPU probe Pod $probe_pod did not reach Running." >&2
+    echo "This probably means no node in the cluster has 2 GPUs available right now." >&2
+    kubectl delete pod "$probe_pod" -n "$NS" --wait=false 2>/dev/null || true
+    exit 1
+fi
+
+testnode=$(kubectl get pod "$probe_pod" -n "$NS" -o jsonpath='{.spec.nodeName}')
+echo "GPU probe Pod $probe_pod scheduled on Node $testnode — using it for the rest of the tests"
+
+kubectl delete pod "$probe_pod" -n "$NS" --wait=true
+
+cheer "GPU probe complete — test node is $testnode"
+
+# ---------------------------------------------------------------------------
 # Create test objects
 # ---------------------------------------------------------------------------
 
 intro_case Basic Launcher Pod Creation
 
-objs=$("$MKOBJS_SCRIPT" -n "$NS")
+objs=$("$MKOBJS_SCRIPT" -n "$NS" --node "$testnode")
 isc=$(echo $objs | awk '{print $1}')
 lc=$(echo $objs | awk '{print $2}')
 rs=$(echo $objs | awk '{print $3}')
@@ -147,8 +198,7 @@ expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$inst | wc -l
 
 export req1=$(kubectl get pods -n "$NS" -o name -l app=dp-example,instance=$inst | sed s%pod/%%)
 echo "Server-requesting Pod is $req1"
-testnode=$(kubectl get pod $req1 -n "$NS" -o jsonpath='{.spec.nodeName}')
-echo "The test Pods run on Node $testnode"
+[ "$(kubectl get pod $req1 -n "$NS" -o jsonpath='{.spec.nodeName}')" = "$testnode" ]
 
 # Wait for launcher-to-requester binding, then capture the launcher name
 expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/dual=$req1 | wc -l | grep -w 1"

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -222,57 +222,57 @@ if (( available_gpus < 1 )); then
     exit 1
 else
 
-collision_inst="${inst}-collision"
-collision_rs="my-request-collision-$inst"
+    collision_inst="${inst}-collision"
+    collision_rs="my-request-collision-$inst"
 
-kubectl get rs "$rs" -n "$NS" -o json \
-  | jq \
-      --arg collision_rs "$collision_rs" \
-      --arg collision_inst "$collision_inst" \
-      --arg testnode "$testnode" \
-      --arg isc "$isc" \
-      '
-      .metadata.name = $collision_rs |
-      del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.annotations, .metadata.ownerReferences, .status) |
-      .spec.replicas = 1 |
-      .spec.selector.matchLabels.instance = $collision_inst |
-      .spec.template.metadata.labels.instance = $collision_inst |
-      .spec.template.spec.nodeSelector = {"kubernetes.io/hostname": $testnode} |
-      .spec.template.metadata.annotations["dual-pods.llm-d.ai/inference-server-config"] = $isc
-    ' \
-  | kubectl apply -n "$NS" -f -
+    kubectl get rs "$rs" -n "$NS" -o json \
+      | jq \
+          --arg collision_rs "$collision_rs" \
+          --arg collision_inst "$collision_inst" \
+          --arg testnode "$testnode" \
+          --arg isc "$isc" \
+          '
+          .metadata.name = $collision_rs |
+          del(.metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.annotations, .metadata.ownerReferences, .status) |
+          .spec.replicas = 1 |
+          .spec.selector.matchLabels.instance = $collision_inst |
+          .spec.template.metadata.labels.instance = $collision_inst |
+          .spec.template.spec.nodeSelector = {"kubernetes.io/hostname": $testnode} |
+          .spec.template.metadata.annotations["dual-pods.llm-d.ai/inference-server-config"] = $isc
+        ' \
+      | kubectl apply -n "$NS" -f -
 
-expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 1"
+    expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 1"
 
-collision_req=$(kubectl get pods -n "$NS" -o name -l app=dp-example,instance=$collision_inst | sed s%pod/%%)
-echo "Collision requester Pod is $collision_req"
+    collision_req=$(kubectl get pods -n "$NS" -o name -l app=dp-example,instance=$collision_inst | sed s%pod/%%)
+    echo "Collision requester Pod is $collision_req"
 
-expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.spec.nodeName})" == "'"$testnode"'" ]'
-expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/dual=$collision_req | wc -l | grep -w 1"
+    expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.spec.nodeName})" == "'"$testnode"'" ]'
+    expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/dual=$collision_req | wc -l | grep -w 1"
 
-collision_launcher=$(kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/dual=$collision_req | sed s%pod/%%)
-echo "Collision launcher Pod is $collision_launcher"
+    collision_launcher=$(kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/dual=$collision_req | sed s%pod/%%)
+    echo "Collision launcher Pod is $collision_launcher"
 
-[ "$collision_launcher" != "$launcher1" ]
+    [ "$collision_launcher" != "$launcher1" ]
 
-expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "'"$collision_launcher"'" ]'
+    expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "'"$collision_launcher"'" ]'
 
-date
-kubectl wait --for condition=Ready pod/$collision_req -n "$NS" --timeout=120s
-[ "$(kubectl get pod $collision_launcher -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
+    date
+    kubectl wait --for condition=Ready pod/$collision_req -n "$NS" --timeout=120s
+    [ "$(kubectl get pod $collision_launcher -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-req_gpus=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
-collision_gpus=$(kubectl get pod "$collision_req" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
-[ -n "$req_gpus" ]
-[ -n "$collision_gpus" ]
-[ "$req_gpus" != "$collision_gpus" ]
+    req_gpus=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
+    collision_gpus=$(kubectl get pod "$collision_req" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
+    [ -n "$req_gpus" ]
+    [ -n "$collision_gpus" ]
+    [ "$req_gpus" != "$collision_gpus" ]
 
-kubectl delete rs "$collision_rs" -n "$NS" --wait=true
-expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 0"
-kubectl delete pod "$collision_launcher" -n "$NS" --wait=true
-expect '! kubectl get pods -n '"$NS"' -o name | grep -qw pod/'"$collision_launcher"
+    kubectl delete rs "$collision_rs" -n "$NS" --wait=true
+    expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$collision_inst | wc -l | grep -w 0"
+    kubectl delete pod "$collision_launcher" -n "$NS" --wait=true
+    expect '! kubectl get pods -n '"$NS"' -o name | grep -qw pod/'"$collision_launcher"
 
-cheer Successful same-node collision handling
+    cheer Successful same-node collision handling
 
 fi # available_gpus check
 

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -203,6 +203,25 @@ fi
 
 intro_case Same-Node Port Collision Creates New Launcher
 
+# Check whether the test node has a free GPU for the collision requester.
+# req1 already holds 1 GPU; the collision requester needs 1 more on the same node.
+allocatable_gpus=$(kubectl get node "$testnode" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+allocated_gpus=$(kubectl get pods --all-namespaces --field-selector spec.nodeName="$testnode" -o json \
+  | jq '[.items[]
+         | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+         | select(.metadata.deletionTimestamp == null)
+         | .spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0"
+         | tonumber] | add // 0')
+available_gpus=$(( allocatable_gpus - allocated_gpus ))
+echo "Node $testnode: allocatable_gpus=$allocatable_gpus allocated_gpus=$allocated_gpus available_gpus=$available_gpus"
+
+if (( available_gpus < 1 )); then
+    echo "FAIL: Node $testnode has no free GPUs ($allocatable_gpus allocatable, $allocated_gpus allocated)." >&2
+    echo "The Same-Node Port Collision test needs 1 free GPU for the collision requester." >&2
+    echo "This is likely due to GPU saturation on the shared cluster." >&2
+    exit 1
+else
+
 collision_inst="${inst}-collision"
 collision_rs="my-request-collision-$inst"
 
@@ -254,6 +273,8 @@ kubectl delete pod "$collision_launcher" -n "$NS" --wait=true
 expect '! kubectl get pods -n '"$NS"' -o name | grep -qw pod/'"$collision_launcher"
 
 cheer Successful same-node collision handling
+
+fi # available_gpus check
 
 # ---------------------------------------------------------------------------
 # Instance Wake-up Fast Path


### PR DESCRIPTION
## Summary
- Before creating any test objects, launch a throwaway Pod requesting 2 GPUs so the scheduler places it on a node that actually has 2 GPUs free right now. Record that node, delete the probe, and pin the requester ReplicaSet to it.
- Add a `--node` flag to both `mkobjs.sh` and `mkobjs-openshift.sh` so the caller can inject a `nodeSelector` into the ReplicaSet at creation time.
- Change the `expect` function to `return 99` instead of `exit 99`, so that it can be used in an `if` statement.
- Includes earlier fixes from #426: fail the collision test early when GPUs are saturated, dump GPU allocation in CI, and lengthen the namespace-deletion timeout.

Fixes #422

## Test plan
- [ ] Run the kind-based E2E suite (`test/e2e/run-launcher-based.sh`) and verify the GPU probe selects a node and all subsequent test cases pass
- [ ] Run the OpenShift CI E2E workflow and verify the probe succeeds on the shared cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note to reviewers

It will probably be easier to review each commit individually, because one of them just makes a bunch of changes in indentation and GitHub's diff display for all four together is very confused.