### PR TITLE
Revise test-cases to always check GPU pin; randomize test-requester GPU pick

### DIFF
--- a/cmd/test-requester/README.md
+++ b/cmd/test-requester/README.md
@@ -7,6 +7,20 @@ in a ConfigMap named "gpu-allocs".
 
 For details, see the comment at the start of [the source](main.go).
 
+## GPU selection
+
+Among the GPUs on the Node that are not already allocated to another
+Pod, the test requester picks `--num-gpus` of them at random. If the
+`NVIDIA_VISIBLE_DEVICES` environment variable is set to anything other
+than `all` (for example, a comma-separated list of GPU UUIDs injected
+by the NVIDIA device plugin), the requester restricts its choices to
+that subset; the special values `void` and `none` mean "no GPUs
+visible" and cause allocation to fail. Tests that need a specific GPU
+identity across scale-up should pin it via `NVIDIA_VISIBLE_DEVICES` on
+the Pod template (see `pin_gpu` in `test/e2e/test-cases.sh`), rather
+than relying on the first-available ordering used by earlier versions
+of this program.
+
 The command line arguments are as follows.
 
 ## Requester specific arguments

--- a/cmd/test-requester/gpu-allocation.go
+++ b/cmd/test-requester/gpu-allocation.go
@@ -33,7 +33,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	dpctlr "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods"
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
 
 	"k8s.io/klog/v2"
 )
@@ -136,11 +135,11 @@ func allocateGPUs(ctx context.Context, coreClient corev1client.CoreV1Interface, 
 			return err
 		}
 		avail := gpuMap.onNode(nodeName)
-		podUIDs, err := getPodUIDs(ctx, podClient)
+		podMap, err := getPodMap(ctx, podClient)
 		if err != nil {
 			return err
 		}
