### PR TITLE
Propagate ISC labels and annotations to launcher Pod on bind/unbind

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -368,6 +368,13 @@ jobs:
           rm -f openshift-client-linux.tar.gz kubectl README.md
           # Install helm
           curl -fsSL --retry 3 --retry-delay 5 https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          # Install yq if not already present (for YAML-to-JSON conversion in deploy_fma.sh)
+          if ! command -v yq &>/dev/null; then
+            YQ_VERSION="v4.53.2"
+            curl -fsSL --retry 3 --retry-delay 5 -o yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+            chmod +x yq
+            sudo mv yq /usr/local/bin/
+          fi
 
       - name: Verify cluster access
         run: |
@@ -456,6 +463,18 @@ jobs:
         run: |
           export CONTAINER_IMG_REG="${CONTAINER_IMG_REG,,}"
           ./test/e2e/deploy_fma.sh
+
+      - name: Dump InferenceServerConfig CRD
+        if: always()
+        run: kubectl get crd inferenceserverconfigs.fma.llm-d.ai -o yaml
+
+      - name: Dump LauncherConfig CRD
+        if: always()
+        run: kubectl get crd launcherconfigs.fma.llm-d.ai -o yaml
+
+      - name: Dump LauncherPopulationPolicy CRD
+        if: always()
+        run: kubectl get crd launcherpopulationpolicies.fma.llm-d.ai -o yaml
 
       - name: Run E2E tests
         env:

