### PR TITLE
Fixes #456 refine the status of LauncherPopulationPolicy

### DIFF
--- a/cmd/launcher-populator/main.go
+++ b/cmd/launcher-populator/main.go
@@ -89,6 +89,7 @@ func main() {
 	ctlr, err := launcherpopulator.NewController(
 		logger,
 		kubeClient.CoreV1(),
+		fmaClient.FmaV1alpha1(),
 		overrides.Context.Namespace,
 		kubePreInformers.Core().V1(),
 		fmaPreInformers,

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -246,19 +246,21 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 			// This is a user error: the LabelSelector in the policy's EnhancedNodeSelector is invalid.
 			// Report it in the policy's Status.Errors so the user can see it via kubectl.
 			logger.Error(selectorErr, "Invalid LabelSelector in policy, reporting in Status", "policy", lpp.Name)
-			if statusErr := ctl.reportLPPSelectorError(ctx, lpp, selectorErr); statusErr != nil {
+			if statusErr := ctl.setLPPStatusErrors(ctx, lpp, []string{selectorErr.Error()}); statusErr != nil {
 				logger.Error(statusErr, "Failed to update Status for policy", "policy", lpp.Name)
 			}
 			continue
+		}
+		// Clear any previously reported selector errors now that the selector is valid.
+		// This is done as soon as selectorErr == nil, before checking err, so that a
+		// transient infrastructure error does not prevent stale Status errors from being cleared.
+		if statusErr := ctl.setLPPStatusErrors(ctx, lpp, nil); statusErr != nil {
+			logger.Error(statusErr, "Failed to clear Status errors for policy", "policy", lpp.Name)
 		}
 		if err != nil {
 			// This is an infrastructure error: the lister failed to list nodes.
 			logger.Error(err, "Failed to get matching nodes for policy", "policy", lpp.Name)
 			continue
-		}
-		// Clear any previously reported selector errors now that the selector is valid.
-		if statusErr := ctl.clearLPPSelectorError(ctx, lpp); statusErr != nil {
-			logger.Error(statusErr, "Failed to clear Status errors for policy", "policy", lpp.Name)
 		}
 
 		for _, countRule := range lpp.Spec.CountForLauncher {

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -37,6 +37,7 @@ import (
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	genctlr "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
+	fmaclientv1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/clientset/versioned/typed/fma/v1alpha1"
 	fmainformers "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/informers/externalversions"
 	fmalisters "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/listers/fma/v1alpha1"
 )
@@ -52,6 +53,7 @@ type Controller interface {
 func NewController(
 	logger klog.Logger,
 	coreClient coreclient.CoreV1Interface,
+	fmaClient fmaclientv1alpha1.FmaV1alpha1Interface,
 	namespace string,
 	corev1PreInformers corev1preinformers.Interface,
 	fmaInformerFactory fmainformers.SharedInformerFactory,
@@ -59,6 +61,7 @@ func NewController(
 	ctl := &controller{
 		enqueueLogger: logger.WithName(ControllerName),
 		coreclient:    coreClient,
+		fmaclient:     fmaClient,
 		namespace:     namespace,
 		podInformer:   corev1PreInformers.Pods().Informer(),
 		podLister:     corev1PreInformers.Pods().Lister(),
@@ -97,6 +100,7 @@ func NewController(
 type controller struct {
 	enqueueLogger klog.Logger
 	coreclient    coreclient.CoreV1Interface
+	fmaclient     fmaclientv1alpha1.FmaV1alpha1Interface
 	namespace     string
 	podInformer   cache.SharedIndexInformer
 	podLister     corev1listers.PodLister
@@ -237,10 +241,24 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 
 	desired := make(map[NodeLauncherKey]DesiredStateEntry)
 	for _, lpp := range policies {
-		nodes, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
+		nodes, selectorErr, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
+		if selectorErr != nil {
+			// This is a user error: the LabelSelector in the policy's EnhancedNodeSelector is invalid.
+			// Report it in the policy's Status.Errors so the user can see it via kubectl.
+			logger.Error(selectorErr, "Invalid LabelSelector in policy, reporting in Status", "policy", lpp.Name)
+			if statusErr := ctl.reportLPPSelectorError(ctx, lpp, selectorErr); statusErr != nil {
+				logger.Error(statusErr, "Failed to update Status for policy", "policy", lpp.Name)
+			}
+			continue
+		}
 		if err != nil {
+			// This is an infrastructure error: the lister failed to list nodes.
 			logger.Error(err, "Failed to get matching nodes for policy", "policy", lpp.Name)
 			continue
+		}
+		// Clear any previously reported selector errors now that the selector is valid.
+		if statusErr := ctl.clearLPPSelectorError(ctx, lpp); statusErr != nil {
+			logger.Error(statusErr, "Failed to clear Status errors for policy", "policy", lpp.Name)
 		}
 
 		for _, countRule := range lpp.Spec.CountForLauncher {
@@ -283,16 +301,20 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 	return desired, nil
 }
 
-// getMatchingNodes returns nodes that match the EnhancedNodeSelector
-func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha1.EnhancedNodeSelector) ([]corev1.Node, error) {
-	// Use label selector to filter nodes
-	labelSelector, err := metav1.LabelSelectorAsSelector(&selector.LabelSelector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert label selector: %w", err)
+// getMatchingNodes returns nodes that match the EnhancedNodeSelector.
+// It returns three values: the matched nodes, a user-facing selector error (non-nil when the
+// LabelSelector itself is malformed — this is a user configuration error), and an internal
+// error (non-nil for unexpected infrastructure failures such as lister errors).
+// Callers should handle selectorErr and err independently.
+func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha1.EnhancedNodeSelector) ([]corev1.Node, error, error) {
+	// Convert the label selector. A failure here is a user error (malformed LabelSelector).
+	labelSelector, selectorErr := metav1.LabelSelectorAsSelector(&selector.LabelSelector)
+	if selectorErr != nil {
+		return nil, fmt.Errorf("invalid label selector: %w", selectorErr), nil
 	}
 	nodes, err := ctl.nodeLister.List(labelSelector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list nodes using nodeLister: %w", err)
+		return nil, nil, fmt.Errorf("failed to list nodes using nodeLister: %w", err)
 	}
 
 	var matchedNodes []corev1.Node
@@ -301,7 +323,7 @@ func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha
 			matchedNodes = append(matchedNodes, *node)
 		}
 	}
-	return matchedNodes, nil
+	return matchedNodes, nil, nil
 }
 
 // reconcileAllLaunchers adjusts all launcher pods according to final requirements.
@@ -352,8 +374,8 @@ func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeN
 	}
 
 	didDelete := false
-	deletionInProgress := false  // tracks pods already being deleted (DeletionTimestamp set)
-	deletionShortfall := false   // excess-pod deletion loop could not delete as many as needed
+	deletionInProgress := false // tracks pods already being deleted (DeletionTimestamp set)
+	deletionShortfall := false  // excess-pod deletion loop could not delete as many as needed
 
 	type creationInfo struct {
 		key   NodeLauncherKey

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -242,20 +242,9 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 	desired := make(map[NodeLauncherKey]DesiredStateEntry)
 	for _, lpp := range policies {
 		nodes, selectorErrs, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
-		if len(selectorErrs) > 0 {
-			// This is a user error: the LabelSelector in the policy's EnhancedNodeSelector is invalid.
-			// Report it in the policy's Status.Errors so the user can see it via kubectl.
-			logger.Error(nil, "Invalid LabelSelector in policy, reporting in Status", "policy", lpp.Name, "errors", selectorErrs)
-			if statusErr := ctl.setLPPStatusErrors(ctx, lpp, selectorErrs); statusErr != nil {
-				logger.Error(statusErr, "Failed to update Status for policy", "policy", lpp.Name)
-			}
-			continue
-		}
-		// Clear any previously reported selector errors now that the selector is valid.
-		// This is done as soon as selectorErrs is empty, before checking err, so that a
-		// transient infrastructure error does not prevent stale Status errors from being cleared.
-		if statusErr := ctl.setLPPStatusErrors(ctx, lpp, nil); statusErr != nil {
-			logger.Error(statusErr, "Failed to clear Status errors for policy", "policy", lpp.Name)
+		// Ensure proper status for lpp.
+		if statusErr := ctl.setLPPStatusErrors(ctx, lpp, selectorErrs); statusErr != nil {
+			logger.Error(statusErr, "Failed to set Status for policy", "policy", lpp.Name)
 		}
 		if err != nil {
 			// This is an infrastructure error: the lister failed to list nodes.

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -241,18 +241,18 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 
 	desired := make(map[NodeLauncherKey]DesiredStateEntry)
 	for _, lpp := range policies {
-		nodes, selectorErr, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
-		if selectorErr != nil {
+		nodes, selectorErrs, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
+		if len(selectorErrs) > 0 {
 			// This is a user error: the LabelSelector in the policy's EnhancedNodeSelector is invalid.
 			// Report it in the policy's Status.Errors so the user can see it via kubectl.
-			logger.Error(selectorErr, "Invalid LabelSelector in policy, reporting in Status", "policy", lpp.Name)
-			if statusErr := ctl.setLPPStatusErrors(ctx, lpp, []string{selectorErr.Error()}); statusErr != nil {
+			logger.Error(nil, "Invalid LabelSelector in policy, reporting in Status", "policy", lpp.Name, "errors", selectorErrs)
+			if statusErr := ctl.setLPPStatusErrors(ctx, lpp, selectorErrs); statusErr != nil {
 				logger.Error(statusErr, "Failed to update Status for policy", "policy", lpp.Name)
 			}
 			continue
 		}
 		// Clear any previously reported selector errors now that the selector is valid.
-		// This is done as soon as selectorErr == nil, before checking err, so that a
+		// This is done as soon as selectorErrs is empty, before checking err, so that a
 		// transient infrastructure error does not prevent stale Status errors from being cleared.
 		if statusErr := ctl.setLPPStatusErrors(ctx, lpp, nil); statusErr != nil {
 			logger.Error(statusErr, "Failed to clear Status errors for policy", "policy", lpp.Name)
@@ -304,15 +304,15 @@ func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[N
 }
 
 // getMatchingNodes returns nodes that match the EnhancedNodeSelector.
-// It returns three values: the matched nodes, a user-facing selector error (non-nil when the
+// It returns three values: the matched nodes, user-facing selector errors (non-nil when the
 // LabelSelector itself is malformed — this is a user configuration error), and an internal
 // error (non-nil for unexpected infrastructure failures such as lister errors).
-// Callers should handle selectorErr and err independently.
-func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha1.EnhancedNodeSelector) ([]corev1.Node, error, error) {
+// Callers should handle selectorErrs and err independently.
+func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha1.EnhancedNodeSelector) ([]corev1.Node, []string, error) {
 	// Convert the label selector. A failure here is a user error (malformed LabelSelector).
 	labelSelector, selectorErr := metav1.LabelSelectorAsSelector(&selector.LabelSelector)
 	if selectorErr != nil {
-		return nil, fmt.Errorf("invalid label selector: %w", selectorErr), nil
+		return nil, []string{fmt.Sprintf("invalid label selector: %v", selectorErr)}, nil
 	}
 	nodes, err := ctl.nodeLister.List(labelSelector)
 	if err != nil {

--- a/pkg/controller/launcher-populator/populator_status_handler.go
+++ b/pkg/controller/launcher-populator/populator_status_handler.go
@@ -1,0 +1,40 @@
+package launcherpopulator
+
+import (
+	"context"
+
+	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
+	applyfmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/applyconfiguration/fma/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// reportLPPSelectorError writes a selector validation error into the LauncherPopulationPolicy's
+// Status.Errors field using Server-Side Apply so the user can observe it via kubectl.
+func (ctl *controller) reportLPPSelectorError(ctx context.Context, lpp *fmav1alpha1.LauncherPopulationPolicy, selectorErr error) error {
+	apply := applyfmav1alpha1.LauncherPopulationPolicy(lpp.Name, lpp.Namespace).
+		WithStatus(applyfmav1alpha1.LauncherPopulationPolicyStatus().
+			WithObservedGeneration(lpp.Generation).
+			WithErrors(selectorErr.Error()))
+	_, err := ctl.fmaclient.LauncherPopulationPolicies(lpp.Namespace).ApplyStatus(ctx, apply, metav1.ApplyOptions{
+		FieldManager: ControllerName,
+		Force:        true,
+	})
+	return err
+}
+
+// clearLPPSelectorError clears any previously reported selector errors from the
+// LauncherPopulationPolicy's Status.Errors field using Server-Side Apply.
+func (ctl *controller) clearLPPSelectorError(ctx context.Context, lpp *fmav1alpha1.LauncherPopulationPolicy) error {
+	if len(lpp.Status.Errors) == 0 {
+		// Nothing to clear.
+		return nil
+	}
+	apply := applyfmav1alpha1.LauncherPopulationPolicy(lpp.Name, lpp.Namespace).
+		WithStatus(applyfmav1alpha1.LauncherPopulationPolicyStatus().
+			WithObservedGeneration(lpp.Generation))
+	_, err := ctl.fmaclient.LauncherPopulationPolicies(lpp.Namespace).ApplyStatus(ctx, apply, metav1.ApplyOptions{
+		FieldManager: ControllerName,
+		Force:        true,
+	})
+	return err
+}

--- a/pkg/controller/launcher-populator/populator_status_handler.go
+++ b/pkg/controller/launcher-populator/populator_status_handler.go
@@ -2,36 +2,26 @@ package launcherpopulator
 
 import (
 	"context"
+	"slices"
 
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	applyfmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/applyconfiguration/fma/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// reportLPPSelectorError writes a selector validation error into the LauncherPopulationPolicy's
-// Status.Errors field using Server-Side Apply so the user can observe it via kubectl.
-func (ctl *controller) reportLPPSelectorError(ctx context.Context, lpp *fmav1alpha1.LauncherPopulationPolicy, selectorErr error) error {
-	apply := applyfmav1alpha1.LauncherPopulationPolicy(lpp.Name, lpp.Namespace).
-		WithStatus(applyfmav1alpha1.LauncherPopulationPolicyStatus().
-			WithObservedGeneration(lpp.Generation).
-			WithErrors(selectorErr.Error()))
-	_, err := ctl.fmaclient.LauncherPopulationPolicies(lpp.Namespace).ApplyStatus(ctx, apply, metav1.ApplyOptions{
-		FieldManager: ControllerName,
-		Force:        true,
-	})
-	return err
-}
-
-// clearLPPSelectorError clears any previously reported selector errors from the
-// LauncherPopulationPolicy's Status.Errors field using Server-Side Apply.
-func (ctl *controller) clearLPPSelectorError(ctx context.Context, lpp *fmav1alpha1.LauncherPopulationPolicy) error {
-	if len(lpp.Status.Errors) == 0 {
-		// Nothing to clear.
+// setLPPStatusErrors sets the LauncherPopulationPolicy's Status.Errors to desiredErrors using
+// Server-Side Apply. Pass nil or an empty slice to clear all errors.
+// The call is skipped when the current Status already matches (same errors and same
+// ObservedGeneration), avoiding unnecessary API round-trips.
+func (ctl *controller) setLPPStatusErrors(ctx context.Context, lpp *fmav1alpha1.LauncherPopulationPolicy, desiredErrors []string) error {
+	if lpp.Status.ObservedGeneration == lpp.Generation && slices.Equal(lpp.Status.Errors, desiredErrors) {
+		// Status already reflects the desired state; nothing to do.
 		return nil
 	}
 	apply := applyfmav1alpha1.LauncherPopulationPolicy(lpp.Name, lpp.Namespace).
 		WithStatus(applyfmav1alpha1.LauncherPopulationPolicyStatus().
-			WithObservedGeneration(lpp.Generation))
+			WithObservedGeneration(lpp.Generation).
+			WithErrors(desiredErrors...))
 	_, err := ctl.fmaclient.LauncherPopulationPolicies(lpp.Namespace).ApplyStatus(ctx, apply, metav1.ApplyOptions{
 		FieldManager: ControllerName,
 		Force:        true,

--- a/pkg/controller/launcher-populator/populator_status_handler.go
+++ b/pkg/controller/launcher-populator/populator_status_handler.go
@@ -18,13 +18,11 @@ func (ctl *controller) setLPPStatusErrors(ctx context.Context, lpp *fmav1alpha1.
 		// Status already reflects the desired state; nothing to do.
 		return nil
 	}
-	apply := applyfmav1alpha1.LauncherPopulationPolicy(lpp.Name, lpp.Namespace).
-		WithStatus(applyfmav1alpha1.LauncherPopulationPolicyStatus().
-			WithObservedGeneration(lpp.Generation).
-			WithErrors(desiredErrors...))
-	_, err := ctl.fmaclient.LauncherPopulationPolicies(lpp.Namespace).ApplyStatus(ctx, apply, metav1.ApplyOptions{
-		FieldManager: ControllerName,
-		Force:        true,
-	})
+	lpp = lpp.DeepCopy()
+	lpp.Status = LauncherPopulationPolicyStatus{
+	    ObservedGeneration: lpp.Generation,
+	    Errors: desiredErrors}
+	echo, err := ctl.fmaclient.LauncherPopulationPolicies(lpp.Namespace).Update(ctx, lpp, metav1.UpdateOptions{FieldManager: ControllerName})
+	klog.FromContext(ctx).V(4).Info("Updated LauncherPopulationPolicyStatus", "name", lpp.Name, "observedGeneration", lpp.Generation, "errors", desiredErrors, "resourceVersion", echo.ResourceVersion)
 	return err
 }

--- a/pkg/controller/launcher-populator/populator_status_handler.go
+++ b/pkg/controller/launcher-populator/populator_status_handler.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
-	applyfmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/applyconfiguration/fma/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 // setLPPStatusErrors sets the LauncherPopulationPolicy's Status.Errors to desiredErrors using
@@ -18,11 +18,16 @@ func (ctl *controller) setLPPStatusErrors(ctx context.Context, lpp *fmav1alpha1.
 		// Status already reflects the desired state; nothing to do.
 		return nil
 	}
-	lpp = lpp.DeepCopy()
-	lpp.Status = LauncherPopulationPolicyStatus{
-	    ObservedGeneration: lpp.Generation,
-	    Errors: desiredErrors}
-	echo, err := ctl.fmaclient.LauncherPopulationPolicies(lpp.Namespace).Update(ctx, lpp, metav1.UpdateOptions{FieldManager: ControllerName})
-	klog.FromContext(ctx).V(4).Info("Updated LauncherPopulationPolicyStatus", "name", lpp.Name, "observedGeneration", lpp.Generation, "errors", desiredErrors, "resourceVersion", echo.ResourceVersion)
+	lppCopy := lpp.DeepCopy()
+	lppCopy.Status = fmav1alpha1.LauncherPopulationPolicyStatus{
+		ObservedGeneration: lpp.Generation,
+		Errors:             desiredErrors,
+	}
+	echo, err := ctl.fmaclient.LauncherPopulationPolicies(lppCopy.Namespace).Update(ctx, lppCopy, metav1.UpdateOptions{FieldManager: ControllerName})
+	resourceVersion := ""
+	if echo != nil {
+		resourceVersion = echo.ResourceVersion
+	}
+	klog.FromContext(ctx).V(4).Info("Updated LauncherPopulationPolicyStatus", "name", lppCopy.Name, "observedGeneration", lppCopy.Generation, "errors", desiredErrors, "resourceVersion", resourceVersion)
 	return err
 }


### PR DESCRIPTION
Fixes #456 

## Background:

If the error is from metav1.LabelSelectorAsSelector(&selector.LabelSelector) then this is a user error that should be reported in the Status of the LauncherPopulationPolicy. Can be done in a follow-on PR.

Originally posted by @MikeSpreitzer in https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/374#discussion_r3145072076