-		if !podUIDs.Has(podUID) {
+		if _, has := podMap[podUID]; !has {
 			return fmt.Errorf("pod UID %q not found among current Pods", podUID)
 		}
 		// Get the current allocations, as a data structure and as a ConfigMap object.
@@ -148,6 +147,7 @@ func allocateGPUs(ctx context.Context, coreClient corev1client.CoreV1Interface, 
 		if err != nil {
 			return err
 		}
+		logger.V(5).Info("Read GPU allocations", "gpuAllocMap", gpuAllocMap)
 		// Collect the ones used by other Pods on the same Node,
 		// and remove obsolete entries from the ConfigMap.
 		used := sets.New[string]()
@@ -155,10 +155,14 @@ func allocateGPUs(ctx context.Context, coreClient corev1client.CoreV1Interface, 
 			if holder.NodeName != nodeName {
 				continue
 			}
-			if !podUIDs.Has(holder.PodUID) {
+			if holderName, held := podMap[holder.PodUID]; !held {
+				logger.V(5).Info("Removing entry for non-existent Pod", "gpuUID", gpuUID, "holderUID", holder.PodUID)
 				delete(gpuAllocCM.Data, gpuUID)
 			} else if holder.PodUID != podUID {
+				logger.V(5).Info("Noting usage", "gpuUID", gpuUID, "holderUID", holder.PodUID, "holderName", holderName)
 				used.Insert(gpuUID)
+			} else {
+				logger.V(5).Info("Noting availability", "gpuUID", gpuUID)
 			}
 		}
 		// Compute the sorted list of unused GPUs on the right Node.
@@ -200,13 +204,15 @@ func allocateGPUs(ctx context.Context, coreClient corev1client.CoreV1Interface, 
 	return gpuUIDs
 }
 
-func getPodUIDs(ctx context.Context, podClient corev1client.PodInterface) (sets.Set[apitypes.UID], error) {
+// Returns map from Pod UID to name
+func getPodMap(ctx context.Context, podClient corev1client.PodInterface) (map[apitypes.UID]string, error) {
 	podList, err := podClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	uids, _ := utils.SliceMap(podList.Items, func(pod corev1.Pod) (apitypes.UID, error) {
-		return pod.UID, nil
-	})
-	return sets.New(uids...), nil
+	ans := make(map[apitypes.UID]string, len(podList.Items))
+	for _, pod := range podList.Items {
+		ans[pod.UID] = pod.Name
+	}
+	return ans, nil
 }

--- a/cmd/test-requester/gpu-allocation.go
+++ b/cmd/test-requester/gpu-allocation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"strings"
 	"time"
@@ -36,6 +37,33 @@ import (
 
 	"k8s.io/klog/v2"
 )
+
+const nvidiaVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"
+
+// visibleGPUFilter reads NVIDIA_VISIBLE_DEVICES and returns (filter, restricted).
+// restricted=false means "no filter" (env unset, empty, or value "all").
+// A returned empty set with restricted=true means "no GPUs visible"
+// (values "void"/"none"); caller should refuse to allocate.
+func visibleGPUFilter() (sets.Set[string], bool) {
+	raw, present := os.LookupEnv(nvidiaVisibleDevicesEnvVar)
+	if !present {
+		return nil, false
+	}
+	switch strings.TrimSpace(raw) {
+	case "", "all":
+		return nil, false
+	case "void", "none":
+		return sets.New[string](), true
+	}
+	filter := sets.New[string]()
+	for uid := range strings.SplitSeq(raw, ",") {
+		uid = strings.TrimSpace(uid)
+		if uid != "" {
+			filter.Insert(uid)
+		}
+	}
+	return filter, true
+}
 
 // This code maintains a ConfigMap named "gpu-allocs" that holds the current test allocations
 // of GPUs. The data of this ConfigMap is a map from GPU UID to the JSON marshaling of a GPUHolder.
@@ -135,6 +163,15 @@ func allocateGPUs(ctx context.Context, coreClient corev1client.CoreV1Interface, 
 			return err
 		}
 		avail := gpuMap.onNode(nodeName)
+		if filter, restricted := visibleGPUFilter(); restricted {
+			for uid := range filter.Difference(avail) {
+				logger.V(5).Info("Ignoring NVIDIA_VISIBLE_DEVICES entry not present on node", "gpuUID", uid, "nodeName", nodeName)
+			}
+			for uid := range avail.Difference(filter) {
+				logger.V(5).Info("Excluding node GPU hidden by NVIDIA_VISIBLE_DEVICES", "gpuUID", uid, "nodeName", nodeName)
+			}
+			avail = avail.Intersection(filter)
+		}
 		podMap, err := getPodMap(ctx, podClient)
 		if err != nil {
 			return err
@@ -165,13 +202,15 @@ func allocateGPUs(ctx context.Context, coreClient corev1client.CoreV1Interface, 
 				logger.V(5).Info("Noting availability", "gpuUID", gpuUID)
 			}
 		}
-		// Compute the sorted list of unused GPUs on the right Node.
+		// Compute the list of unused GPUs on the right Node, then shuffle it so
+		// that selection is non-deterministic --- closer to what the real Kubernetes
+		// scheduler + NVIDIA device plugin would do. When NVIDIA_VISIBLE_DEVICES is
+		// set, `avail` has already been narrowed to that subset above.
 		rem := sets.List(avail.Difference(used))
 		if uint(len(rem)) < numGPUs {
 			return fmt.Errorf("fewer than %d GPUs available (%v) for node %q", numGPUs, rem, nodeName)
 		}
-		// Take the requested number
-		// FROM THE HEAD OF THE LIST --- this is a choice to aid making repeatable tests.
+		rand.Shuffle(len(rem), func(i, j int) { rem[i], rem[j] = rem[j], rem[i] })
 		gpuUIDs = rem[:numGPUs]
 		for _, gpuUID := range gpuUIDs {
 			holder := GPUHolder{NodeName: nodeName, PodUID: podUID}

--- a/test/e2e/mkobjs.sh
+++ b/test/e2e/mkobjs.sh
@@ -191,6 +191,7 @@ spec:
           - --node=\$(NODE_NAME)
           - --pod-uid=\$(POD_UID)
           - --namespace=\$(NAMESPACE)
+          - -v=5
           env:
             - name: NODE_NAME
               valueFrom:

--- a/test/e2e/run-launcher-based.sh
+++ b/test/e2e/run-launcher-based.sh
@@ -169,5 +169,4 @@ FMA_NAMESPACE=default \
 MKOBJS_SCRIPT=./test/e2e/mkobjs.sh \
 FMA_CHART_INSTANCE_NAME=fma \
 READY_TARGET=1 \
-E2E_PLATFORM=kind \
 ./test/e2e/test-cases.sh

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -13,7 +13,6 @@
 #   FMA_CHART_INSTANCE_NAME - Helm release name prefix (default: fma)
 #   READY_TARGET            - minimum ready launchers before proceeding (default: 2)
 #   POLICIES_ENABLED        - "true"/"false"; auto-detected if unset
-#   E2E_PLATFORM            - "openshift" or "kind" (default: openshift)
 #   POLL_LIMIT_SECS         - polling timeout seconds (default: 600)
 #   FMA_DEBUG               - "true" to enable shell tracing (set -x)
 
@@ -28,7 +27,6 @@ fi
 POLL_LIMIT_SECS="${POLL_LIMIT_SECS:-600}"
 READY_TARGET="${READY_TARGET:-2}"
 FMA_CHART_INSTANCE_NAME="${FMA_CHART_INSTANCE_NAME:-fma}"
-E2E_PLATFORM="${E2E_PLATFORM:-openshift}"
 
 NS="$FMA_NAMESPACE"
 
@@ -72,9 +70,9 @@ expect() {
 }
 
 # pin_gpu patches the ReplicaSet so subsequent pods reuse the same GPU UUID.
-# Sets nvidia.com/gpu limit/request to 0 (bypassing OpenShift's GPU assignment
-# on that platform) and injects NVIDIA_VISIBLE_DEVICES. On kind the test-requester
-# honors this to restrict its random GPU pick to the pinned UUID.
+# Sets nvidia.com/gpu limit/request to 0 (bypassing the NVIDIA device plugin's
+# fresh assignment on OpenShift) and injects NVIDIA_VISIBLE_DEVICES, which the
+# test-requester honors to restrict its random GPU pick to the pinned UUID.
 # Uses global $assigned_gpu_uuids and $NS.
 # Arguments: <rs-name>
 pin_gpu() {

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -226,15 +226,10 @@ date
 kubectl wait --for condition=Ready pod/$req1 -n "$NS" --timeout=180s
 [ "$(kubectl get pod $launcher1 -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-# On OpenShift, record the GPU UUID assigned by the cluster so we can pin it later.
-# The controller writes the UUID(s) to the dual-pods.llm-d.ai/accelerators annotation
-# after querying the requester's SPI endpoint; it is guaranteed to be set by the time
-# the pod is Ready.
-if [ "$E2E_PLATFORM" = "openshift" ]; then
-    expect '[ -n "$(kubectl get pod -n '"$NS"' $req1 -o jsonpath={.metadata.annotations.dual-pods\\.llm-d\\.ai/accelerators})" ]'
-    assigned_gpu_uuids=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
-    echo "Assigned GPU UUID(s) on OpenShift: $assigned_gpu_uuids"
-fi
+# Discover and remember the assigned GPUs.
+expect '[ -n "$(kubectl get pod -n '"$NS"' $req1 -o jsonpath={.metadata.annotations.dual-pods\\.llm-d\\.ai/accelerators})" ]'
+assigned_gpu_uuids=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
+echo "Assigned GPU UUID(s): $assigned_gpu_uuids"
 
 cheer Successful launcher-based pod creation
 
@@ -396,7 +391,7 @@ kubectl wait --for condition=Ready pod/$req2 -n "$NS" --timeout=120s
 [ "$(kubectl get pod $launcher1 -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
 # On OpenShift, verify the same GPU UUID was assigned after wake-up.
-if [ "$E2E_PLATFORM" = "openshift" ]; then check_gpu_pin $req2; fi
+check_gpu_pin $req2
 
 cheer Successful instance wake-up fast path
 
@@ -441,7 +436,7 @@ date
 kubectl wait --for condition=Ready pod/$req3 -n "$NS" --timeout=120s
 [ "$(kubectl get pod $launcher1 -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-if [ "$E2E_PLATFORM" = "openshift" ]; then check_gpu_pin $req3; fi
+check_gpu_pin $req3
 
 cheer Successful multiple instances sharing one launcher
 
@@ -486,7 +481,7 @@ date
 kubectl wait --for condition=Ready pod/$req4 -n "$NS" --timeout=120s
 [ "$(kubectl get pod $launcher1 -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-if [ "$E2E_PLATFORM" = "openshift" ]; then check_gpu_pin $req4; fi
+check_gpu_pin $req4
 
 cheer Successful switching instances in one launcher
 
@@ -552,7 +547,7 @@ date
 kubectl wait --for condition=Ready pod/$req_post_restart -n "$NS" --timeout=30s
 [ "$(kubectl get pod $launcher1 -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-if [ "$E2E_PLATFORM" = "openshift" ]; then check_gpu_pin $req_post_restart; fi
+check_gpu_pin $req_post_restart
 
 cheer Successful controller restart state recovery
 
@@ -650,7 +645,7 @@ kubectl wait --for condition=Ready pod/$req_after_delete -n "$NS" --timeout=120s
 [ "$(kubectl get pod $launcher_after_delete -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
 # Check that the new requester has the proper GPU UUIDs annotation.
-if [ "$E2E_PLATFORM" = "openshift" ]; then check_gpu_pin $req_after_delete; fi
+check_gpu_pin $req_after_delete
 
 cheer Successful unbound launcher deletion cleanup
 
@@ -666,8 +661,8 @@ intro_case Stopped Instance Recovery
 #
 # Starting state: $req_after_delete is bound to $launcher_after_delete, both Ready.
 
-echo "Bound requester: $req_after_delete, launcher: $launcher_after_delete"
 req_uid_before=$(kubectl get pod $req_after_delete -n "$NS" -o jsonpath='{.metadata.uid}')
+echo "Bound requester: $req_after_delete (UID $req_uid_before), launcher: $launcher_after_delete"
 
 # Get the running instance ID from the launcher
 instance_id=$(kubectl exec -n "$NS" $launcher_after_delete -c inference-server -- python3 -c '
@@ -717,7 +712,7 @@ date
 kubectl wait --for condition=Ready pod/$req_recovered -n "$NS" --timeout=120s
 [ "$(kubectl get pod $launcher_after_delete -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-if [ "$E2E_PLATFORM" = "openshift" ]; then check_gpu_pin $req_recovered; fi
+check_gpu_pin $req_recovered
 
 cheer Successful stopped instance recovery
 

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -71,9 +71,10 @@ expect() {
     done
 }
 
-# pin_gpu patches the ReplicaSet to bypass OpenShift's GPU assignment.
-# Sets nvidia.com/gpu limit/request to 0 and injects NVIDIA_VISIBLE_DEVICES
-# so subsequent pods reuse the same GPU UUID without going through the device plugin.
+# pin_gpu patches the ReplicaSet so subsequent pods reuse the same GPU UUID.
+# Sets nvidia.com/gpu limit/request to 0 (bypassing OpenShift's GPU assignment
+# on that platform) and injects NVIDIA_VISIBLE_DEVICES. On kind the test-requester
+# honors this to restrict its random GPU pick to the pinned UUID.
 # Uses global $assigned_gpu_uuids and $NS.
 # Arguments: <rs-name>
 pin_gpu() {
@@ -345,8 +346,8 @@ kubectl scale rs $rs -n "$NS" --replicas=0
 
 expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$inst | wc -l | grep -w 0"
 
-# On OpenShift, pin the GPU so the next scale-up reuses the same GPU.
-if [ "$E2E_PLATFORM" = "openshift" ]; then pin_gpu $rs; fi
+# Pin the GPU so the next scale-up reuses the same GPU on every platform.
+pin_gpu $rs
 
 # Patch requester ReplicaSet to stick to testnode
 kubectl patch rs $rs -n "$NS" -p '{"spec": {"template": {"spec": {"nodeSelector": {"kubernetes.io/hostname": "'$testnode'"} }} }}'
@@ -390,7 +391,7 @@ date
 kubectl wait --for condition=Ready pod/$req2 -n "$NS" --timeout=120s
 [ "$(kubectl get pod $launcher1 -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
 
-# On OpenShift, verify the same GPU UUID was assigned after wake-up.
+# Verify the same GPU UUID was assigned after wake-up.
 check_gpu_pin $req2
 
 cheer Successful instance wake-up fast path


### PR DESCRIPTION
The GPU assignment logic works regardless of OpenShift or not.

Also extends the test-requester's fake GPU allocator to behave more
like the real Kubernetes scheduler + NVIDIA device plugin:

- Pick among unused GPUs at random rather than from the head of the
  sorted list.
- If `NVIDIA_VISIBLE_DEVICES` is set on the requester container,
  restrict the candidate set to those UUIDs (`all` means no
  restriction; `void`/`none` means no GPUs visible and fails
  allocation).

Existing tests pin the picked UUID via `pin_gpu` before scale-up,
so randomizing the initial pick does not affect them.

Fixes #409