### PR TITLE
Requester tcp proxy v2

### DIFF
--- a/cmd/requester/README.md
+++ b/cmd/requester/README.md
@@ -2,6 +2,74 @@ This document shows the steps to exercise the requester and dual-pods controller
 in a local k8s environment with model `ibm-granite/granite-3.3-2b-instruct`
 cached on local PV in the cluster.
 
+## Requester Overview
+
+The requester executable runs in the requester container of a server-requesting
+Pod. Its purpose is two-fold:
+
+1. **Look to the rest of llm-d like an inference server.** The requester listens
+   on the same set of ports an inference server would and forwards client traffic
+   to the bound vLLM instance via a built-in TCP reverse proxy.
+2. **Relay controller-bound state to and from the dual-pods controller.** The
+   requester exposes a small SPI surface so that the dual-pods controller can
+   read GPU IDs, push the bound server's address, and update readiness state.
+
+Adding the reverse TCP proxy makes the requester look *more* like an inference
+server than it otherwise would: client requests can be sent directly to the
+requester Pod's IP and the proxy forwards them to the actual server-providing
+Pod after binding.
+
+The server-requesting Pod runs three servers:
+
+| Server | Default Port | Purpose |
+|--------|-------------|---------|
+| Probes | 8080 | Readiness relay (`/ready` endpoint) — reflects the health status of the bound inference server |
+| SPI | 8081 | Dual-pods controller interface (`/v1/dual-pods/accelerators`, `/v1/proxy/config`) — exposes GPU info and accepts proxy configuration from the controller |
+| Proxy | 8082 | TCP reverse proxy listen port — accepts client connections and forwards them to the bound vLLM instance; rejects connections until configured |
+
+### TCP Proxy
+
+The requester includes a **TCP proxy** that forwards traffic to the bound inference server.
+After the dual-pods controller binds the requester to a server-providing Pod, it configures
+the proxy target via a `PUT` to the SPI endpoint at `/v1/proxy/config`. You can query the
+current proxy configuration with `GET /v1/proxy/config`.
+
+## Command-line flags
+
+### Port Configuration
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--probes-port` | `8080` | Port number for readiness/liveness probes |
+| `--spi-port` | `8081` | Port for dual-pods SPI requests |
+| `--proxy-port` | `8082` | TCP proxy listen port for forwarding client connections |
+
+### Proxy Configuration
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--proxy-dial-timeout` | `10s` | Timeout for dialing the backend inference server |
+
+### Logging (klog)
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--logtostderr` | `true` | Log to standard error instead of files |
+| `--alsologtostderr` | — | Log to standard error as well as files (no effect when `--logtostderr=true`) |
+| `--log_dir` | — | If non-empty, write log files in this directory (no effect when `--logtostderr=true`) |
+| `--log_file` | — | If non-empty, use this log file (no effect when `--logtostderr=true`) |
+| `--log_file_max_size` | `1800` | Maximum size a log file can grow to, in MB (no effect when `--logtostderr=true`) |
+| `--log_backtrace_at` | `:0` | When logging hits line file:N, emit a stack trace |
+| `--v` | `0` | Number for the log level verbosity |
+| `--vmodule` | — | Comma-separated list of pattern=N settings for file-filtered logging |
+| `--stderrthreshold` | `2` | Logs at or above this threshold go to stderr (no effect when `--logtostderr=true`) |
+| `--one_output` | — | Only write logs to their native severity level (no effect when `--logtostderr=true`) |
+| `--skip_headers` | — | Avoid header prefixes in log messages |
+| `--skip_log_headers` | — | Avoid headers when opening log files (no effect when `--logtostderr=true`) |
+| `--add_dir_header` | — | Add the file directory to the header of log messages |
+
+## Local Testing
+
 Build and push the requester container image (use your favorate
 `CONTAINER_IMG_REG`) with a command like the following. You can omit
 the `TARGETARCH` if the runtime ISA matches your build time ISA.
@@ -114,10 +182,12 @@ spec:
             containerPort: 8080
           - name: spi
             containerPort: 8081
+          - name: proxy
+            containerPort: 8082
           readinessProbe:
             httpGet:
-              path: /ready
-              port: 8080
+              path: /health
+              port: 8082
             initialDelaySeconds: 2
             periodSeconds: 5
           resources:
@@ -198,10 +268,12 @@ spec:
             containerPort: 8080
           - name: spi
             containerPort: 8081
+          - name: proxy
+            containerPort: 8082
           readinessProbe:
             httpGet:
-              path: /ready
-              port: 8080
+              path: /health
+              port: 8082
             initialDelaySeconds: 2
             periodSeconds: 5
           resources:
@@ -268,6 +340,9 @@ ports:
   - containerPort: 8081
     name: spi
     protocol: TCP
+  - containerPort: 8082
+    name: proxy
+    protocol: TCP
 readinessProbe:
   failureThreshold: 3
   httpGet:
@@ -299,11 +374,13 @@ Check the relayed readiness.
 ```console
 $ kubectl wait pod/my-request-5n2m6-dual-2wn7w --for=condition=Ready --timeout=120s
 pod/my-request-5n2m6-dual-2wn7w condition met
-$ curl $REQ_IP:8080/ready
-OK
+$ curl $REQ_IP:8082/health
+{"status":"ok"}
 ```
 
 Make an inference request.
+
+### Direct to inference server
 ```console
 $ kubectl get po -owide
 NAME                          READY   STATUS    RESTARTS   AGE     IP           NODE               NOMINATED NODE   READINESS GATES
