### PR TITLE
Fix broken workflow references to llm-d-infra reusable workflows

### DIFF
--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -3,7 +3,7 @@ on: pull_request_target
 
 jobs:
   signed-commits:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yaml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   gatekeeper:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yaml@main

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   prow:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yaml@main

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   auto-merge:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yaml@main

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -3,4 +3,4 @@ on: pull_request
 
 jobs:
   remove-lgtm:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yaml@main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   unstale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yaml@main
     permissions:
       issues: write


### PR DESCRIPTION
## Summary
- Upstream [llm-d/llm-d-infra#153](https://github.com/llm-d/llm-d-infra/pull/153) renamed all reusable workflow files from `.yml` to `.yaml`, breaking every workflow in this repo that referenced them (see e.g. [this failed run](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/actions/runs/25509088445)).
- Update the seven affected workflow files to use the new `.yaml` extension on the referenced reusable workflows.

Fixes #489

## Test plan
- [ ] Confirm the workflows that consume these reusable workflows succeed on this PR (signed-commits, non-main-gatekeeper, prow-commands, etc.).
- [ ] Spot-check that no remaining `reusable-*.yml@main` references exist under `.github/workflows/`.