### PR TITLE
Sync docs/upstream-versions.md with actual go.mod pins

### DIFF
--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,10 +8,10 @@
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |-----------|-------------|----------|---------------|---------------|
 | **Go** | `1.24.2` | version | `go.mod` line 3 | [golang/go](https://github.com/golang/go) |
-| **k8s.io/api** | `v0.34.0` | tag | `go.mod` line 7 | [kubernetes/api](https://github.com/kubernetes/api) |
-| **k8s.io/apimachinery** | `v0.34.0` | tag | `go.mod` line 8 | [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery) |
-| **k8s.io/client-go** | `v0.34.0` | tag | `go.mod` line 9 | [kubernetes/client-go](https://github.com/kubernetes/client-go) |
-| **sigs.k8s.io/controller-runtime** | `v0.22.1` | tag | `go.mod` line 12 | [kubernetes-sigs/controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) |
+| **k8s.io/api** | `v0.34.7` | tag | `go.mod` line 7 | [kubernetes/api](https://github.com/kubernetes/api) |
+| **k8s.io/apimachinery** | `v0.34.7` | tag | `go.mod` line 8 | [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery) |
+| **k8s.io/client-go** | `v0.34.7` | tag | `go.mod` line 9 | [kubernetes/client-go](https://github.com/kubernetes/client-go) |
+| **sigs.k8s.io/controller-runtime** | `v0.22.5` | tag | `go.mod` line 12 | [kubernetes-sigs/controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) |
 | **vllm/vllm-openai** | `v0.15.1` | tag | `cmd/requester/README.md` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
 | **vllm (CPU build)** | `v0.15.1` | tag | `dockerfiles/Dockerfile.launcher.cpu` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
 | **nvidia/cuda** | `12.8.0-base-ubuntu22.04` | tag | `dockerfiles/Dockerfile.requester` | [NVIDIA CUDA](https://hub.docker.com/r/nvidia/cuda) |


### PR DESCRIPTION
## Summary
- Update the k8s.io/* pins (`v0.34.0` → `v0.34.7`) and sigs.k8s.io/controller-runtime (`v0.22.1` → `v0.22.5`) in `docs/upstream-versions.md` to match the current `go.mod`.

Fixes #315.

Note: the issue was filed when go.mod had `v0.34.4` / `v0.22.5`; go.mod has since advanced to `v0.34.7` for the k8s.io packages, so this PR uses the current go.mod values (the stated source of truth).

## Test plan
- [x] `typos docs/upstream-versions.md` clean
- [x] Values verified against `go.mod` lines 7-9 and 12