@@ -320,12 +397,30 @@ $ curl -s http://10.0.0.145:8000/v1/completions \
 {"id":"cmpl-cfe04f79eb904748891561c76ae29986","object":"text_completion","created":1763768447,"model":"ibm-granite/granite-3.3-2b-instruct","choices":[{"index":0,"text":" Paris, which is known for its rich history, cultural landmarks, and iconic architecture like the Eiffel Tower and Notre","logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":5,"total_tokens":35,"completion_tokens":30,"prompt_tokens_details":null},"kv_transfer_params":null}
 ```
 
+### Via the TCP proxy
+```console
+$ curl -s http://$REQ_IP:8082/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ibm-granite/granite-3.3-2b-instruct",
+    "prompt": "The capital of France is",
+    "max_tokens": 30
+  }'
+{"id":"...","object":"text_completion","created":1763768447,"model":"ibm-granite/granite-3.3-2b-instruct",...}
+
+$ # Verify proxy configuration via SPI endpoint
+$ curl -s http://$REQ_IP:8081/v1/proxy/config
+{"address":"10.0.0.145","port":8000}
+```
+
 Check the log of the server-requesting pod.
 ```console
 $ kubectl logs my-request-5n2m6
 I1121 23:22:48.119370       1 server.go:64] "starting server" logger="probes-server" port="8080"
 I1121 23:22:48.142001       1 server.go:84] "Got GPU UUIDs" logger="spi-server" uuids=["GPU-0d1d8df2-4bc7-98fe-1d41-a5d13a5866d1"]
 I1121 23:22:48.142119       1 server.go:171] "starting server" logger="spi-server" port="8081"
