### PR TITLE
Also dump log(s) of previous dual-pods controller

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -535,12 +535,16 @@ jobs:
         run: |
           if [ -r dual-pods-controller-first-prev.log ]
           then cat dual-pods-controller-first-prev.log
-          else echo The previous dual-pods controller ran at most once
+          else echo The first dual-pods controller ran at most once
           fi
 
       - name: Dump log of first dual-pods controller
         if: always()
-        run: cat dual-pods-controller-first.log
+        run: |
+          if [ -r dual-pods-controller-first.log ]
+          then cat dual-pods-controller-first.log
+          else echo The first dual-pods controller left no log
+          fi
 
       - name: Dump Pod logs
         if: always()

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -530,6 +530,18 @@ jobs:
         if: always()
         run: kubectl get events -n "$FMA_NAMESPACE" --sort-by='.lastTimestamp'
 
+      - name: Dump previous log of first dual-pods controller
+        if: always()
+        run: |
+          if [ -r dual-pods-controller-first-prev.log ]
+          then cat dual-pods-controller-first-prev.log
+          else echo The previous dual-pods controller ran at most once
+          fi
+
+      - name: Dump log of first dual-pods controller
+        if: always()
+        run: cat dual-pods-controller-first.log
+
       - name: Dump Pod logs
         if: always()
         run: |

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -68,6 +68,18 @@ jobs:
         if: always()
         run: kubectl get rs -A
 
+      - name: Dump previous log of first dual-pods controller
+        if: always()
+        run: |
+          if [ -r dual-pods-controller-first-prev.log ]
+          then cat dual-pods-controller-first-prev.log
+          else echo The previous dual-pods controller ran at most once
+          fi
+
+      - name: Dump log of first dual-pods controller
+        if: always()
+        run: cat dual-pods-controller-first.log
+
       - name: show dual-pods controller log
         if: always()
         run: kubectl logs deploy/fma-dual-pods-controller

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -73,12 +73,16 @@ jobs:
         run: |
           if [ -r dual-pods-controller-first-prev.log ]
           then cat dual-pods-controller-first-prev.log
-          else echo The previous dual-pods controller ran at most once
+          else echo The first dual-pods controller ran at most once
           fi
 
       - name: Dump log of first dual-pods controller
         if: always()
-        run: cat dual-pods-controller-first.log
+        run: |
+          if [ -r dual-pods-controller-first.log ]
+          then cat dual-pods-controller-first.log
+          else echo The first dual-pods controller left no log
+          fi
 
       - name: show dual-pods controller log
         if: always()

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -182,6 +182,8 @@ date
 kubectl wait --for condition=Ready pod/$req --timeout=35s
 kubectl wait --for condition=Ready pod/$prv --timeout=1s
 
+kubectl get pods -o wide
+
 cheer Successful upside
 
 : Test node deletion
@@ -194,6 +196,11 @@ kubectl delete node $doomed
 LIMIT=100 expect '[ $(kubectl get ds -n kube-system kube-proxy -o jsonpath={.status.currentNumberScheduled}) == "2" ]'
 expect '! kubectl get pod $req'
 expect '! kubectl get pod $prv'
+
+
+expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -vw 0 | grep -vw 1"
+
+kubectl get pods -o wide
 
 expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -w 2"
 
@@ -223,6 +230,8 @@ expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -w 1"
 
 sleep 10 # does it stay that way?
 
+kubectl get pods -o wide
+
 kubectl get pods -o name | grep -c "^pod/$rs" | grep -w 1
 
 kubectl get pod $prv -L dual-pods.llm-d.ai/dual
@@ -232,6 +241,10 @@ cheer Successful requester deletion
 : Scale back up and check for re-use of existing provider
 
 kubectl scale rs $rs --replicas=1
+
+expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -vw 0 | grep -vw 1"
+
+kubectl get pods -o wide
 
 expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -w 2"
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -42,6 +42,24 @@ function clear_img_repo() (
     done
 )
 
+# pin_gpu patches the ReplicaSet so subsequent pods reuse the same GPU
+# UUID.  Sets nvidia.com/gpu limit/request to 0 (bypassing the NVIDIA
+# device plugin's fresh assignment) and injects
+# NVIDIA_VISIBLE_DEVICES, which the test-requester honors to restrict
+# its random GPU pick to the pinned UUID.
+# Uses global $assigned_gpu_uuids.
+# Arguments: <rs-name>
+pin_gpu() {
+    local rs="$1"
+    echo "Pinning GPU for ReplicaSet $rs: NVIDIA_VISIBLE_DEVICES=$assigned_gpu_uuids" >&2
+    local patch
+    patch=$(printf \
+        '{"spec":{"template":{"spec":{"containers":[{"name":"inference-server","resources":{"limits":{"nvidia.com/gpu":"0"},"requests":{"nvidia.com/gpu":"0"}},"env":[{"name":"NVIDIA_VISIBLE_DEVICES","value":"%s"}]}]}}}}' \
+        "$assigned_gpu_uuids")
+    kubectl patch rs "$rs" -p "$patch"
+}
+
+
 : Build the container images, no push
 
 clear_img_repo ko.local/test-requester
