### PR TITLE
fix: populator retries after per-node reconciliation errors

### DIFF
--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -345,10 +345,10 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Node no longer exists, skipping reconciliation", "node", nodeName)
-		} else {
-			logger.Error(err, "Unexpected error from node lister (should be impossible), skipping reconciliation", "node", nodeName)
+			return false, nil
 		}
-		return false, nil
+		logger.Error(err, "Unexpected error from node lister (should be impossible), will retry", "node", nodeName)
+		return true, nil
 	}
 
 	didDelete := false

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -321,6 +321,7 @@ func (ctl *controller) reconcileAllLaunchers(ctx context.Context, desired map[No
 		needsRequeue, err := ctl.reconcileLaunchersOnSingleNode(ctx, nodeName, keys, desired)
 		if err != nil {
 			logger.Error(err, "Failed to reconcile launchers on node", "node", nodeName)
+			anyRequeueNeeded = true
 			continue
 		}
 		anyRequeueNeeded = anyRequeueNeeded || needsRequeue
@@ -344,9 +345,10 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Node no longer exists, skipping reconciliation", "node", nodeName)
-			return false, nil
+		} else {
+			logger.Error(err, "Unexpected error from node lister (should be impossible), skipping reconciliation", "node", nodeName)
 		}
-		return false, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		return false, nil
 	}
 
 	didDelete := false


### PR DESCRIPTION
## Summary

- When `reconcileLaunchersOnSingleNode` returned an error (e.g. a pod deletion failed due to a transient API error), `reconcileAllLaunchers` logged it and moved on without triggering a retry, leaving the cluster potentially inconsistent.
- Fix: set `anyRequeueNeeded = true` whenever a per-node error is returned, so the work item is requeued.
- Also collapse the `nodeLister.Get` error handling: the lister only ever returns NotFound in practice, so the non-NotFound branch is unreachable. It now logs distinctively rather than propagating an error.

## Test plan

- [x] Existing unit/integration tests pass
- [ ] Manual review: verify that a simulated pod-deletion error causes the item to be requeued

Fixes #462