### PR TITLE
Simplify LauncherConfig object names in E2E tests

### DIFF
--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -121,7 +121,7 @@ spec:
       e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
       e2e-test.fma.llm-d.ai/isc-annotation: test-value
-  launcherConfigName: launcher-config-$inst
+  launcherConfigName: "$inst"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: InferenceServerConfig
@@ -141,7 +141,7 @@ spec:
       e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
       e2e-test.fma.llm-d.ai/isc-annotation: test-value
-  launcherConfigName: launcher-config-$inst
+  launcherConfigName: "$inst"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: InferenceServerConfig
@@ -161,12 +161,12 @@ spec:
       e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
       e2e-test.fma.llm-d.ai/isc-annotation: test-value
-  launcherConfigName: launcher-config-$inst
+  launcherConfigName: "$inst"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: LauncherConfig
 metadata:
-  name: launcher-config-$inst
+  name: "$inst"
   labels:
     fma-e2e-instance: "$inst"
 spec:
@@ -215,7 +215,7 @@ spec:
       matchLabels:
         nvidia.com/gpu.present: "true"
   countForLauncher:
-    - launcherConfigName: launcher-config-$inst
+    - launcherConfigName: "$inst"
       launcherCount: 1
 ---
 apiVersion: apps/v1
@@ -266,7 +266,7 @@ EOF
        )
 then
     echo inference-server-config-smol-$inst
-    echo launcher-config-$inst
+    echo "$inst"
     echo my-request-$inst
     echo inference-server-config-qwen-$inst
     echo inference-server-config-tinyllama-$inst

--- a/test/e2e/mkobjs.sh
+++ b/test/e2e/mkobjs.sh
@@ -61,7 +61,7 @@ spec:
       e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
       e2e-test.fma.llm-d.ai/isc-annotation: test-value
-  launcherConfigName: launcher-config-$inst
+  launcherConfigName: "$inst"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: InferenceServerConfig
@@ -82,7 +82,7 @@ spec:
       e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
       e2e-test.fma.llm-d.ai/isc-annotation: test-value
-  launcherConfigName: launcher-config-$inst
+  launcherConfigName: "$inst"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: InferenceServerConfig
@@ -103,12 +103,12 @@ spec:
       e2e-test.fma.llm-d.ai/isc-label: test-value
     annotations:
       e2e-test.fma.llm-d.ai/isc-annotation: test-value
-  launcherConfigName: launcher-config-$inst
+  launcherConfigName: "$inst"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: LauncherConfig
 metadata:
-  name: launcher-config-$inst
+  name: "$inst"
   labels:
     instance: "$inst"
     fma-e2e-instance: "$inst"
@@ -157,7 +157,7 @@ spec:
       matchLabels:
         nvidia.com/gpu.present: "true"
   countForLauncher:
-    - launcherConfigName: launcher-config-$inst
+    - launcherConfigName: "$inst"
       launcherCount: 1
 ---
 apiVersion: apps/v1
@@ -225,7 +225,7 @@ EOF
 then
     # output to be parsed by caller, e.g. the e2e test script
     echo inference-server-config-smol-$inst
-    echo launcher-config-$inst
+    echo "$inst"
     echo my-request-$inst
     echo inference-server-config-qwen-$inst
     echo inference-server-config-tinyllama-$inst


### PR DESCRIPTION
Removed "launcher config" from the names of these objects, because Kubernetes objects do not need Hungarian notation and this extra verbosity makes the names of the launcher Pods stutter (e.g., "launcher-launcher-config-$inst").

This follows up on a comment on an earlier PR: https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/374#discussion_r3148593422