--- a/api/fma/v1alpha1/inferenceserverconfig_types.go
+++ b/api/fma/v1alpha1/inferenceserverconfig_types.go
@@ -44,7 +44,18 @@ type ModelServerConfig struct {
 	// EnvVars are the environment variables for the vLLM instance
 	// +optional
 	EnvVars     map[string]string `json:"env_vars,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+
+	// Labels are applied to the server-providing Pod while bound.
+	// Keys must be valid Kubernetes label keys and must not use reserved prefixes
+	// (dual-pods.llm-d.ai/, kubernetes.io/, k8s.io/).
+	// Values must be valid Kubernetes label values.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Annotations are applied to the server-providing Pod while bound.
+	// Keys must be valid Kubernetes annotation keys and must not use reserved prefixes
+	// (dual-pods.llm-d.ai/, kubernetes.io/, k8s.io/).
+	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 

--- a/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
+++ b/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
@@ -54,6 +54,10 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
+                    description: |-
+                      Annotations are applied to the server-providing Pod while bound.
+                      Keys must be valid Kubernetes annotation keys and must not use reserved prefixes
+                      (dual-pods.llm-d.ai/, kubernetes.io/, k8s.io/).
                     type: object
                   env_vars:
                     additionalProperties:
@@ -64,6 +68,11 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
+                    description: |-
+                      Labels are applied to the server-providing Pod while bound.
+                      Keys must be valid Kubernetes label keys and must not use reserved prefixes
+                      (dual-pods.llm-d.ai/, kubernetes.io/, k8s.io/).
+                      Values must be valid Kubernetes label values.
                     type: object
                   options:
                     description: Options are the vLLM startup options, excluding Port

--- a/config/validating-admission-policies/fma-immutable-fields.yaml
+++ b/config/validating-admission-policies/fma-immutable-fields.yaml
@@ -25,6 +25,8 @@ spec:
         (
           oldObject.metadata.?annotations['dual-pods.llm-d.ai/requester'].orValue('') == object.metadata.?annotations['dual-pods.llm-d.ai/requester'].orValue('') &&
           oldObject.metadata.?annotations['dual-pods.llm-d.ai/status'].orValue('') == object.metadata.?annotations['dual-pods.llm-d.ai/status'].orValue('') &&
+          oldObject.metadata.?annotations['dual-pods.llm-d.ai/isc-label-keys'].orValue('') == object.metadata.?annotations['dual-pods.llm-d.ai/isc-label-keys'].orValue('') &&
+          oldObject.metadata.?annotations['dual-pods.llm-d.ai/isc-annotation-keys'].orValue('') == object.metadata.?annotations['dual-pods.llm-d.ai/isc-annotation-keys'].orValue('') &&
           oldObject.metadata.?labels['dual-pods.llm-d.ai/dual'].orValue('') == object.metadata.?labels['dual-pods.llm-d.ai/dual'].orValue('')
         )
       message: "One or more annotations/labels are managed by FMA controllers and cannot be modified directly."

--- a/docs/e2e-recipe.md
+++ b/docs/e2e-recipe.md
@@ -532,9 +532,9 @@ spec:
       VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
-      component: inference
+      example.fma.llm-d.ai/isc-label: example-value
     annotations:
-      description: "Example InferenceServerConfig"
+      example.fma.llm-d.ai/isc-annotation: example-value
   launcherConfigName: my-launcher-config
 ---
 apiVersion: fma.llm-d.ai/v1alpha1

--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -83,8 +83,10 @@ import (
 // of the server-requesting Pod.
 // An inference server's UID is the UID of the server-requesting Pod.
 
-const requesterAnnotationKey = "dual-pods.llm-d.ai/requester"
-const nominalHashAnnotationKey = "dual-pods.llm-d.ai/nominal"
+const requesterAnnotationKey      = "dual-pods.llm-d.ai/requester"
+const nominalHashAnnotationKey    = "dual-pods.llm-d.ai/nominal"
+const iscLabelKeysAnnotationKey   = "dual-pods.llm-d.ai/isc-label-keys"
+const iscAnnotationKeysAnnotationKey = "dual-pods.llm-d.ai/isc-annotation-keys"
 
 const providerFinalizer = "dual-pods.llm-d.ai/provider"
 const requesterFinalizer = "dual-pods.llm-d.ai/requester"
@@ -294,8 +296,10 @@ type serverData struct {
 	GPUIndices    []string
 	GPUIndicesStr *string
 
-	ProvidingPodName string
-	InstanceID       string // if provider launcher-based
+	ProvidingPodName  string
+	InstanceID        string   // if provider launcher-based
+	ISCLabelKeys      []string // keys of ISC labels applied to providingPod
+	ISCAnnotationKeys []string // keys of ISC annotations applied to providingPod
 
 	ReadinessRelayed *bool
 

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -42,6 +42,7 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	k8sserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -52,6 +53,17 @@ import (
 	ctlrcommon "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
 	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
+
+var reservedKeyPrefixes = []string{"dual-pods.llm-d.ai/", "kubernetes.io/", "k8s.io/"}
+
+func hasReservedPrefix(key string) bool {
+	for _, prefix := range reservedKeyPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 type nodeItem struct {
 	NodeName string
@@ -354,6 +366,25 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 	// If there is already a bound server-providing Pod then ensure that it is awake,
 	// ensure status reported, and relay readiness if needed.
 	if providingPod != nil {
+		// Recover ISC label/annotation keys from tracking annotations after controller restart.
+		if serverDat.ISCLabelKeys == nil {
+			if v, ok := providingPod.Annotations[iscLabelKeysAnnotationKey]; ok {
+				if v == "" {
+					serverDat.ISCLabelKeys = []string{}
+				} else {
+					serverDat.ISCLabelKeys = strings.Split(v, " ")
+				}
+			}
+		}
+		if serverDat.ISCAnnotationKeys == nil {
+			if v, ok := providingPod.Annotations[iscAnnotationKeysAnnotationKey]; ok {
+				if v == "" {
+					serverDat.ISCAnnotationKeys = []string{}
+				} else {
+					serverDat.ISCAnnotationKeys = strings.Split(v, " ")
+				}
+			}
+		}
 		var serverPort int16
 		if launcherBased {
 			serverPort = int16(isc.Spec.ModelServerConfig.Port)
@@ -493,7 +524,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				logger.V(2).Info("Unexpected: multiple sleeping Pods match; using the first", "requesterName", requestingPod.Name)
 			}
 			providingPod = sleepingAnys[0].(*corev1.Pod)
-			return ctl.bind(ctx, serverDat, requestingPod, providingPod, nil, -1)
+			return ctl.bind(ctx, serverDat, requestingPod, providingPod, nil, -1, nil, nil)
 		}
 		// What remains is to make a new server-providing Pod --- if the sleeper budget allows.
 
@@ -591,7 +622,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				}
 				launcherDat.Instances[iscHash] = time.Now()
 				// TODO(waltforme): the bind method may need more revision to fully handle launcher-based server providing Pods
-				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(isc.Spec.ModelServerConfig.Port))
+				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(isc.Spec.ModelServerConfig.Port), isc.Spec.ModelServerConfig.Labels, isc.Spec.ModelServerConfig.Annotations)
 			} else {
 				// Slower path: create new instance in launcher with capacity
 				logger.V(5).Info("Creating new vLLM instance", "iscHash", iscHash)
@@ -605,7 +636,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				)
 				launcherDat.Instances[iscHash] = time.Now()
 				// TODO(waltforme): the bind method may need more revision to fully handle launcher-based server providing Pods
-				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(isc.Spec.ModelServerConfig.Port))
+				return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(isc.Spec.ModelServerConfig.Port), isc.Spec.ModelServerConfig.Labels, isc.Spec.ModelServerConfig.Annotations)
 			}
 		}
 	}
@@ -901,20 +932,63 @@ func (ctl *controller) enforceSleeperBudget(ctx context.Context, serverDat *serv
 
 // Note: instPort is used only for launcher-based server-providing Pods.
 // instanceID is non-nil iff launcher-based
-func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requestingPod, providingPod *corev1.Pod, instanceID *string, instPort int16) (error, bool) {
+func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requestingPod, providingPod *corev1.Pod, instanceID *string, instPort int16, iscLabels, iscAnnotations map[string]string) (error, bool) {
 	logger := klog.FromContext(ctx)
 	providingPod = providingPod.DeepCopy()
-	providingPod.Annotations[requesterAnnotationKey] = string(requestingPod.UID) + " " + requestingPod.Name
+	providingPod.Annotations = utils.MapSet(providingPod.Annotations, requesterAnnotationKey, string(requestingPod.UID)+" "+requestingPod.Name)
 	if !slices.Contains(providingPod.Finalizers, providerFinalizer) {
 		providingPod.Finalizers = append(providingPod.Finalizers, providerFinalizer)
 	}
 	providingPod.Labels = utils.MapSet(providingPod.Labels, api.DualLabelName, requestingPod.Name)
+	launcherBased := instanceID != nil
+	var problems []string
+	for k, v := range iscLabels {
+		if errs := k8svalidation.IsQualifiedName(k); len(errs) > 0 {
+			problems = append(problems, fmt.Sprintf("ISC label key %q is not a valid qualified name: %s", k, strings.Join(errs, "; ")))
+		} else if hasReservedPrefix(k) {
+			problems = append(problems, fmt.Sprintf("ISC label key %q uses a reserved prefix", k))
+		} else if _, exists := providingPod.Labels[k]; exists {
+			problems = append(problems, fmt.Sprintf("ISC label key %q collides with existing pod label", k))
+		}
+		if errs := k8svalidation.IsValidLabelValue(v); len(errs) > 0 {
+			problems = append(problems, fmt.Sprintf("ISC label value %q for key %q is not valid: %s", v, k, strings.Join(errs, "; ")))
+		}
+	}
+	for k := range iscAnnotations {
+		if errs := k8svalidation.IsQualifiedName(k); len(errs) > 0 {
+			problems = append(problems, fmt.Sprintf("ISC annotation key %q is not a valid qualified name: %s", k, strings.Join(errs, "; ")))
+		} else if hasReservedPrefix(k) {
+			problems = append(problems, fmt.Sprintf("ISC annotation key %q uses a reserved prefix", k))
+		} else if _, exists := providingPod.Annotations[k]; exists {
+			problems = append(problems, fmt.Sprintf("ISC annotation key %q collides with existing pod annotation", k))
+		}
+	}
+	if len(problems) > 0 {
+		return ctl.ensureReqStatus(ctx, requestingPod, serverDat, problems...)
+	}
+	labelKeys := make([]string, 0, len(iscLabels))
+	for k, v := range iscLabels {
+		providingPod.Labels[k] = v
+		labelKeys = append(labelKeys, k)
+	}
+	slices.Sort(labelKeys)
+	serverDat.ISCLabelKeys = labelKeys
+	annotationKeys := make([]string, 0, len(iscAnnotations))
+	for k, v := range iscAnnotations {
+		providingPod.Annotations[k] = v
+		annotationKeys = append(annotationKeys, k)
+	}
+	slices.Sort(annotationKeys)
+	serverDat.ISCAnnotationKeys = annotationKeys
+	if launcherBased {
+		providingPod.Annotations[iscLabelKeysAnnotationKey] = strings.Join(labelKeys, " ")
+		providingPod.Annotations[iscAnnotationKeysAnnotationKey] = strings.Join(annotationKeys, " ")
+	}
 	serverDat.Sleeping = nil
 	echo, err := ctl.coreclient.Pods(ctl.namespace).Update(ctx, providingPod, metav1.UpdateOptions{FieldManager: ControllerName})
 	if err != nil {
 		return fmt.Errorf("failed to bind server-providing Pod %s: %w", providingPod.Name, err), true
 	}
-	launcherBased := instanceID != nil
 	serverDat.ProvidingPodName = providingPod.Name
 	if launcherBased {
 		serverDat.InstanceID = *instanceID
@@ -1090,6 +1164,51 @@ func (ctl *controller) ensureUnbound(ctx context.Context, serverDat *serverData,
 	}
 	// Ensure finalizer is absent
 	providingPod.Finalizers, fChange = utils.SliceRemoveOnce(providingPod.Finalizers, providerFinalizer)
+	// Recover ISC label/annotation keys if not yet cached (e.g., controller restarted
+	// and ensureUnbound is reached before the normal reconciliation path).
+	if serverDat.ISCLabelKeys == nil {
+		if v, ok := providingPod.Annotations[iscLabelKeysAnnotationKey]; ok {
+			if v == "" {
+				serverDat.ISCLabelKeys = []string{}
+			} else {
+				serverDat.ISCLabelKeys = strings.Split(v, " ")
+			}
+		}
+	}
+	if serverDat.ISCAnnotationKeys == nil {
+		if v, ok := providingPod.Annotations[iscAnnotationKeysAnnotationKey]; ok {
+			if v == "" {
+				serverDat.ISCAnnotationKeys = []string{}
+			} else {
+				serverDat.ISCAnnotationKeys = strings.Split(v, " ")
+			}
+		}
+	}
+	// Remove ISC labels
+	for _, k := range serverDat.ISCLabelKeys {
+		if _, have := providingPod.Labels[k]; have {
+			delete(providingPod.Labels, k)
+			lChange = true
+		}
+	}
+	serverDat.ISCLabelKeys = nil
+	// Remove ISC annotations
+	for _, k := range serverDat.ISCAnnotationKeys {
+		if _, have := providingPod.Annotations[k]; have {
+			delete(providingPod.Annotations, k)
+			aChange = true
+		}
+	}
+	serverDat.ISCAnnotationKeys = nil
+	// Remove tracking annotations
+	if _, have := providingPod.Annotations[iscLabelKeysAnnotationKey]; have {
+		delete(providingPod.Annotations, iscLabelKeysAnnotationKey)
+		aChange = true
+	}
+	if _, have := providingPod.Annotations[iscAnnotationKeysAnnotationKey]; have {
+		delete(providingPod.Annotations, iscAnnotationKeysAnnotationKey)
+		aChange = true
+	}
 	if aChange || fChange || lChange {
 		if providingPod.Labels != nil {
 			delete(providingPod.Labels, api.DualLabelName)

--- a/test/e2e/deploy_fma.sh
+++ b/test/e2e/deploy_fma.sh
@@ -6,6 +6,8 @@
 # Deploys the FMA controllers (dual-pods controller + launcher-populator)
 # and waits for them to be available.
 #
+# Required tools: kubectl, helm, jq, yq (https://github.com/mikefarah/yq).
+#
 # Required environment variables:
 #   FMA_NAMESPACE              - target Kubernetes namespace
 #   FMA_CHART_INSTANCE_NAME    - Helm chart instance name
@@ -34,6 +36,14 @@ set -euo pipefail
 if [ "${FMA_DEBUG:-false}" = "true" ]; then
     set -x
 fi
+
+# Preflight: verify required tools are available
+for tool in kubectl helm jq yq; do
+    if ! command -v "$tool" &>/dev/null; then
+        echo "ERROR: required tool '$tool' is not installed" >&2
+        exit 1
+    fi
+done
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -89,8 +99,8 @@ CRD_NAMES=""
 for crd_file in config/crd/*.yaml; do
     crd_name=$(kubectl apply --dry-run=client -f "$crd_file" -o jsonpath='{.metadata.name}')
     CRD_NAMES="$CRD_NAMES $crd_name"
-    if kubectl get crd "$crd_name" &>/dev/null; then
-        echo "  CRD $crd_name already exists, skipping"
+    if kubectl get crd "$crd_name" -o json 2>/dev/null | jq -e --slurpfile desired <(yq -o json '.spec' "$crd_file") '.spec as $server | ($server * $desired[0]) == $server' &>/dev/null; then
+        echo "  CRD $crd_name already exists and is up to date, skipping"
     else
         echo "  Applying $crd_file ($crd_name)"
         kubectl apply --server-side -f "$crd_file"
@@ -178,7 +188,7 @@ helm upgrade --install "$FMA_CHART_INSTANCE_NAME" charts/fma-controllers \
 
 step "Wait for controllers to be ready"
 
-kubectl wait --for=condition=available --timeout=120s \
+kubectl wait --for=condition=available --timeout=180s \
     deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" -n "$FMA_NAMESPACE"
 kubectl wait --for=condition=available --timeout=120s \
     deployment "${FMA_CHART_INSTANCE_NAME}-launcher-populator" -n "$FMA_NAMESPACE"

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -118,9 +118,9 @@ spec:
       VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
-      component: inference
+      e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
-      description: "E2E test InferenceServerConfig"
+      e2e-test.fma.llm-d.ai/isc-annotation: test-value
   launcherConfigName: launcher-config-$inst
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
@@ -138,9 +138,9 @@ spec:
       VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
-      component: inference
+      e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
-      description: "E2E test InferenceServerConfig"
+      e2e-test.fma.llm-d.ai/isc-annotation: test-value
   launcherConfigName: launcher-config-$inst
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
@@ -158,9 +158,9 @@ spec:
       VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
-      component: inference
+      e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
-      description: "E2E test InferenceServerConfig"
+      e2e-test.fma.llm-d.ai/isc-annotation: test-value
   launcherConfigName: launcher-config-$inst
 ---
 apiVersion: fma.llm-d.ai/v1alpha1

--- a/test/e2e/mkobjs.sh
+++ b/test/e2e/mkobjs.sh
@@ -58,9 +58,9 @@ spec:
       VLLM_LOGGING_LEVEL: "DEBUG"
       VLLM_CPU_KVCACHE_SPACE: "1" # GiB, helpful for small models to reduce CPU memory usage during testing
     labels:
-      component: inference
+      e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
-      description: "Example InferenceServerConfig"
+      e2e-test.fma.llm-d.ai/isc-annotation: test-value
   launcherConfigName: launcher-config-$inst
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
@@ -79,9 +79,9 @@ spec:
       VLLM_LOGGING_LEVEL: "DEBUG"
       VLLM_CPU_KVCACHE_SPACE: "1" # GiB, helpful for small models to reduce CPU memory usage during testing
     labels:
-      component: inference
+      e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
-      description: "Example InferenceServerConfig"
+      e2e-test.fma.llm-d.ai/isc-annotation: test-value
   launcherConfigName: launcher-config-$inst
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
@@ -100,9 +100,9 @@ spec:
       VLLM_LOGGING_LEVEL: "DEBUG"
       VLLM_CPU_KVCACHE_SPACE: "1" # GiB, helpful for small models to reduce CPU memory usage during testing
     labels:
-      component: inference
+      e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
-      description: "Example InferenceServerConfig"
+      e2e-test.fma.llm-d.ai/isc-annotation: test-value
   launcherConfigName: launcher-config-$inst
 ---
 apiVersion: fma.llm-d.ai/v1alpha1

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -208,6 +208,10 @@ echo "Launcher Pod is $launcher1"
 # Verify requester is bound to launcher (bidirectional check)
 expect '[ "$(kubectl get pod -n '"$NS"' $req1 -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "$launcher1" ]'
 
+# Verify ISC labels and annotations were propagated to launcher
+[ "$(kubectl get pod -n "$NS" $launcher1 -o jsonpath='{.metadata.labels.e2e-test\.fma\.llm-d\.ai/isc-label}')" == "test-value" ] || { echo "ERROR: ISC label not propagated to launcher pod $launcher1"; exit 1; }
+[ "$(kubectl get pod -n "$NS" $launcher1 -o jsonpath='{.metadata.annotations.e2e-test\.fma\.llm-d\.ai/isc-annotation}')" == "test-value" ] || { echo "ERROR: ISC annotation not propagated to launcher pod $launcher1"; exit 1; }
+
 # Wait for both pods to be ready
 date
 kubectl wait --for condition=Ready pod/$req1 -n "$NS" --timeout=180s
@@ -349,6 +353,10 @@ kubectl get pod $launcher1 -n "$NS"
 # Verify launcher is unbound (no dual label pointing to requester)
 expect '[ "$(kubectl get pod -n '"$NS"' $launcher1 -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "" ]'
 
+# Verify ISC labels and annotations were removed from launcher
+[ "$(kubectl get pod -n "$NS" $launcher1 -o jsonpath='{.metadata.labels.e2e-test\.fma\.llm-d\.ai/isc-label}')" == "" ] || { echo "ERROR: ISC label not removed from launcher pod $launcher1 after unbind"; exit 1; }
+[ "$(kubectl get pod -n "$NS" $launcher1 -o jsonpath='{.metadata.annotations.e2e-test\.fma\.llm-d\.ai/isc-annotation}')" == "" ] || { echo "ERROR: ISC annotation not removed from launcher pod $launcher1 after unbind"; exit 1; }
+
 # Scale back up (should reuse same launcher and wake sleeping instance)
 kubectl scale rs $rs -n "$NS" --replicas=1
 
@@ -364,6 +372,10 @@ launcher2=$(kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/dual=$req2 |
 
 # Verify requester is bound to launcher (bidirectional check)
 expect '[ "$(kubectl get pod -n '"$NS"' $req2 -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "$launcher1" ]'
+
+# Verify ISC labels and annotations re-propagated after re-bind
+[ "$(kubectl get pod -n "$NS" $launcher1 -o jsonpath='{.metadata.labels.e2e-test\.fma\.llm-d\.ai/isc-label}')" == "test-value" ] || { echo "ERROR: ISC label not re-propagated to launcher pod $launcher1 after re-bind"; exit 1; }
+[ "$(kubectl get pod -n "$NS" $launcher1 -o jsonpath='{.metadata.annotations.e2e-test\.fma\.llm-d\.ai/isc-annotation}')" == "test-value" ] || { echo "ERROR: ISC annotation not re-propagated to launcher pod $launcher1 after re-bind"; exit 1; }
 
 # Wait for requester to be ready (launcher should already be ready)
 date

--- a/test/e2e/validate.sh
+++ b/test/e2e/validate.sh
@@ -88,6 +88,24 @@ else
   echo "✓ SUCCESS: annotation deletion was rejected, as expected"
 fi
 
+echo "Test 5b: Attempting to change immutable annotation 'dual-pods.llm-d.ai/isc-label-keys' on launcher pod — expect rejection"
+if output=$(kubectl annotate -n "$FMA_NAMESPACE" pod "${launcher1}" "dual-pods.llm-d.ai/isc-label-keys=tampered" --overwrite 2>&1); then
+  echo "ERROR: annotation change succeeded but should have been rejected"
+  echo "kubectl output: ${output}"
+  exit 51
+else
+  echo "✓ SUCCESS: annotation change was rejected, as expected"
+fi
+
+echo "Test 5c: Attempting to change immutable annotation 'dual-pods.llm-d.ai/isc-annotation-keys' on launcher pod — expect rejection"
+if output=$(kubectl annotate -n "$FMA_NAMESPACE" pod "${launcher1}" "dual-pods.llm-d.ai/isc-annotation-keys=tampered" --overwrite 2>&1); then
+  echo "ERROR: annotation change succeeded but should have been rejected"
+  echo "kubectl output: ${output}"
+  exit 52
+else
+  echo "✓ SUCCESS: annotation change was rejected, as expected"
+fi
+
 echo "Test 6: Attempting to change non-protected label on bound pod — expect no rejection"
 if output=$(kubectl label -n "$FMA_NAMESPACE" pod "${req1}" "regular-label=yes" --overwrite 2>&1); then
   echo "✓ SUCCESS: non-protected label update on bound pod allowed, as expected"


### PR DESCRIPTION
## Summary

- Propagates `InferenceServerConfig.spec.modelServerConfig.labels` and `.annotations` to the launcher Pod on bind, removes them on unbind
- Tracks applied keys via `dual-pods.llm-d.ai/isc-label-keys` and `dual-pods.llm-d.ai/isc-annotation-keys` annotations on the Pod, enabling correct removal after controller restart
- Protects the tracking annotations from non-controller mutation via the `fma-immutable-fields` ValidatingAdmissionPolicy

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] E2E: verify ISC label/annotation appear on launcher Pod after bind
- [x] E2E: verify ISC label/annotation removed from launcher Pod after unbind
- [x] E2E: verify ISC label/annotation re-appear after re-bind
- [x] E2E: verify ValidatingAdmissionPolicy rejects non-controller changes to tracking annotations

Resolves #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)