### PR TITLE
Tighten VAP ServiceAccount check and remove policy stubs

### DIFF
--- a/charts/fma-controllers/templates/policies/validating-admission-policy-binding-fields.yaml
+++ b/charts/fma-controllers/templates/policies/validating-admission-policy-binding-fields.yaml
@@ -1,2 +1,0 @@
-# ValidatingAdmissionPolicyBinding objects are no longer managed by this chart.
-# Apply config/validating-admission-policies/ to your cluster instead.

--- a/charts/fma-controllers/templates/policies/validating-admission-policy-binding-serverReqPod.yaml
+++ b/charts/fma-controllers/templates/policies/validating-admission-policy-binding-serverReqPod.yaml
@@ -1,2 +1,0 @@
-# ValidatingAdmissionPolicyBinding objects are no longer managed by this chart.
-# Apply config/validating-admission-policies/ to your cluster instead.

--- a/charts/fma-controllers/templates/policies/validating-admission-policy-bound-serverReqPod.yaml
+++ b/charts/fma-controllers/templates/policies/validating-admission-policy-bound-serverReqPod.yaml
@@ -1,2 +1,0 @@
-# ValidatingAdmissionPolicy objects are no longer managed by this chart.
-# Apply config/validating-admission-policies/ to your cluster instead.

--- a/charts/fma-controllers/templates/policies/validating-admission-policy-immutable-fields.yaml
+++ b/charts/fma-controllers/templates/policies/validating-admission-policy-immutable-fields.yaml
@@ -1,2 +1,0 @@
-# ValidatingAdmissionPolicy objects are no longer managed by this chart.
-# Apply config/validating-admission-policies/ to your cluster instead.

--- a/config/validating-admission-policies/fma-bound-serverreqpod.yaml
+++ b/config/validating-admission-policies/fma-bound-serverreqpod.yaml
@@ -17,11 +17,8 @@ spec:
     # once a server-requesting Pod is bound to a server-providing Pod. It permits
     # such changes only when the requester is an FMA controller service
     # account.
-    # NOTE: this particular test on ServiceAccount name is extra relaxed,
-    # to also match ServiceAccounts that predate PR 297; after that PR merges,
-    # we can tighten up by looking for the suffix `-fma-controllers`.
     - expression: |
-        request.userInfo.username.matches("^system:serviceaccount:[^:]+:[^:]*-controllers$") ||
+        request.userInfo.username.matches("^system:serviceaccount:[^:]+:[^:]*-fma-controllers$") ||
         !(
           oldObject.metadata.?annotations['dual-pods.llm-d.ai/inference-server-config'].orValue('') != "" &&
           oldObject.metadata.?labels['dual-pods.llm-d.ai/dual'].orValue('') != ""

--- a/config/validating-admission-policies/fma-immutable-fields.yaml
+++ b/config/validating-admission-policies/fma-immutable-fields.yaml
@@ -17,11 +17,8 @@ spec:
     # some critical annotations/labels. It permits
     # such changes only when the requester is an FMA controller service
     # account.
-    # NOTE: this particular test on ServiceAccount name is extra relaxed,
-    # to also match ServiceAccounts that predate PR 297; after that PR merges,
-    # we can tighten up by looking for the suffix `-fma-controllers`.
     - expression: |
-        request.userInfo.username.matches("^system:serviceaccount:[^:]+:[^:]*-controllers$") ||
+        request.userInfo.username.matches("^system:serviceaccount:[^:]+:[^:]*-fma-controllers$") ||
         (
           oldObject.metadata.?annotations['dual-pods.llm-d.ai/requester'].orValue('') == object.metadata.?annotations['dual-pods.llm-d.ai/requester'].orValue('') &&
           oldObject.metadata.?annotations['dual-pods.llm-d.ai/status'].orValue('') == object.metadata.?annotations['dual-pods.llm-d.ai/status'].orValue('') &&


### PR DESCRIPTION
## Summary
- Tightened the ServiceAccount name regex in `fma-immutable-fields` and `fma-bound-serverreqpod` ValidatingAdmissionPolicy objects to require the `-fma-controllers` suffix instead of the broader `-controllers`, now that PR #297 has been adopted
- Deleted the stub files in `charts/fma-controllers/templates/policies/` that existed only for Git archaeology purposes
- Removed the NOTE comments about the relaxed pattern

Closes #308

## Test plan
- [x] Verify the ValidatingAdmissionPolicy objects accept requests from ServiceAccounts ending in `-fma-controllers`
- [x] Verify the ValidatingAdmissionPolicy objects reject requests from ServiceAccounts ending in `-controllers` (but not `-fma-controllers`)
- [x] Confirm no regressions in e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)