@@ -219,6 +237,10 @@ kubectl wait --for condition=Ready pod/$prv --timeout=1s
 used=$(kubectl get pod $req -o jsonpath={.spec.nodeName})
 [ "$used" == "$keeper" ]
 
+assigned_gpu_uuids=$(kubectl get pod "$req" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
+echo "Assigned GPU UUID(s): $assigned_gpu_uuids"
+
+
 cheer Successful test of node deletion
 
 : Test requester deletion
@@ -232,13 +254,21 @@ sleep 10 # does it stay that way?
 
 kubectl get pods -o wide
 
-kubectl get pods -o name | grep -c "^pod/$rs" | grep -w 1
-
 kubectl get pod $prv -L dual-pods.llm-d.ai/dual
+
+kubectl get pods -o name | grep -c "^pod/$rs" | grep -w 1
 
 cheer Successful requester deletion
 
-: Scale back up and check for re-use of existing provider
+: Alter RS, to pin GPUs
+
+pin_gpu $rs
+
+: Delete provider, it becomes irrelevant after changing the RS
+
+kubectl delete pod $prv
+
+: Scale up, identify new requester and provider
 
 kubectl scale rs $rs --replicas=1
 
@@ -248,9 +278,26 @@ kubectl get pods -o wide
 
 expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -w 2"
 
-sleep 10
+pods=($(kubectl get pods -o name | grep "^pod/$rs" | sed s%pod/%%))
+req=${pods[0]}
+prv=${pods[1]}
 
-kubectl get pods -o name | grep -c "^pod/$rs" | grep -w 2
+expect '[ "$(kubectl get pod $req -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "$prv" ]'
+
+expect '[ "$(kubectl get pod $prv -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "$req" ]'
+
+cheer Successful pin of GPUs
+
+: Delete requester, expect replacement using same provider
+
+kubectl delete pod $req
+
+expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -vw 0 | grep -vw 1"
+
+kubectl get pods -o wide
+
+expect "kubectl get pods -o name | grep -c '^pod/$rs' | grep -w 2"
+
 kubectl get pods -o name -l app=dp-example | grep -c "^pod/$rs" | grep -w 1
 
 nrq=$(kubectl get pods -o name -l app=dp-example | grep "^pod/$rs" | sed s%pod/%%)
@@ -262,7 +309,7 @@ expect '[ "$(kubectl get pod $nrq -o jsonpath={.metadata.labels.dual-pods\\.llm-
 expect '[ "$(kubectl get pod $prv -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "$nrq" ]'
 
 date
-kubectl wait --for condition=Ready pod/$nrq --timeout=10s
+kubectl wait --for condition=Ready pod/$nrq --timeout=35s
 kubectl wait --for condition=Ready pod/$prv --timeout=1s
 
 cheer Successful re-use

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -69,10 +69,11 @@ expect() {
     done
 }
 
-# pin_gpu patches the ReplicaSet so subsequent pods reuse the same GPU UUID.
-# Sets nvidia.com/gpu limit/request to 0 (bypassing the NVIDIA device plugin's
-# fresh assignment on OpenShift) and injects NVIDIA_VISIBLE_DEVICES, which the
-# test-requester honors to restrict its random GPU pick to the pinned UUID.
+# pin_gpu patches the ReplicaSet so subsequent pods reuse the same GPU
+# UUID.  Sets nvidia.com/gpu limit/request to 0 (bypassing the NVIDIA
+# device plugin's fresh assignment) and injects
+# NVIDIA_VISIBLE_DEVICES, which the test-requester honors to restrict
+# its random GPU pick to the pinned UUID.
 # Uses global $assigned_gpu_uuids and $NS.
 # Arguments: <rs-name>
 pin_gpu() {

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -509,6 +509,11 @@ launcher_instances_before=$(kubectl exec -n "$NS" $launcher1 -- python3 -c 'impo
 echo "Launcher has $launcher_instances_before instances before controller restart"
 [ "$launcher_instances_before" -gt "0" ]
 
+# Save log(s) from the current controller Pod, which is about to be replaced
+kubectl get -n "$NS" deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller"
+kubectl logs -n "$NS" deployment/"${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" > dual-pods-controller-first.log
+kubectl logs -n "$NS" deployment/"${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" -p > dual-pods-controller-first-prev.log || true
+
 # Restart the dual-pods controller to test state recovery
 echo "Restarting dual-pods controller..."
 kubectl rollout restart deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" -n "$NS"


### PR DESCRIPTION
This PR extends the test-cases.sh and debug dumping job steps so that the log(s) of the first dual-pods controller are included.

Fixes: #446 
Fixes: #481 