### PR TITLE
Consolidate internal state of the dual-pods controller

### DIFF
--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -306,9 +306,10 @@ type serverData struct {
 
 	ProvidingPodName     string
 	InstanceID           string // ISC hash; set when computed, independent of instance existence
-	InstanceKnownToExist bool   // meaningful only for launcher-based providers
-	ISCLabelKeys      []string // keys of ISC labels applied to providingPod
-	ISCAnnotationKeys []string // keys of ISC annotations applied to providingPod
+	InstanceConfig       *VllmConfig
+	InstanceKnownToExist bool     // meaningful only for launcher-based providers
+	ISCLabelKeys         []string // keys of ISC labels applied to providingPod
+	ISCAnnotationKeys    []string // keys of ISC annotations applied to providingPod
 
 	ReadinessRelayed *bool
 

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -365,13 +365,17 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 	var cfg *VllmConfig
 	var iscHash string
 	if launcherBased {
-		cfg, iscHash, err = ctl.configInferenceServer(isc, serverDat.GPUIDs)
-		if err != nil {
-			return fmt.Errorf("failed to configure inference server config: %w", err), true
-		}
-		if serverDat.InstanceID == "" {
+		if serverDat.InstanceConfig == nil {
+			cfg, iscHash, err = ctl.configInferenceServer(isc, serverDat.GPUIDs)
+			if err != nil {
+				return fmt.Errorf("failed to configure inference server config: %w", err), true
+			}
+			serverDat.InstanceConfig = cfg
 			serverDat.InstanceID = iscHash
 			serverDat.ServerPort = int16(isc.Spec.ModelServerConfig.Port)
+		} else {
+			cfg = serverDat.InstanceConfig
+			iscHash = serverDat.InstanceID
 		}
 	}
 
@@ -399,7 +403,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		}
 		var serverPort int16
 		if launcherBased {
-			serverPort = int16(isc.Spec.ModelServerConfig.Port)
+			serverPort = serverDat.ServerPort
 		} else {
 			_, serverPort, err = utils.GetInferenceServerContainerIndexAndPort(providingPod)
 			if err != nil { // Impossible, because such a providingPod would never be created by this controller
@@ -472,7 +476,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				logger.V(5).Info("Created vLLM instance", "instance_id", result.InstanceID, "status", result.Status)
 				// If ISC tracking annotations are missing (pre-bound pod), propagate the ISC metadata.
 				if _, propagated := providingPod.Annotations[iscLabelKeysAnnotationKey]; !propagated {
-					return ctl.bind(ctx, serverDat, requestingPod, providingPod, &serverDat.InstanceID, int16(isc.Spec.ModelServerConfig.Port),
+					return ctl.bind(ctx, serverDat, requestingPod, providingPod, &serverDat.InstanceID, serverDat.ServerPort,
 						isc.Spec.ModelServerConfig.Labels, isc.Spec.ModelServerConfig.Annotations, true)
 				}
 			}
@@ -613,7 +617,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		return err, false
 	}
 
-	desiredPort := isc.Spec.ModelServerConfig.Port
+	desiredPort := int32(serverDat.ServerPort)
 	logger.V(5).Info("Nominal hash of InferenceServerConfig", "hash", iscHash)
 
 	if len(launcherPodAnys) > 0 {
@@ -638,7 +642,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			// The "bound provider" path will handle instance creation/waking.
 			// This ensures the invariant: vllm awake implies provider Pod is bound.
 			logger.V(5).Info("Selected launcher Pod, binding first", "name", launcherPod.Name, "hasSleepingInstance", hasSleepingInstance)
-			return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, int16(isc.Spec.ModelServerConfig.Port), isc.Spec.ModelServerConfig.Labels, isc.Spec.ModelServerConfig.Annotations, true)
+			return ctl.bind(ctx, serverDat, requestingPod, launcherPod, &iscHash, serverDat.ServerPort, isc.Spec.ModelServerConfig.Labels, isc.Spec.ModelServerConfig.Annotations, true)
 		}
 	}
 	// Remains: Zero matching launcher Pods, or the matching launcher Pod cannot host more instances to fulfill the request.
@@ -1301,10 +1305,6 @@ func (ctl *controller) ensureUnbound(ctx context.Context, serverDat *serverData,
 	} else {
 		logger.V(3).Info("Server-providing Pod remains unbound", "name", providingPod.Name, "resourceVersion", providingPod.ResourceVersion)
 	}
-	serverDat.ProvidingPodName = ""
-	serverDat.ServerPort = -1
-	serverDat.InstanceID = ""
-	serverDat.InstanceKnownToExist = false
 	return nil
 }
 

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -321,7 +321,7 @@ else
     expect '[ "$(kubectl get pod -n '"$NS"' '"$collision_req"' -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "'"$collision_launcher"'" ]'
 
     date
-    kubectl wait --for condition=Ready pod/$collision_req -n "$NS" --timeout=120s
+    kubectl wait --for condition=Ready pod/$collision_req -n "$NS" --timeout=180s
     [ "$(kubectl get pod $collision_launcher -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
     req_gpus=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')


### PR DESCRIPTION
This PR introduces a little consolidation to the internal state of the dual-pods controller by addressing https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/443#discussion_r3143987814 and https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/443#discussion_r3144018244.

For the e2e test, the PR also now gives the same timeout (180s) to the 2nd cold-started inference server (the colliding one) with the 1st cold-started inference server.