+I1121 23:22:48.142200       1 server.go:67] "Starting TCP proxy server" logger="proxy-server" port=8082 dialTimeout="10s"
+I1121 23:22:48.142300       1 server.go:90] "TCP proxy server listening" logger="proxy-server" port=8082 target="10.0.0.145:8000"
 I1121 23:30:32.039243       1 server.go:139] "Setting ready" logger="spi-server" newReady=false
 I1121 23:37:13.904292       1 server.go:139] "Setting ready" logger="spi-server" newReady=true
 ```

--- a/cmd/requester/main.go
+++ b/cmd/requester/main.go
@@ -19,56 +19,72 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination"
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"github.com/spf13/pflag"
 
 	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/config"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/proxy"
 )
 
 func main() {
+	cfg := config.NewDefault()
+
 	klog.InitFlags(nil)
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	cfg.AddFlags(pflag.CommandLine)
+	pflag.Parse()
 
 	// set up signals so we handle the shutdown signal gracefully
 	ctx := signals.SetupSignalHandler()
 	logger := klog.FromContext(ctx)
 
-	// Read ports from environment variables, fallback to defaults
-	probesPort := os.Getenv("PROBES_PORT")
-	if probesPort == "" {
-		probesPort = "8080"
-	}
-
-	spiPort := os.Getenv("SPI_PORT")
-	if spiPort == "" {
-		spiPort = "8081"
-	}
+	pflag.CommandLine.VisitAll(func(f *pflag.Flag) {
+		logger.V(1).Info("Config", "flag", f.Name, "value", f.Value.String())
+	})
 
 	var ready atomic.Bool
+	proxySrv := proxy.New(cfg.Proxy)
 
 	var wg sync.WaitGroup
-	wg.Add(2)
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
-		err := coordination.Run(ctx, spiPort, &ready, os.Stdout)
+		err := coordination.Run(ctx, strconv.FormatUint(uint64(cfg.SPIPort), 10), &ready, os.Stdout, proxySrv.Configure)
 		if err != nil {
-			logger.Error(err, "failed to start requester SPI server")
+			logger.Error(err, "failed to run requester SPI server")
 		}
 	}()
 
 	// Start the readiness probe server
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
-		err := probes.Run(ctx, probesPort, &ready)
+		err := probes.Run(ctx, strconv.FormatUint(uint64(cfg.ProbesPort), 10), &ready)
 		if err != nil {
-			logger.Error(err, "failed to start requester probes server")
+			logger.Error(err, "failed to run requester probes server")
+		}
+	}()
+
+	// Start the reverse proxy server
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		err := proxySrv.Run(ctx)
+		if err != nil {
+			logger.Error(err, "failed to run requester proxy server")
 		}
 	}()
 

--- a/cmd/test-requester/main.go
+++ b/cmd/test-requester/main.go
@@ -30,12 +30,14 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination"
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"k8s.io/klog/v2"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/config"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/proxy"
 )
 
 // This variant requester emulates the GPU allocation behavior of
@@ -58,8 +60,7 @@ func main() {
 	overrides := &clientcmd.ConfigOverrides{}
 	var nodeName, podUID string
 	numGPUs := uint(1)
-	probesPort := int16(8080)
-	spiPort := int16(8081)
+	cfg := config.NewDefault()
 
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -67,8 +68,7 @@ func main() {
 	pflag.CommandLine.StringVar(&nodeName, "node", nodeName, "name of this Pod's Node")
 	pflag.CommandLine.StringVar(&podUID, "pod-uid", podUID, "UID of this Pod")
 	pflag.CommandLine.UintVar(&numGPUs, "num-gpus", numGPUs, "number of GPUs to allocate")
-	pflag.CommandLine.Int16Var(&probesPort, "probes-port", probesPort, "port number for /ready")
-	pflag.CommandLine.Int16Var(&spiPort, "spi-port", spiPort, "port for dual-pods requests")
+	cfg.AddFlags(pflag.CommandLine)
 
 	pflag.Parse()
 
@@ -108,26 +108,38 @@ func main() {
 	gpuUUIDs := allocateGPUs(ctx, kubeClient.CoreV1(), nodeName, overrides.Context.Namespace, apitypes.UID(podUID), numGPUs)
 
 	var ready atomic.Bool
+	proxySrv := proxy.New(cfg.Proxy)
 
 	var wg sync.WaitGroup
-	wg.Add(2)
-
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
-		err := coordination.RunWithGPUUUIDs(ctx, strconv.FormatInt(int64(spiPort), 10), &ready, os.Stdout, gpuUUIDs)
+		err := coordination.RunWithGPUUUIDs(ctx, strconv.FormatUint(uint64(cfg.SPIPort), 10), &ready, os.Stdout, gpuUUIDs, proxySrv.Configure)
 		if err != nil {
-			logger.Error(err, "failed to start requester SPI server")
+			logger.Error(err, "failed to run requester SPI server")
 		}
 	}()
 
 	// Start the readiness probe server
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
-		err := probes.Run(ctx, strconv.FormatInt(int64(probesPort), 10), &ready)
+		err := probes.Run(ctx, strconv.FormatUint(uint64(cfg.ProbesPort), 10), &ready)
 		if err != nil {
-			logger.Error(err, "failed to start requester probes server")
+			logger.Error(err, "failed to run requester probes server")
+		}
+	}()
+
+	// Start the reverse proxy server
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		err := proxySrv.Run(ctx)
+		if err != nil {
+			logger.Error(err, "failed to run requester proxy server")
 		}
 	}()
 

--- a/config/examples/requester.yaml
+++ b/config/examples/requester.yaml
@@ -6,17 +6,18 @@ spec:
   containers:
     - name: requester-container
       image: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester:latest
+      command:
+        - /app/requester
+        - --probes-port=8080
+        - --spi-port=8081
+        - --proxy-port=8082
       ports:
         - containerPort: 8080
         - containerPort: 8081
-      env:
-        - name: PROBES_PORT
-          value: "8080"
-        - name: SPI_PORT
-          value: "8081"
+        - containerPort: 8082
       readinessProbe:
         httpGet:
-          path: /ready
-          port: 8080
+          path: /health
+          port: 8082
         initialDelaySeconds: 3
         periodSeconds: 5

--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -125,6 +125,49 @@ assigned to the server-requesting Pod) for running `vllm serve`. To
 swap a model out, the controller issues a request that does not
 include those details.
 
+#### Requester TCP Proxy
+
+The requester container includes a TCP proxy server that forwards
+inference requests to the actual vLLM instance running in the
+server-providing Pod (typically managed by the launcher). This
+abstraction allows clients to send requests to the server-requesting
+Pod without needing to know the actual port vLLM is listening on.
+
+The proxy operates as a simple TCP-level forwarder: each incoming
+client connection results in a new outbound connection to the
+configured vLLM target. Because this operates at the TCP layer, it
+supports any protocol over TCP (HTTP/1.x, HTTP/2, HTTPS, gRPC, etc.).
+
+The proxy is configured via a RESTful resource at
+`/v1/proxy/config`. The resource supports GET and PUT:
+
+1. **Configuration** (PUT): When the dual-pods controller binds a
+   server-requesting Pod to a server-providing Pod, it sends an HTTP
+   PUT request to the requester's proxy configuration endpoint
+   (`/v1/proxy/config`). The request body contains the target address
+   (server-providing Pod IP) and the port vLLM is listening on:
+
+   ```json
+   {"address": "10.244.1.5", "port": 8005}
+   ```
+
+   A successful configuration returns HTTP 200 with a message
+   describing the change. If the proxy is already
+   configured, the request returns HTTP 409 (Conflict).
+
+2. **Status checking** (GET): The proxy's current configuration can
+   be queried via an HTTP GET request to `/v1/proxy/config`. If the
+   proxy has been configured, it returns HTTP 200 with a JSON body
+   containing the current target address and port. If not, it returns
+   HTTP 404.
+
+
+3. **Request forwarding**: Once configured, the TCP proxy forwards
+   all incoming connections to the configured vLLM instance. This
+   includes OpenAI-compatible API endpoints like `/v1/chat/completions`,
+   `/v1/completions`, etc. Because this is a TCP-level proxy, it supports
+   any protocol over TCP (HTTP/1.x, HTTP/2, HTTPS, gRPC, etc.).
+
 ### Scenarios
 
 The outer product of

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/llm-d-incubation/llm-d-fast-model-actuation
 go 1.24.2
 
 require (
+	github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	k8s.io/api v0.34.9

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -35,6 +36,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048 h1:jaqViOFFlZtkAwqvwZN+id37fosQqR5l3Oki9Dk4hz8=
+github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048/go.mod h1:Di7LXRyUcnvAcLicFhtM9/MlZl/TNgRSDHORM2c6CMI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -459,6 +459,8 @@ type serverData struct {
 	// Set of InstanceID deleted to make room for this instance
 	InstancesDeleted sets.Set[string]
 
+	ProxyConfigured bool // true once ensureProxyConfigured has succeeded
+
 	ReadinessRelayed *bool
 
 	Sleeping *bool

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -510,6 +510,14 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		if err != nil {
 			return err, true
 		}
+		// After a controller restart the binding may have been persisted
+		// but the proxy config never sent. Ensure it is configured now.
+		if !serverDat.ProxyConfigured {
+			if err := ensureProxyConfigured(ctx, requestingPod, providingPod, adminPort, serverPort); err != nil {
+				return err, true
+			}
+			serverDat.ProxyConfigured = true
+		}
 		// Relay readiness if not already done.
 		// For launcher-based providers, readiness follows the bound instance's
 		// sleeping state rather than the launcher's Pod readiness.
@@ -1305,6 +1313,24 @@ func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requesti
 			return fmt.Errorf("unable to wake up server because port not known: %w", err), true
 		}
 	}
+	// Initialize a reverse proxy between the launcher Pod and the requester Pod.
+	// Requests can be proxied to the launcher Pod from the requester Pod.
+	adminPort := requestingPod.Annotations[api.AdminPortAnnotationName]
+	if adminPort == "" {
+		adminPort = api.AdminPortDefaultValue
+	}
+	requesterAddr := fmt.Sprintf("%s:%s", requestingPod.Status.PodIP, adminPort)
+	launcherAddr := fmt.Sprintf("%s:%d", providingPod.Status.PodIP, serverPort)
+	url := fmt.Sprintf("http://%s%s", requesterAddr, stubapi.ProxyConfigPath)
+	proxyConfig, _ := json.Marshal(stubapi.ProxyTargetConfig{
+		Address: providingPod.Status.PodIP,
+		Port:    uint16(serverPort),
+	})
+
+	if err := doPut(ctx, url, bytes.NewReader(proxyConfig)); err != nil {
+		return fmt.Errorf("failed to initialize proxy (requester %s -> launcher %s): %w",
+			requesterAddr, launcherAddr, err), true
+	}
 	if !skipWake {
 		err = ctl.wakeSleeper(ctx, serverDat, requestingPod, providingPod, serverPort, "freshly-bound")
 		if err != nil {
@@ -1895,6 +1921,72 @@ func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1
 		logger.V(2).Info("Failed to set status/finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "instanceID", desiredInstanceID, "finalizers", requestingPod.Finalizers, "resourceVersion", requestingPod.ResourceVersion, "k8sCallStartTime", updStartStr, "err", err.Error())
 	}
 	return err, err != nil
+}
+
+func doPut(ctx context.Context, url string, data io.Reader) error {
+	return doHTTPRequest(ctx, http.MethodPut, url, data)
+}
+
+func ensureProxyConfigured(ctx context.Context, requestingPod, providingPod *corev1.Pod, adminPort string, serverPort int32) error {
+	logger := klog.FromContext(ctx)
+	proxyURL := fmt.Sprintf("http://%s:%s%s", requestingPod.Status.PodIP, adminPort, stubapi.ProxyConfigPath)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL, nil)
+	if err != nil {
+		return fmt.Errorf("ensureProxyConfigured: create GET request: %w", err)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("ensureProxyConfigured: GET %s: %w", proxyURL, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("ensureProxyConfigured: GET %s returned %d: %s", proxyURL, resp.StatusCode, string(body))
+	}
+
+	proxyConfig, _ := json.Marshal(stubapi.ProxyTargetConfig{
+		Address: providingPod.Status.PodIP,
+		Port:    uint16(serverPort),
+	})
+	if err := doPut(ctx, proxyURL, bytes.NewReader(proxyConfig)); err != nil {
+		return fmt.Errorf("ensureProxyConfigured: PUT %s: %w", proxyURL, err)
+	}
+	logger.V(2).Info("Configured proxy after controller restart",
+		"requester", requestingPod.Name, "provider", providingPod.Name,
+		"target", fmt.Sprintf("%s:%d", providingPod.Status.PodIP, serverPort))
+	return nil
+}
+
+func doHTTPRequest(ctx context.Context, method, url string, data io.Reader) error {
+	req, err := http.NewRequestWithContext(ctx, method, url, data)
+	if err != nil {
+		return fmt.Errorf("http %s %q: %w", method, url, err)
+	}
+	if data != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http %s %q: %w", method, url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("http %s %q returned unexpected status %d; response body=%s", method, url, resp.StatusCode, string(body))
+	}
+
+	return nil
 }
 
 var coreScheme *k8sruntime.Scheme

--- a/pkg/server/requester/config/config.go
+++ b/pkg/server/requester/config/config.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/proxy"
+)
+
+// Config holds all configurable runtime parameters for the requester.
+type Config struct {
+	ProbesPort uint16
+	SPIPort    uint16
+	Proxy      proxy.ProxyConfig
+}
+
+// NewDefault returns a Config with sensible defaults.
+func NewDefault() Config {
+	return Config{
+		ProbesPort: 8080,
+		SPIPort:    8081,
+		Proxy:      proxy.DefaultProxyConfig,
+	}
+}
+
+// AddFlags registers command-line flags for all Config fields.
+func (cfg *Config) AddFlags(fs *pflag.FlagSet) {
+	fs.Uint16Var(&cfg.ProbesPort, "probes-port", cfg.ProbesPort, "port number for readiness/liveness probes")
+	fs.Uint16Var(&cfg.SPIPort, "spi-port", cfg.SPIPort, "port for dual-pods SPI requests")
+	cfg.Proxy.AddFlags(fs)
+}

--- a/pkg/server/requester/coordination/server.go
+++ b/pkg/server/requester/coordination/server.go
@@ -73,7 +73,7 @@ func getGpuUUIDs() ([]string, error) {
 
 // Run starts an HTTP server managing the endpoints
 // consumed by the dual-pods controller.
-func Run(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer) error {
+func Run(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer, proxyConfigHandler http.HandlerFunc) error {
 	logger := klog.FromContext(ctx).WithName("spi-server")
 
 	gpuUUIDs, err := getGpuUUIDs()
@@ -85,7 +85,7 @@ func Run(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writ
 	} else {
 		logger.Info("Got GPU UUIDs", "uuids", gpuUUIDs)
 	}
-	return RunWithGPUUUIDs(ctx, port, ready, logWriter, gpuUUIDs)
+	return RunWithGPUUUIDs(ctx, port, ready, logWriter, gpuUUIDs, proxyConfigHandler)
 }
 
 func gpuMemoryHandler(logger klog.Logger) func(w http.ResponseWriter, r *http.Request) {
@@ -204,7 +204,7 @@ func newSetLogHandler(logger klog.Logger, logWriter io.Writer) func(w http.Respo
 	}
 }
 
-func RunWithGPUUUIDs(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer, gpuUUIDs []string) error {
+func RunWithGPUUUIDs(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer, gpuUUIDs []string, proxyConfigHandler http.HandlerFunc) error {
 	logger := klog.FromContext(ctx).WithName("spi-server")
 	mux := http.NewServeMux()
 	mux.HandleFunc(strings.Join([]string{"GET", stubapi.AcceleratorQueryPath}, " "), gpuHandler(gpuUUIDs))
@@ -212,6 +212,7 @@ func RunWithGPUUUIDs(ctx context.Context, port string, ready *atomic.Bool, logWr
 	mux.HandleFunc("POST "+stubapi.BecomeReadyPath, newSetReadyHandler(logger, ready, true))
 	mux.HandleFunc("POST "+stubapi.BecomeUnreadyPath, newSetReadyHandler(logger, ready, false))
 	mux.HandleFunc("POST "+stubapi.SetLogPath, newSetLogHandler(logger, logWriter))
+	mux.HandleFunc(stubapi.ProxyConfigPath, proxyConfigHandler)
 
 	server := &http.Server{
 		Addr:    ":" + port,

--- a/pkg/server/requester/coordination/server_test.go
+++ b/pkg/server/requester/coordination/server_test.go
@@ -39,7 +39,7 @@ func FuzzServer(f *testing.F) {
 	ctx, cancel := context.WithCancel(f.Context())
 	port := "28083"
 	go func() {
-		err := RunWithGPUUUIDs(ctx, port, &ready, nil, gpuIDs)
+		err := RunWithGPUUUIDs(ctx, port, &ready, nil, gpuIDs, http.NotFound)
 		if err != nil {
 			f.Logf("Run failed: %s", err.Error())
 		}
@@ -89,7 +89,7 @@ func TestLogChunking(t *testing.T) {
 	var ready atomic.Bool
 	port := "28084"
 	go func() {
-		err := RunWithGPUUUIDs(ctx, port, &ready, &logBuilder, []string{"x"})
+		err := RunWithGPUUUIDs(ctx, port, &ready, &logBuilder, []string{"x"}, http.NotFound)
 		if err != nil {
 			t.Logf("Run failed: %s", err.Error())
 		}

--- a/pkg/server/requester/coordination/server_test.go
+++ b/pkg/server/requester/coordination/server_test.go
@@ -22,14 +22,32 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
+
+// waitForServer blocks until the HTTP server started in a goroutine is
+// accepting connections on the given port, avoiding a startup race where the
+// first request fires before the listener is bound.
+func waitForServer(tb testing.TB, port string) {
+	tb.Helper()
+	for range 100 {
+		conn, err := net.DialTimeout("tcp", "localhost:"+port, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	tb.Fatalf("server on port %s did not become ready", port)
+}
 
 func FuzzServer(f *testing.F) {
 	f.Add(true)
@@ -44,6 +62,7 @@ func FuzzServer(f *testing.F) {
 			f.Logf("Run failed: %s", err.Error())
 		}
 	}()
+	waitForServer(f, port)
 	paths := map[bool]string{false: stubapi.BecomeUnreadyPath, true: stubapi.BecomeReadyPath}
 	f.Fuzz(func(t *testing.T, beReady bool) {
 		path := paths[beReady]
@@ -94,6 +113,7 @@ func TestLogChunking(t *testing.T) {
 			t.Logf("Run failed: %s", err.Error())
 		}
 	}()
+	waitForServer(t, port)
 	for {
 		curLen := logBuilder.Len()
 		if curLen > fullLogSize-fullLogSize/60 {

--- a/pkg/server/requester/proxy/server.go
+++ b/pkg/server/requester/proxy/server.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/inetaf/tcpproxy"
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog/v2"
+
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
+)
+
+// ProxyConfig holds the proxy server's runtime parameters that are provided
+// at requester startup, via the requester command line. It is distinct from
+// stubapi.ProxyTargetConfig, which holds the runtime parameters provided
+// later by the dual-pods controller (the backend the proxy forwards to).
+type ProxyConfig struct {
+	// Port is the port the proxy listens on.
+	Port uint16
+	// DialTimeout is the timeout for dialing backend connections.
+	DialTimeout time.Duration
+}
+
+// DefaultProxyConfig provides sensible defaults.
+var DefaultProxyConfig = ProxyConfig{
+	Port:        8082,
+	DialTimeout: 10 * time.Second,
+}
+
+// AddFlags registers command-line flags for all proxy configuration fields.
+func (cfg *ProxyConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.Uint16Var(&cfg.Port, "proxy-port", cfg.Port, "port for TCP proxy")
+	fs.DurationVar(&cfg.DialTimeout, "proxy-dial-timeout", cfg.DialTimeout, "timeout for proxy backend dial")
+}
+
+// Server is a TCP reverse proxy that waits for a backend target to be
+// delivered via Configure, then forwards all connections to that target.
+type Server struct {
+	cfg ProxyConfig
+
+	// configCh carries the target from Configure to Run; sent on at most once.
+	configCh chan stubapi.ProxyTargetConfig
+	// startedCh carries the result of starting the listener (nil on success).
+	// Run sends exactly one value then closes: nil on success, an error on
+	// Start failure or shutdown-before-configuration.
+	startedCh chan error
+
+	// target is the most recently delivered backend target; guarded by stateMu
+	// because GET and the duplicate-PUT check race with the first PUT writer.
+	stateMu sync.Mutex
+	target  *stubapi.ProxyTargetConfig
+}
+
+// New creates a Server with the given configuration.
+func New(cfg ProxyConfig) *Server {
+	return &Server{
+		cfg:       cfg,
+		configCh:  make(chan stubapi.ProxyTargetConfig, 1),
+		startedCh: make(chan error, 1),
+	}
+}
+
+// Run starts the TCP proxy server. It blocks waiting for Configure to deliver
+// the backend target, then constructs and starts a tcpproxy.Proxy listening on
+// cfg.Port. It returns when the context is cancelled or the proxy stops.
+//
+// Run and Configure may be invoked in either order from different goroutines.
+func (s *Server) Run(ctx context.Context) error {
+	logger := klog.FromContext(ctx).WithName("proxy-server")
+	logger.Info("Starting TCP proxy server", "port", s.cfg.Port, "dialTimeout", s.cfg.DialTimeout)
+
+	var tgt stubapi.ProxyTargetConfig
+	select {
+	case tgt = <-s.configCh:
+		logger.V(2).Info("Received proxy target from Configure", "target", tgt)
+	case <-ctx.Done():
+		logger.V(2).Info("Context cancelled before proxy was configured")
+		s.startedCh <- fmt.Errorf("proxy shutdown cancelled before configuration")
+		close(s.startedCh)
+		return nil
+	}
+
+	targetAddr := tgt.String()
+	p := &tcpproxy.Proxy{}
+	p.AddRoute(fmt.Sprintf(":%d", s.cfg.Port), &tcpproxy.DialProxy{
+		Addr:        targetAddr,
+		DialTimeout: s.cfg.DialTimeout,
+	})
+
+	if err := p.Start(); err != nil {
+		startErr := fmt.Errorf("failed to start proxy listener on port %d: %w", s.cfg.Port, err)
+		s.startedCh <- startErr
+		close(s.startedCh)
+		logger.Error(err, "Failed to start TCP proxy listener", "port", s.cfg.Port)
+		return startErr
+	}
+	s.startedCh <- nil
+	close(s.startedCh)
+	logger.Info("TCP proxy server listening", "port", s.cfg.Port, "target", targetAddr)
+
+	go func() {
+		<-ctx.Done()
+		logger.V(2).Info("Shutting down TCP proxy server")
+		_ = p.Close()
+	}()
+
+	waitErr := p.Wait()
+	if ctx.Err() != nil {
+		logger.V(2).Info("TCP proxy server stopped after context cancellation", "waitErr", waitErr)
+		return nil
+	}
+	if waitErr != nil {
+		logger.Error(waitErr, "TCP proxy server stopped unexpectedly")
+		return waitErr
+	}
+	logger.Info("TCP proxy server stopped")
+	return nil
+}
+
+// Configure handles the proxy configuration HTTP endpoint at ProxyConfigPath.
+//
+// GET returns the configured target (200) or 404 if not yet configured.
+// PUT delivers the backend target. PUT may succeed only once; subsequent PUTs
+// return 409. PUT does not return until the proxy is actively listening, so
+// callers can rely on a 200 response to mean the proxy is ready to accept
+// connections.
+func (s *Server) Configure(w http.ResponseWriter, r *http.Request) {
+	logger := klog.FromContext(r.Context()).WithName("proxy-server")
+
+	switch r.Method {
+	case http.MethodGet:
+		s.stateMu.Lock()
+		cur := s.target
+		s.stateMu.Unlock()
+		if cur == nil {
+			http.Error(w, "proxy not configured", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(cur)
+		return
+	case http.MethodPut:
+		// fall through to body handling below
+	default:
+		http.Error(w, "method not allowed, use GET or PUT", http.StatusMethodNotAllowed)
+		return
+	}
+
+	defer func() { _ = r.Body.Close() }()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	var cfg stubapi.ProxyTargetConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		http.Error(w, fmt.Sprintf("failed to parse JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	if cfg.Address == "" {
+		http.Error(w, "address is required", http.StatusBadRequest)
+		return
+	}
+	if cfg.Port == 0 {
+		http.Error(w, "invalid port", http.StatusBadRequest)
+		return
+	}
+
+	s.stateMu.Lock()
+	if s.target != nil {
+		s.stateMu.Unlock()
+		http.Error(w, "proxy already configured", http.StatusConflict)
+		return
+	}
+	s.target = &cfg
+	s.stateMu.Unlock()
+
+	logger.V(2).Info("Delivering proxy target to Run", "target", cfg)
+
+	// configCh has cap=1 and is reachable at most once per process lifetime,
+	// so the send never blocks.
+	s.configCh <- cfg
+
+	// Wait for Run to confirm the listener is up. Abort if the request
+	// is cancelled; Run always sends on startedCh (nil, start error, or
+	// shutdown error), so this select is guaranteed to unblock.
+	select {
+	case startErr := <-s.startedCh:
+		if startErr != nil {
+			http.Error(w, fmt.Sprintf("proxy failed to start: %v", startErr), http.StatusInternalServerError)
+			return
+		}
+	case <-r.Context().Done():
+		http.Error(w, "request cancelled before proxy started listening", http.StatusServiceUnavailable)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, "configured proxy to: %s", cfg.String())
+}

--- a/pkg/server/requester/proxy/server_test.go
+++ b/pkg/server/requester/proxy/server_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
+)
+
+// CI machines can be heavily loaded, so use generous timeouts for any
+// operation that crosses the proxy or talks to the network.
+const (
+	testDialTimeout = 10 * time.Second
+	testReadTimeout = 10 * time.Second
+)
+
+// startProxy runs Run in a goroutine and returns a stop function.
+// Calling stop cancels the context and waits for the goroutine to exit,
+// ensuring no goroutine leaks between tests.
+func startProxy(t *testing.T, srv *Server) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := srv.Run(ctx); err != nil {
+			t.Logf("proxy Run error: %v", err)
+		}
+	}()
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+// startTestEchoServer starts a TCP server that echoes back any data it
+// receives. The returned closer shuts the listener AND any accepted
+// connections so tests do not leak goroutines.
+func startTestEchoServer(t *testing.T) (addr string, port uint16, closer func()) {
+	t.Helper()
+	ln, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("failed to start echo server: %v", err)
+	}
+	tcpAddr := ln.Addr().(*net.TCPAddr) // ListenTCP guarantees *TCPAddr
+	addr = tcpAddr.String()
+	port = uint16(tcpAddr.Port)
+
+	var (
+		connsMu sync.Mutex
+		conns   []net.Conn
+	)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			connsMu.Lock()
+			conns = append(conns, conn)
+			connsMu.Unlock()
+			go func(c net.Conn) {
+				_, _ = io.Copy(c, c)
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+
+	return addr, port, func() {
+		_ = ln.Close()
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}
+}
+
+// findFreePort returns a free TCP port.
+func findFreePort(t *testing.T) uint16 {
+	t.Helper()
+	ln, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	port := uint16(ln.Addr().(*net.TCPAddr).Port)
+	_ = ln.Close()
+	return port
+}
+
+func TestProxy_EchoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	_, backendPort, backendCloser := startTestEchoServer(t)
+	defer backendCloser()
+
+	proxyPort := findFreePort(t)
+	srv := New(ProxyConfig{Port: proxyPort, DialTimeout: testDialTimeout})
+	stop := startProxy(t, srv)
+	defer stop()
+
+	body := stubapi.ProxyTargetConfig{Address: "127.0.0.1", Port: backendPort}
+	jsonBody, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPut, stubapi.ProxyConfigPath, bytes.NewReader(jsonBody))
+	w := httptest.NewRecorder()
+	srv.Configure(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Configure failed: %d — %s", w.Code, w.Body.String())
+	}
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), testDialTimeout)
+	if err != nil {
+		t.Fatalf("failed to dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	testMsg := "hello proxy\n"
+	if _, err := conn.Write([]byte(testMsg)); err != nil {
+		t.Fatalf("failed to write to proxy: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(testReadTimeout))
+	got := make([]byte, len(testMsg))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("failed to read echo: %v", err)
+	}
+	if string(got) != testMsg {
+		t.Errorf("expected echo of %q, got %q", testMsg, got)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	extra := make([]byte, 1)
+	if n, _ := conn.Read(extra); n > 0 {
+		t.Errorf("unexpected trailing byte %q after echo", extra[:n])
+	}
+}
+
+func TestProxy_NoListenerBeforeConfigure(t *testing.T) {
+	t.Parallel()
+
+	proxyPort := findFreePort(t)
+	srv := New(ProxyConfig{Port: proxyPort, DialTimeout: DefaultProxyConfig.DialTimeout})
+	stop := startProxy(t, srv)
+	defer stop()
+
+	// Run is blocked waiting for Configure, so the proxy port has no listener.
+	time.Sleep(500 * time.Millisecond)
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), 2*time.Second)
+	if err == nil {
+		_ = conn.Close()
+		t.Errorf("expected dial to fail before Configure, but it succeeded")
+	}
+}
+
+func TestConfigure_GetStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := New(ProxyConfig{Port: findFreePort(t), DialTimeout: testDialTimeout})
+
+	// Before Configure, GET should return 404.
+	req1 := httptest.NewRequest(http.MethodGet, stubapi.ProxyConfigPath, nil)
+	w1 := httptest.NewRecorder()
+	srv.Configure(w1, req1)
+	if w1.Code != http.StatusNotFound {
+		t.Errorf("GET before configure should return 404, got %d", w1.Code)
+	}
+
+	// PUT requires Run to be active, since Configure waits for listener readiness.
+	stop := startProxy(t, srv)
+	defer stop()
+
+	_, backendPort, backendCloser := startTestEchoServer(t)
+	defer backendCloser()
+
+	body := stubapi.ProxyTargetConfig{Address: "127.0.0.1", Port: backendPort}
+	jsonBody, _ := json.Marshal(body)
+	req2 := httptest.NewRequest(http.MethodPut, stubapi.ProxyConfigPath, bytes.NewReader(jsonBody))
+	w2 := httptest.NewRecorder()
+	srv.Configure(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("Configure failed: %d — %s", w2.Code, w2.Body.String())
+	}
+
+	req3 := httptest.NewRequest(http.MethodGet, stubapi.ProxyConfigPath, nil)
+	w3 := httptest.NewRecorder()
+	srv.Configure(w3, req3)
+	if w3.Code != http.StatusOK {
+		t.Errorf("GET after configure should return 200, got %d", w3.Code)
+	}
+
+	var got stubapi.ProxyTargetConfig
+	if err := json.Unmarshal(w3.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to parse response JSON: %v", err)
+	}
+	if got != body {
+		t.Errorf("GET returned %+v, want %+v", got, body)
+	}
+}
+
+func TestConfigure_DifferentConfigReturnsConflict(t *testing.T) {
+	t.Parallel()
+
+	proxyPort := findFreePort(t)
+	srv := New(ProxyConfig{Port: proxyPort, DialTimeout: testDialTimeout})
+	stop := startProxy(t, srv)
+	defer stop()
+
+	_, backendPort, backendCloser := startTestEchoServer(t)
+	defer backendCloser()
+
+	body := stubapi.ProxyTargetConfig{Address: "127.0.0.1", Port: backendPort}
+	jsonBody, _ := json.Marshal(body)
+	req1 := httptest.NewRequest(http.MethodPut, stubapi.ProxyConfigPath, bytes.NewReader(jsonBody))
+	w1 := httptest.NewRecorder()
+	srv.Configure(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first Configure failed: %d — %s", w1.Code, w1.Body.String())
+	}
+
+	reqGet := httptest.NewRequest(http.MethodGet, stubapi.ProxyConfigPath, nil)
+	wGet := httptest.NewRecorder()
+	srv.Configure(wGet, reqGet)
+	if wGet.Code != http.StatusOK {
+		t.Fatalf("GET after configure failed: %d — %s", wGet.Code, wGet.Body.String())
+	}
+	var got stubapi.ProxyTargetConfig
+	if err := json.Unmarshal(wGet.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to parse GET response: %v", err)
+	}
+	if got != body {
+		t.Errorf("GET returned %+v, want %+v", got, body)
+	}
+
+	// Reconfigure with a DIFFERENT config — should still be rejected, so the
+	// 409 actually proves "reconfigure is blocked" rather than "duplicate
+	// write is a no-op".
+	differentBody := stubapi.ProxyTargetConfig{Address: "10.0.0.1", Port: backendPort + 1}
+	diffJSON, _ := json.Marshal(differentBody)
+	req2 := httptest.NewRequest(http.MethodPut, stubapi.ProxyConfigPath, bytes.NewReader(diffJSON))
+	w2 := httptest.NewRecorder()
+	srv.Configure(w2, req2)
+	if w2.Code != http.StatusConflict {
+		t.Errorf("reconfigure with different config should return 409, got %d — body: %s", w2.Code, w2.Body.String())
+	}
+}
+
+func TestConfigure_BadRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		expectCode int
+	}{
+		{"DELETE not allowed", http.MethodDelete, "", http.StatusMethodNotAllowed},
+		{"invalid JSON", http.MethodPut, `{invalid json}`, http.StatusBadRequest},
+		{"missing address", http.MethodPut, `{"address":"","port":8080}`, http.StatusBadRequest},
+		{"invalid port zero", http.MethodPut, `{"address":"127.0.0.1","port":0}`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := New(ProxyConfig{Port: findFreePort(t), DialTimeout: testDialTimeout})
+			req := httptest.NewRequest(tt.method, stubapi.ProxyConfigPath, bytes.NewReader([]byte(tt.body)))
+			w := httptest.NewRecorder()
+			srv.Configure(w, req)
+
+			if w.Code != tt.expectCode {
+				t.Errorf("expected status %d, got %d — body: %s", tt.expectCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/spi/interface.go
+++ b/pkg/spi/interface.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package spi
 
+import (
+	"net"
+	"strconv"
+)
+
 // This file defines interface of the stub.
 
 // AcceleratorQueryPath is the path part of the URL that is polled
@@ -59,3 +64,26 @@ const SetLogPath = "/v1/set-log"
 // LogStartPosParam is the name of the query parameter that
 // holds that starting position of a log chunk.
 const LogStartPosParam = "startPos"
+
+// ProxyConfigPath is the path for the proxy configuration resource.
+// Supports two HTTP methods:
+//   - GET: retrieves the configuration status of the proxy.
+//     Returns 200 if configured, 404 if not.
+//   - PUT: configures the proxy with a target address and port.
+//     After successful configuration, the proxy will forward TCP
+//     connections to the configured target.
+const ProxyConfigPath = "/v1/proxy/config"
+
+// ProxyTargetConfig is the request and response body for configuring the proxy
+// with a target address and port (sent by the dual-pods controller).
+type ProxyTargetConfig struct {
+	// Address is the target host to proxy to.
+	Address string `json:"address"`
+	// Port is the target port number.
+	Port uint16 `json:"port"`
+}
+
+// String returns the target formatted as a "host:port" network address.
+func (t ProxyTargetConfig) String() string {
+	return net.JoinHostPort(t.Address, strconv.FormatUint(uint64(t.Port), 10))
+}

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -260,6 +260,8 @@ spec:
             containerPort: 8080
           - name: spi
             containerPort: 8081
+          - name: proxy          
+            containerPort: 8082
           readinessProbe:
             httpGet:
               path: /ready

--- a/test/e2e/mkobjs.sh
+++ b/test/e2e/mkobjs.sh
@@ -207,6 +207,8 @@ spec:
             containerPort: 8080
           - name: spi
             containerPort: 8081
+          - name: proxy          
+            containerPort: 8082
           readinessProbe:
             httpGet:
               path: /ready

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -554,6 +554,71 @@ cheer Successful switching instances in one launcher
 # Qwen2.5-0.5B-Instruct sleeping on $launcher1 (AKA $launcher2 ... $launcher4)
 
 # ---------------------------------------------------------------------------
+# Reverse Proxy Initialization and Forwarding
+# ---------------------------------------------------------------------------
+
+intro_case Reverse Proxy Initialization and Forwarding
+
+# This test verifies that the dual-pods controller initializes the TCP proxy
+# on the requester pod after binding, and that the proxy configuration points
+# to the correct launcher pod IP.
+#
+# Starting state: $req4 is bound to $launcher1, both Ready.
+
+echo "Checking proxy configuration on requester pod $req4"
+
+# Port-forward to the requester's SPI port to query proxy config
+kubectl port-forward pod/"$req4" 28091:8081 -n "$NS" &
+PF_SPI_PID=$!
+sleep 2
+
+http_code=$(curl -s -o /tmp/proxy_resp.json -w '%{http_code}' "http://localhost:28091/v1/proxy/config" 2>/dev/null)
+kill "$PF_SPI_PID" 2>/dev/null || true
+wait "$PF_SPI_PID" 2>/dev/null || true
+
+proxy_resp=$(cat /tmp/proxy_resp.json)
+rm -f /tmp/proxy_resp.json
+
+# GET /v1/proxy/config returns JSON {"address":"...","port":...} or 404 if not configured
+if [ "$http_code" != "200" ]; then
+    echo "ERROR: expected proxy config to return 200, got $http_code, body: '$proxy_resp'" >&2
+    exit 1
+fi
+
+echo "Proxy is configured: $proxy_resp"
+
+# Verify proxy config matches expected JSON using jq
+launcher1_ip=$(kubectl get pod "$launcher1" -n "$NS" -o jsonpath='{.status.podIP}')
+launcher1_port=$(kubectl get inferenceserverconfig "$isc" -n "$NS" -o jsonpath='{.spec.modelServerConfig.port}')
+
+expected=$(printf '{"address":"%s","port":%d}' "$launcher1_ip" "$launcher1_port")
+if ! echo "$proxy_resp" | jq -e --argjson expected "$expected" '. == $expected' >/dev/null 2>&1; then
+    echo "ERROR: proxy config does not match expected: expected=$expected, got='$proxy_resp'" >&2
+    exit 1
+fi
+echo "Proxy config matches expected: $expected"
+
+# Verify traffic forwarding through the TCP proxy port (8082)
+# The proxy forwards to the vLLM inference port configured in the InferenceServerConfig
+echo "Verifying traffic forwarding through TCP proxy port"
+kubectl port-forward pod/"$req4" 28092:8082 -n "$NS" &
+PF_PROXY_PID=$!
+sleep 2
+
+health_status=$(curl -s -o /dev/null -w "%{http_code}" \
+    "http://localhost:28092/health" 2>/dev/null || echo "000")
+kill "$PF_PROXY_PID" 2>/dev/null || true
+wait "$PF_PROXY_PID" 2>/dev/null || true
+
+if [ "$health_status" != "200" ]; then
+    echo "ERROR: vLLM /health via proxy port returned $health_status (expected 200)" >&2
+    exit 1
+fi
+echo "Proxy forwarding verified: /health via proxy port returned 200"
+
+cheer Successful reverse proxy initialization and forwarding
+
+# ---------------------------------------------------------------------------
 # Per-launcher Instance Cap Enforcement
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR continues the unfinished work from #423, further simplifying and refactoring the TCP proxy within the requester.

Additionally, the experiments have been redesigned and re-run to measure the overhead introduced by the TCP proxy. For the experimental report, please refer to: https://docs.google.com/document/d/1qX4KtcTJEfdatgVmtsveOMfjm883MG-HW-e7ddmlqkA


## Main Changes since #423

- **Proxy concurrency model rewritten.** Replaced the `lazyTarget` placeholder + always-running listener with a two-channel design (`configCh` from `Configure` to `Run`, `startedCh` the other way). References: [Configure waits until listening](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/423#discussion_r3230008633), [two-channel simplification](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/423#discussion_r3230478593).

- **`AddFlags` now takes `*pflag.FlagSet`.** Updated the receiver in both `pkg/server/requester/config/config.go` and `pkg/server/requester/proxy/server.go`; call sites in `cmd/requester/main.go` and `cmd/test-requester/main.go` updated accordingly. References: [`config.go`](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/423#discussion_r3229648923), [`proxy/server.go`](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/423#discussion_r3229820658).

- **Imports regrouped per #447.** Six-group canonical order in `cmd/requester/main.go`: stdlib → non-k8s third-party → k8s → k8s-dependent → other llm-d repos → this repo. References: [import grouping](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/423#discussion_r3229612646).

- **Example yaml gets the proxy port; readiness probe targets the proxy.** `config/examples/requester.yaml` now declares `containerPort: 8082` and `--proxy-port=8082`, and the `readinessProbe` is `httpGet /health:8082`. The same readiness change is reflected in `cmd/requester/README.md`'s example PodSpecs and the curl walk-through. The probes server itself is left in place — cleaning it up is intentionally deferred to a follow-on PR. References: [point readinessProbe at proxy port instead of adding another proxy layer](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/423#discussion_r3229785147).

- **README Overview rewritten** to frame the requester as the inference server's stand-in plus a relay to/from the dual-pods controller, and to note that the TCP proxy makes the requester look *more* like an inference server. References: [README framing](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/423#discussion_r3229738522).


cc @MikeSpreitzer @aavarghese 