### PR TITLE
Retain more docker logging in CI

### DIFF
--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -44,13 +44,16 @@ jobs:
           then echo Old daemon.json:
                cat /etc/docker/daemon.json
                echo
-               jq '. * {"log-opts": {"max-size":"20m", "max-file": "5"}}' /etc/docker/daemon.json > nudaemon.json && sudo mv -f nudaemon.json /etc/docker/daemon.json
+               jq '. * {"log-opts": {"max-size":"50m", "max-file": "3"}}' /etc/docker/daemon.json > nudaemon.json && (cat nudaemon.json | sudo tee /etc/docker/daemon.json > /dev/null)
                echo New daemon.json:
-               cat /etc/docker/daemon.json
+               cat nudaemon.json
+               rm nudaemon.json
                sudo systemctl restart docker.service
+               systemctl status docker.service
           else echo There is no old daemon.json, here is the new:
-               echo '{"log-opts": {"max-size":"20m", "max-file": "5"}}' | sudo tee /etc/docker/daemon.json
+               echo '{"log-opts": {"max-size":"50m", "max-file": "3"}}' | sudo tee /etc/docker/daemon.json
                sudo systemctl restart docker.service
+               systemctl status docker.service
           fi
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -38,6 +38,20 @@ jobs:
   run-launcher-test:
     runs-on: ubuntu-22.04-arm
     steps:
+      - name: Retain more docker logs
+        run: |
+          if [ -f /etc/docker/daemon.json ]
+          then echo Old daemon.json:
+               cat /etc/docker/daemon.json
+               echo
+               jq '. * {"log-opts": {"max-size":"20m", "max-file": "5"}}' /etc/docker/daemon.json > nudaemon.json && sudo mv -f nudaemon.json /etc/docker/daemon.json
+               echo New daemon.json:
+               cat /etc/docker/daemon.json
+               sudo systemctl restart docker.service
+          else echo There is no old daemon.json, here is the new:
+               echo '{"log-opts": {"max-size":"20m", "max-file": "5"}}' | sudo tee /etc/docker/daemon.json
+               sudo systemctl restart docker.service
+          fi
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.24.2'


### PR DESCRIPTION
This PR increases the volume of docker log retention in the workflow that runs launcher-based E2E on a `kind` cluster (OpenShift requires a different solution).

This is intended to help with part of #446 .