### PR TITLE
make populator incremental handling

### DIFF
--- a/pkg/controller/common/interface.go
+++ b/pkg/controller/common/interface.go
@@ -32,6 +32,9 @@ const (
 	// corresponding LauncherConfig object's PodTemplate that the server-providing Pod uses.
 	LauncherConfigHashAnnotationKey = "dual-pods.llm-d.ai/launcher-config-hash"
 
+	// LauncherTemplateHashAnnotationKey is the node-independent template hash on a launcher Pod, used for spec-drift detection.
+	LauncherTemplateHashAnnotationKey = "dual-pods.llm-d.ai/launcher-populator-template-hash"
+
 	// LauncherServicePort is the port number on which the launcher exposes its HTTP service
 	// for the management of vLLM instances.
 	// This is a contract between the controllers and the launcher implementation.

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -589,7 +589,11 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		)
 	}
 
-	desiredLauncherPod, err := utils.BuildLauncherPodFromTemplate(lc.Spec.PodTemplate, ctl.namespace, requestingPod.Spec.NodeName, lcName)
+	desiredLauncherTemplateHash, err := utils.ComputeLauncherTemplateHash(lc.Spec.PodTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to compute template hash for LauncherConfig %q: %w", lcName, err), true
+	}
+	desiredLauncherPod, err := utils.BuildLauncherPodFromTemplate(lc.Spec.PodTemplate, ctl.namespace, requestingPod.Spec.NodeName, lcName, desiredLauncherTemplateHash)
 	if err != nil {
 		return fmt.Errorf("failed to build launcher Pod from LauncherConfig %q: %w", lcName, err), true
 	}

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -111,7 +111,7 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 //   - records the per-LPP derived data into ctl.policy.lpps[name];
 //   - applies the LPP to digest entries on every matched node.
 //
-// Other code paths must NOT call setLPPStatusErrors or ValidateLauncherPodTemplate.
+// Other code paths must NOT call setLPPStatusErrors or getMatchingNodes.
 func (ctl *controller) updateDigestForLPP(ctx context.Context, name string) error {
 	logger := klog.FromContext(ctx)
 
@@ -191,9 +191,30 @@ func (ctl *controller) updateDigestForLPP(ctx context.Context, name string) erro
 		}
 	}
 
+	// LC names currently referenced by this LPP. Used to detach the LPP from
+	// digest entries whose lcName has been dropped from CountForLauncher even
+	// though the node still matches the selector.
+	newLCNames := sets.New[string]()
+	for _, cr := range lpp.Spec.CountForLauncher {
+		newLCNames.Insert(cr.LauncherConfigName)
+	}
+
 	// Apply LPP to each matched node and enqueue affected keys.
 	for i := range currentMatchedNodes {
 		node := &currentMatchedNodes[i]
+		// Detach the LPP from entries on this still-matching node whose lcName
+		// is no longer referenced by lpp.Spec.CountForLauncher.
+		if nodeMap, ok := ctl.policy.digest[node.Name]; ok {
+			for lcName, entry := range nodeMap {
+				if _, hasLPP := entry.lpps[name]; !hasLPP {
+					continue
+				}
+				if newLCNames.Has(lcName) {
+					continue
+				}
+				ctl.detachLPPFromEntry(nodeMap, name, node.Name, lcName, entry)
+			}
+		}
 		ctl.applyLPPToDigestForNode(lpp, node)
 		for _, cr := range lpp.Spec.CountForLauncher {
 			ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: node.Name, LauncherConfigName: cr.LauncherConfigName}})
@@ -226,6 +247,16 @@ func (ctl *controller) updateDigestForNode(ctx context.Context, nodeName string)
 // recomputeDigestForNode rebuilds digest entries for a single node by replaying
 // every cached LPP. Pure read of ctl.policy.lpps + ctl.policy.lcs.
 func (ctl *controller) recomputeDigestForNode(node *corev1.Node) {
+	// Snapshot LC names currently in the digest for this node so we can also
+	// enqueue keys for entries that disappear after replay (e.g., a previously
+	// matching LPP no longer matches this node).
+	affected := sets.New[string]()
+	if oldMap, ok := ctl.policy.digest[node.Name]; ok {
+		for lcName := range oldMap {
+			affected.Insert(lcName)
+		}
+	}
+
 	ctl.policy.digest[node.Name] = make(map[string]*digestEntry)
 
 	for _, lppd := range ctl.policy.lpps {
@@ -234,6 +265,9 @@ func (ctl *controller) recomputeDigestForNode(node *corev1.Node) {
 
 	nodeMap := ctl.policy.digest[node.Name]
 	for lcName := range nodeMap {
+		affected.Insert(lcName)
+	}
+	for lcName := range affected {
 		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: node.Name, LauncherConfigName: lcName}})
 	}
 	if len(nodeMap) == 0 {

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -293,32 +293,8 @@ func (ctl *controller) applyLPPToDigestForNode(lpp *fmav1alpha1.LauncherPopulati
 			entry = &digestEntry{lpps: make(map[string]*fmav1alpha1.LauncherPopulationPolicy)}
 			ctl.policy.setEntry(node.Name, lcName, entry)
 		}
-
-		lcd := ctl.policy.lcDigestFor(lcName)
-		switch {
-		case lcd == nil || lcd.object == nil:
-			// LC not yet processed or known to be absent: handsOff. The LC's
-			// own update path (updateDigestForLC) will re-enqueue this LPP
-			// when the LC becomes existent.
-			entry.handsOff = true
-			entry.spec = nil
-		case lcd.templateErr != "":
-			// Template invalid; error is already in LC.Status.
-			entry.handsOff = true
-			entry.spec = nil
-		default:
-			entry.handsOff = false
-			entry.spec = &lcd.object.Spec
-			entry.ownerRef = lcd.ownerRef
-		}
-
-		if cr.LauncherCount > entry.count {
-			entry.count = cr.LauncherCount
-		}
-		if entry.lpps == nil {
-			entry.lpps = make(map[string]*fmav1alpha1.LauncherPopulationPolicy)
-		}
 		entry.lpps[lpp.Name] = lpp
+		ctl.recomputeEntryFromLPPs(entry, lcName)
 	}
 }
 

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -22,6 +22,7 @@ import (
 
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -50,23 +51,19 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get LC %s: %w", name, err)
 		}
-		// LC deleted.
+		if !prevExists {
+			return nil
+		}
 		logger.Info("LC deleted, marking referencing keys as handsOff", "config", name)
 		delete(ctl.policy.lcs, name)
-		for _, key := range ctl.policy.keysForLC(name) {
-			if entry := ctl.policy.getEntry(key.NodeName, key.LauncherConfigName); entry != nil {
-				entry.handsOff = true
-				entry.spec = nil
-				entry.count = 0
-				ctl.keyQueue.Queue.Add(keyItem{key})
-			}
+		for key, entry := range ctl.policy.entriesForLC(name) {
+			entry.handsOff = true
+			entry.spec = nil
+			entry.count = 0
+			ctl.keyQueue.Queue.Add(keyItem{key})
 		}
-		// Existence flip: re-enqueue LPPs that reference this LC so they can
-		// recompute missingLCs.
-		if prevExists {
-			for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
-				ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
-			}
+		for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
+			ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
 		}
 		return nil
 	}
@@ -81,9 +78,11 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 	if templateErr == "" {
 		h, hashErr := utils.ComputeLauncherTemplateHash(lc.Spec.PodTemplate)
 		if hashErr != nil {
-			return fmt.Errorf("failed to compute template hash for LC %s: %w", name, hashErr)
+			templateErr = hashErr.Error()
+			logger.Error(hashErr, "Failed to hash PodTemplate, reporting in Status", "config", name)
+		} else {
+			templateHash = h
 		}
-		templateHash = h
 	}
 	if statusErr := ctl.setLCStatusErrors(ctx, lc, nonNilSlice(templateErr)); statusErr != nil {
 		return fmt.Errorf("failed to set Status for LC %s: %w", name, statusErr)
@@ -110,18 +109,15 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 	}
 
 	// Refresh per-key entries that reference this LC.
-	for _, key := range ctl.policy.keysForLC(name) {
-		entry := ctl.policy.getEntry(key.NodeName, key.LauncherConfigName)
-		if entry == nil {
-			continue
-		}
+	lcd := ctl.policy.lcs[name]
+	for key, entry := range ctl.policy.entriesForLC(name) {
 		if templateErr != "" {
 			entry.handsOff = true
 			entry.spec = nil
 		} else {
 			entry.handsOff = false
-			entry.spec = &lc.Spec
-			entry.ownerRef = makeLCOwnerRef(lc)
+			entry.spec = &lcd.object.Spec
+			entry.ownerRef = lcd.ownerRef
 		}
 		ctl.keyQueue.Queue.Add(keyItem{key})
 	}
@@ -216,8 +212,9 @@ func (ctl *controller) updateDigestForLPP(ctx context.Context, name string) erro
 	}
 
 	// Apply LPP to each matched node and enqueue affected keys.
-	for _, node := range currentMatchedNodes {
-		ctl.applyLPPToDigestForNode(lpp, node.Name)
+	for i := range currentMatchedNodes {
+		node := &currentMatchedNodes[i]
+		ctl.applyLPPToDigestForNode(lpp, node)
 		for _, cr := range lpp.Spec.CountForLauncher {
 			ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: node.Name, LauncherConfigName: cr.LauncherConfigName}})
 		}
@@ -233,52 +230,41 @@ func (ctl *controller) updateDigestForLPP(ctx context.Context, name string) erro
 func (ctl *controller) updateDigestForNode(ctx context.Context, nodeName string) error {
 	logger := klog.FromContext(ctx)
 
-	_, err := ctl.nodeLister.Get(nodeName)
+	node, err := ctl.nodeLister.Get(nodeName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Node deleted, removing from digest", "node", nodeName)
-			removedKeys := ctl.policy.removeNode(nodeName)
-			for _, key := range removedKeys {
-				ctl.keyQueue.Queue.Add(keyItem{key})
-			}
+			delete(ctl.policy.digest, nodeName)
 			return nil
 		}
 		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
 	}
-	return ctl.recomputeDigestForNode(nodeName)
+	ctl.recomputeDigestForNode(node)
+	return nil
 }
 
 // recomputeDigestForNode rebuilds digest entries for a single node by replaying
 // every cached LPP. Pure read of ctl.policy.lpps + ctl.policy.lcs.
-func (ctl *controller) recomputeDigestForNode(nodeName string) error {
-	ctl.policy.digest[nodeName] = make(map[string]*digestEntry)
+func (ctl *controller) recomputeDigestForNode(node *corev1.Node) {
+	ctl.policy.digest[node.Name] = make(map[string]*digestEntry)
 
 	for _, lppd := range ctl.policy.lpps {
-		if lppd == nil || lppd.object == nil {
-			continue
-		}
-		ctl.applyLPPToDigestForNode(lppd.object, nodeName)
+		ctl.applyLPPToDigestForNode(lppd.object, node)
 	}
 
-	nodeMap := ctl.policy.digest[nodeName]
+	nodeMap := ctl.policy.digest[node.Name]
 	for lcName := range nodeMap {
-		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
+		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: node.Name, LauncherConfigName: lcName}})
 	}
 	if len(nodeMap) == 0 {
-		delete(ctl.policy.digest, nodeName)
+		delete(ctl.policy.digest, node.Name)
 	}
-	return nil
 }
 
 // applyLPPToDigestForNode evaluates one LPP for one node and updates the digest
 // using ONLY ctl.policy.lcs as the source of truth for LC status. It never
 // validates templates, writes Status, or fetches from listers.
-func (ctl *controller) applyLPPToDigestForNode(lpp *fmav1alpha1.LauncherPopulationPolicy, nodeName string) {
-	node, err := ctl.nodeLister.Get(nodeName)
-	if err != nil {
-		// Node missing or transient lister error: nothing to apply.
-		return
-	}
+func (ctl *controller) applyLPPToDigestForNode(lpp *fmav1alpha1.LauncherPopulationPolicy, node *corev1.Node) {
 	labelSelector, selectorErr := metav1.LabelSelectorAsSelector(&lpp.Spec.EnhancedNodeSelector.LabelSelector)
 	if selectorErr != nil {
 		return
@@ -293,10 +279,10 @@ func (ctl *controller) applyLPPToDigestForNode(lpp *fmav1alpha1.LauncherPopulati
 	for _, cr := range lpp.Spec.CountForLauncher {
 		lcName := cr.LauncherConfigName
 
-		entry := ctl.policy.getEntry(nodeName, lcName)
+		entry := ctl.policy.getEntry(node.Name, lcName)
 		if entry == nil {
 			entry = &digestEntry{lpps: make(map[string]*fmav1alpha1.LauncherPopulationPolicy)}
-			ctl.policy.setEntry(nodeName, lcName, entry)
+			ctl.policy.setEntry(node.Name, lcName, entry)
 		}
 
 		lcd := ctl.policy.lcDigestFor(lcName)
@@ -388,5 +374,3 @@ func (ctl *controller) recomputeEntryFromLPPs(entry *digestEntry, lcName string)
 		entry.ownerRef = lcd.ownerRef
 	}
 }
-
-

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -250,12 +250,7 @@ func (ctl *controller) recomputeDigestForNode(node *corev1.Node) {
 	// Snapshot LC names currently in the digest for this node so we can also
 	// enqueue keys for entries that disappear after replay (e.g., a previously
 	// matching LPP no longer matches this node).
-	affected := sets.New[string]()
-	if oldMap, ok := ctl.policy.digest[node.Name]; ok {
-		for lcName := range oldMap {
-			affected.Insert(lcName)
-		}
-	}
+	affected := sets.KeySet(ctl.policy.digest[node.Name])
 
 	ctl.policy.digest[node.Name] = make(map[string]*digestEntry)
 

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcherpopulator
+
+import (
+	"context"
+	"fmt"
+
+	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+)
+
+// updateDigestForLC is the SOLE place that:
+//   - validates the LC PodTemplate (utils.ValidateLauncherPodTemplate);
+//   - computes the node-independent template hash;
+//   - writes LauncherConfig.Status (via setLCStatusErrors);
+//   - records the per-LC derived data into ctl.policy.lcs[name].
+//
+// Other code paths must read ctl.policy.lcs[name] instead of recomputing.
+// On LC existence transitions or templateErr changes, all LPPs that reference
+// this LC are enqueued so they can refresh their lppDigest (missingLCs) and
+// re-apply to the digest.
+func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	prev := ctl.policy.lcs[name]
+	prevExists := prev != nil && prev.object != nil
+
+	lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(name)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get LC %s: %w", name, err)
+		}
+		// LC deleted.
+		logger.Info("LC deleted, marking referencing keys as handsOff", "config", name)
+		delete(ctl.policy.lcs, name)
+		for _, key := range ctl.policy.keysForLC(name) {
+			if entry := ctl.policy.getEntry(key.NodeName, key.LauncherConfigName); entry != nil {
+				entry.handsOff = true
+				entry.spec = nil
+				entry.count = 0
+				ctl.keyQueue.Queue.Add(keyItem{key})
+			}
+		}
+		// Existence flip: re-enqueue LPPs that reference this LC so they can
+		// recompute missingLCs.
+		if prevExists {
+			for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
+				ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
+			}
+		}
+		return nil
+	}
+
+	// LC exists: validate and produce the lcDigest.
+	var templateErr string
+	if vErr := utils.ValidateLauncherPodTemplate(lc.Spec.PodTemplate); vErr != nil {
+		templateErr = vErr.Error()
+		logger.Error(vErr, "Invalid PodTemplate in LC, reporting in Status", "config", name)
+	}
+	var templateHash string
+	if templateErr == "" {
+		h, hashErr := utils.ComputeLauncherTemplateHash(lc.Spec.PodTemplate)
+		if hashErr != nil {
+			return fmt.Errorf("failed to compute template hash for LC %s: %w", name, hashErr)
+		}
+		templateHash = h
+	}
+	if statusErr := ctl.setLCStatusErrors(ctx, lc, nonNilSlice(templateErr)); statusErr != nil {
+		return fmt.Errorf("failed to set Status for LC %s: %w", name, statusErr)
+	}
+
+	prevTemplateErr := ""
+	if prev != nil {
+		prevTemplateErr = prev.templateErr
+	}
+
+	ctl.policy.lcs[name] = &lcDigest{
+		object:       lc,
+		templateErr:  templateErr,
+		templateHash: templateHash,
+		ownerRef:     makeLCOwnerRef(lc),
+	}
+
+	// If the LC just became existent, or its template-validity flipped, the
+	// LPPs that reference it must be re-evaluated.
+	if !prevExists || prevTemplateErr != templateErr {
+		for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
+			ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
+		}
+	}
+
+	// Refresh per-key entries that reference this LC.
+	for _, key := range ctl.policy.keysForLC(name) {
+		entry := ctl.policy.getEntry(key.NodeName, key.LauncherConfigName)
+		if entry == nil {
+			continue
+		}
+		if templateErr != "" {
+			entry.handsOff = true
+			entry.spec = nil
+		} else {
+			entry.handsOff = false
+			entry.spec = &lc.Spec
+			entry.ownerRef = makeLCOwnerRef(lc)
+		}
+		ctl.keyQueue.Queue.Add(keyItem{key})
+	}
+	return nil
+}
+
+// updateDigestForLPP is the SOLE place that:
+//   - runs getMatchingNodes (collecting selector errors);
+//   - determines which referenced LCs are missing (by reading ctl.policy.lcs);
+//   - writes LauncherPopulationPolicy.Status (via setLPPStatusErrors);
+//   - records the per-LPP derived data into ctl.policy.lpps[name];
+//   - applies the LPP to digest entries on every matched node.
+//
+// Other code paths must NOT call setLPPStatusErrors or ValidateLauncherPodTemplate.
+func (ctl *controller) updateDigestForLPP(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	lpp, err := ctl.lppLister.LauncherPopulationPolicies(ctl.namespace).Get(name)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get LPP %s: %w", name, err)
+		}
+		// LPP deleted: detach from all referencing entries.
+		logger.Info("LPP deleted, updating digest incrementally", "policy", name)
+		for nodeName, nodeMap := range ctl.policy.digest {
+			for lcName, entry := range nodeMap {
+				if _, hasLPP := entry.lpps[name]; !hasLPP {
+					continue
+				}
+				ctl.detachLPPFromEntry(nodeMap, name, nodeName, lcName, entry)
+			}
+		}
+		delete(ctl.policy.lpps, name)
+		return nil
+	}
+
+	// Resolve matched nodes and selector errors.
+	currentMatchedNodes, selectorErrs, matchErr := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
+	if matchErr != nil {
+		return fmt.Errorf("failed to get matching nodes for policy %s: %w", lpp.Name, matchErr)
+	}
+
+	// Compute missing-LC errors by consulting ctl.policy.lcs only.
+	var missingLCs []string
+	for _, cr := range lpp.Spec.CountForLauncher {
+		lcd := ctl.policy.lcDigestFor(cr.LauncherConfigName)
+		if lcd == nil || lcd.object == nil {
+			missingLCs = append(missingLCs, fmt.Sprintf(
+				"LauncherConfig %q referenced in CountForLauncher does not exist", cr.LauncherConfigName))
+		}
+	}
+
+	// Combine all user-facing errors and write LPP.Status (the SOLE writer).
+	allErrs := append([]string(nil), selectorErrs...)
+	allErrs = append(allErrs, missingLCs...)
+	if statusErr := ctl.setLPPStatusErrors(ctx, lpp, allErrs); statusErr != nil {
+		return fmt.Errorf("failed to set Status for policy %s: %w", lpp.Name, statusErr)
+	}
+
+	// Snapshot the LPP digest.
+	ctl.policy.lpps[name] = &lppDigest{
+		object:       lpp,
+		selectorErrs: selectorErrs,
+		missingLCs:   missingLCs,
+	}
+
+	// Determine old matched nodes from existing digest entries.
+	oldNodes := sets.New[string]()
+	for nodeName, nodeMap := range ctl.policy.digest {
+		for _, entry := range nodeMap {
+			if _, hasLPP := entry.lpps[name]; hasLPP {
+				oldNodes.Insert(nodeName)
+				break
+			}
+		}
+	}
+	currentMatched := sets.New[string]()
+	for _, node := range currentMatchedNodes {
+		currentMatched.Insert(node.Name)
+	}
+	removedNodes := oldNodes.Difference(currentMatched).UnsortedList()
+
+	// Detach the LPP from entries on nodes it no longer matches.
+	for _, nodeName := range removedNodes {
+		nodeMap := ctl.policy.digest[nodeName]
+		for lcName, entry := range nodeMap {
+			if _, hasLPP := entry.lpps[name]; !hasLPP {
+				continue
+			}
+			ctl.detachLPPFromEntry(nodeMap, name, nodeName, lcName, entry)
+		}
+	}
+
+	// Apply LPP to each matched node and enqueue affected keys.
+	for _, node := range currentMatchedNodes {
+		ctl.applyLPPToDigestForNode(lpp, node.Name)
+		for _, cr := range lpp.Spec.CountForLauncher {
+			ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: node.Name, LauncherConfigName: cr.LauncherConfigName}})
+		}
+	}
+
+	return nil
+}
+
+// updateDigestForNode handles a Node add/update/delete event.
+// It recomputes digest entries for the affected node by replaying every cached
+// LPP. It does not validate templates or write Status; those are produced by
+// updateDigestForLC / updateDigestForLPP exclusively.
+func (ctl *controller) updateDigestForNode(ctx context.Context, nodeName string) error {
+	logger := klog.FromContext(ctx)
+
+	_, err := ctl.nodeLister.Get(nodeName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Node deleted, removing from digest", "node", nodeName)
+			removedKeys := ctl.policy.removeNode(nodeName)
+			for _, key := range removedKeys {
+				ctl.keyQueue.Queue.Add(keyItem{key})
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+	return ctl.recomputeDigestForNode(nodeName)
+}
+
+// recomputeDigestForNode rebuilds digest entries for a single node by replaying
+// every cached LPP. Pure read of ctl.policy.lpps + ctl.policy.lcs.
+func (ctl *controller) recomputeDigestForNode(nodeName string) error {
+	ctl.policy.digest[nodeName] = make(map[string]*digestEntry)
+
+	for _, lppd := range ctl.policy.lpps {
+		if lppd == nil || lppd.object == nil {
+			continue
+		}
+		ctl.applyLPPToDigestForNode(lppd.object, nodeName)
+	}
+
+	nodeMap := ctl.policy.digest[nodeName]
+	for lcName := range nodeMap {
+		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
+	}
+	if len(nodeMap) == 0 {
+		delete(ctl.policy.digest, nodeName)
+	}
+	return nil
+}
+
+// applyLPPToDigestForNode evaluates one LPP for one node and updates the digest
+// using ONLY ctl.policy.lcs as the source of truth for LC status. It never
+// validates templates, writes Status, or fetches from listers.
+func (ctl *controller) applyLPPToDigestForNode(lpp *fmav1alpha1.LauncherPopulationPolicy, nodeName string) {
+	node, err := ctl.nodeLister.Get(nodeName)
+	if err != nil {
+		// Node missing or transient lister error: nothing to apply.
+		return
+	}
+	labelSelector, selectorErr := metav1.LabelSelectorAsSelector(&lpp.Spec.EnhancedNodeSelector.LabelSelector)
+	if selectorErr != nil {
+		return
+	}
+	if !labelSelector.Matches(labels.Set(node.Labels)) {
+		return
+	}
+	if !matchesResourceConditions(node.Status.Allocatable, lpp.Spec.EnhancedNodeSelector.AllocatableResources) {
+		return
+	}
+
+	for _, cr := range lpp.Spec.CountForLauncher {
+		lcName := cr.LauncherConfigName
+
+		entry := ctl.policy.getEntry(nodeName, lcName)
+		if entry == nil {
+			entry = &digestEntry{lpps: make(map[string]*fmav1alpha1.LauncherPopulationPolicy)}
+			ctl.policy.setEntry(nodeName, lcName, entry)
+		}
+
+		lcd := ctl.policy.lcDigestFor(lcName)
+		switch {
+		case lcd == nil || lcd.object == nil:
+			// LC not yet processed or known to be absent: handsOff. The LC's
+			// own update path (updateDigestForLC) will re-enqueue this LPP
+			// when the LC becomes existent.
+			entry.handsOff = true
+			entry.spec = nil
+		case lcd.templateErr != "":
+			// Template invalid; error is already in LC.Status.
+			entry.handsOff = true
+			entry.spec = nil
+		default:
+			entry.handsOff = false
+			entry.spec = &lcd.object.Spec
+			entry.ownerRef = lcd.ownerRef
+		}
+
+		if cr.LauncherCount > entry.count {
+			entry.count = cr.LauncherCount
+		}
+		if entry.lpps == nil {
+			entry.lpps = make(map[string]*fmav1alpha1.LauncherPopulationPolicy)
+		}
+		entry.lpps[lpp.Name] = lpp
+	}
+}
+
+// removeLPPFromEntry removes an LPP reference from a digest entry.
+// If the entry has no remaining LPPs, it is reset to a zero state.
+func (ctl *controller) removeLPPFromEntry(entry *digestEntry, lppName string) {
+	delete(entry.lpps, lppName)
+	if len(entry.lpps) == 0 {
+		entry.count = 0
+		entry.spec = nil
+		entry.handsOff = false
+	}
+}
+
+func (ctl *controller) detachLPPFromEntry(nodeMap map[string]*digestEntry, lppName, nodeName, lcName string, entry *digestEntry) {
+	ctl.removeLPPFromEntry(entry, lppName)
+	if len(entry.lpps) == 0 {
+		delete(nodeMap, lcName)
+		if len(nodeMap) == 0 {
+			delete(ctl.policy.digest, nodeName)
+		}
+	} else {
+		ctl.recomputeEntryFromLPPs(entry, lcName)
+	}
+	ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
+}
+
+// recomputeEntryFromLPPs recomputes the (handsOff, count, spec, ownerRef) of a
+// digestEntry from its remaining LPP references and the cached lcDigest.
+// Pure read; no Status writes or template validation.
+func (ctl *controller) recomputeEntryFromLPPs(entry *digestEntry, lcName string) {
+	if len(entry.lpps) == 0 {
+		entry.count = 0
+		entry.spec = nil
+		entry.handsOff = false
+		return
+	}
+
+	var maxCount int32
+	for _, lpp := range entry.lpps {
+		for _, cr := range lpp.Spec.CountForLauncher {
+			if cr.LauncherConfigName == lcName && cr.LauncherCount > maxCount {
+				maxCount = cr.LauncherCount
+			}
+		}
+	}
+
+	lcd := ctl.policy.lcDigestFor(lcName)
+	switch {
+	case lcd == nil || lcd.object == nil:
+		entry.handsOff = true
+		entry.count = maxCount
+		entry.spec = nil
+	case lcd.templateErr != "":
+		entry.handsOff = true
+		entry.count = maxCount
+		entry.spec = nil
+	default:
+		entry.handsOff = false
+		entry.count = maxCount
+		entry.spec = &lcd.object.Spec
+		entry.ownerRef = lcd.ownerRef
+	}
+}
+
+

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -54,14 +54,8 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 		if !prevExists {
 			return nil
 		}
-		logger.Info("LC deleted, marking referencing keys as handsOff", "config", name)
+		logger.Info("LC deleted, requeuing referencing LPPs", "config", name)
 		delete(ctl.policy.lcs, name)
-		for key, entry := range ctl.policy.entriesForLC(name) {
-			entry.handsOff = true
-			entry.spec = nil
-			entry.count = 0
-			ctl.keyQueue.Queue.Add(keyItem{key})
-		}
 		for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
 			ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
 		}
@@ -89,8 +83,10 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 	}
 
 	prevTemplateErr := ""
+	prevTemplateHash := ""
 	if prev != nil {
 		prevTemplateErr = prev.templateErr
+		prevTemplateHash = prev.templateHash
 	}
 
 	ctl.policy.lcs[name] = &lcDigest{
@@ -100,26 +96,10 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 		ownerRef:     makeLCOwnerRef(lc),
 	}
 
-	// If the LC just became existent, or its template-validity flipped, the
-	// LPPs that reference it must be re-evaluated.
-	if !prevExists || prevTemplateErr != templateErr {
+	if !prevExists || prevTemplateErr != templateErr || prevTemplateHash != templateHash {
 		for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
 			ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
 		}
-	}
-
-	// Refresh per-key entries that reference this LC.
-	lcd := ctl.policy.lcs[name]
-	for key, entry := range ctl.policy.entriesForLC(name) {
-		if templateErr != "" {
-			entry.handsOff = true
-			entry.spec = nil
-		} else {
-			entry.handsOff = false
-			entry.spec = &lcd.object.Spec
-			entry.ownerRef = lcd.ownerRef
-		}
-		ctl.keyQueue.Queue.Add(keyItem{key})
 	}
 	return nil
 }
@@ -325,16 +305,22 @@ func (ctl *controller) removeLPPFromEntry(entry *digestEntry, lppName string) {
 }
 
 func (ctl *controller) detachLPPFromEntry(nodeMap map[string]*digestEntry, lppName, nodeName, lcName string, entry *digestEntry) {
+	prevHandsOff, prevCount := entry.handsOff, entry.count
+
 	ctl.removeLPPFromEntry(entry, lppName)
 	if len(entry.lpps) == 0 {
 		delete(nodeMap, lcName)
 		if len(nodeMap) == 0 {
 			delete(ctl.policy.digest, nodeName)
 		}
-	} else {
-		ctl.recomputeEntryFromLPPs(entry, lcName)
+		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
+		return
 	}
-	ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
+
+	ctl.recomputeEntryFromLPPs(entry, lcName)
+	if entry.handsOff != prevHandsOff || entry.count != prevCount {
+		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
+	}
 }
 
 // recomputeEntryFromLPPs recomputes the (handsOff, count, spec, ownerRef) of a

--- a/pkg/controller/launcher-populator/digested-policy.go
+++ b/pkg/controller/launcher-populator/digested-policy.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcherpopulator
+
+import (
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
+)
+
+// digestEntry is the per-NodeLauncherKey entry in the digestedPolicy.
+// It holds the digested desired count and supporting details needed for
+// creating launcher Pods.
+type digestEntry struct {
+	handsOff bool   // true when user error (LC missing or invalid template) precludes action
+	count    int32  // max over relevant (existing, well-formed) CountForLauncher
+	spec     *fmav1alpha1.LauncherConfigSpec
+	ownerRef metav1.OwnerReference
+	lpps     map[string]*fmav1alpha1.LauncherPopulationPolicy // LPPs contributing to this entry
+}
+
+// lcDigest holds all node-independent derived data for a LauncherConfig.
+// Written exclusively by updateDigestForLC; read by all other paths.
+type lcDigest struct {
+	object       *fmav1alpha1.LauncherConfig // nil iff the LC API object does not exist
+	templateErr  string                      // empty when ValidateLauncherPodTemplate passes
+	templateHash string                      // populated only when templateErr == ""
+	ownerRef     metav1.OwnerReference       // populated only when object != nil
+}
+
+// lppDigest holds all derived data for a LauncherPopulationPolicy.
+// Written exclusively by updateDigestForLPP; read by all other paths.
+type lppDigest struct {
+	object       *fmav1alpha1.LauncherPopulationPolicy
+	selectorErrs []string // user-facing errors from getMatchingNodes
+	missingLCs   []string // CountForLauncher entries referencing a non-existent LC
+}
+
+// digestedPolicy holds the controller's digested view of all policies.
+// It is the single source of truth for per-key reconciliation:
+//   - digest maps each (node, LC) pair to its desired state. INVARIANT: an outer
+//     nodeName key exists if and only if its inner map is non-empty; mutators
+//     must remove the outer key when the last inner entry is deleted.
+//   - lcs caches the per-LC digest, including template validation result and hash.
+//   - lpps caches the per-LPP digest, including selector errors and missing-LC list.
+//
+// Concurrency: mu serializes write transactions performed by the (single)
+// digest worker against snapshot reads performed by the keyQueue workers. The
+// digest worker holds Lock() for the duration of one updateDigestForX call;
+// readers hold RLock() while taking a small value-typed snapshot, then drop
+// the lock before issuing K8s API calls.
+type digestedPolicy struct {
+	mu     sync.RWMutex
+	digest map[string]map[string]*digestEntry // node name → LC name → entry
+	lcs    map[string]*lcDigest               // LC name → lcDigest
+	lpps   map[string]*lppDigest              // LPP name → lppDigest
+}
+
+// keySnapshot is a value-typed view of one digestEntry plus the LC's template
+// hash, captured under digestedPolicy.mu.RLock(). Once returned, the snapshot
+// is safe to read outside the lock; underlying *fmav1alpha1.LauncherConfigSpec
+// points into the informer cache, which Kubernetes does not mutate in place.
+type keySnapshot struct {
+	exists       bool
+	handsOff     bool
+	count        int32
+	spec         *fmav1alpha1.LauncherConfigSpec
+	ownerRef     metav1.OwnerReference
+	templateHash string
+}
+
+// newDigestedPolicy creates an empty digestedPolicy.
+func newDigestedPolicy() *digestedPolicy {
+	return &digestedPolicy{
+		digest: make(map[string]map[string]*digestEntry),
+		lcs:    make(map[string]*lcDigest),
+		lpps:   make(map[string]*lppDigest),
+	}
+}
+
+// lcDigestFor returns the lcDigest for lcName, or nil when the LC has not been
+// processed yet.
+func (dp *digestedPolicy) lcDigestFor(lcName string) *lcDigest {
+	return dp.lcs[lcName]
+}
+
+// lppNamesRefByLC returns names of all cached LPPs that reference lcName in
+// their CountForLauncher list. Used to enqueue dependents on LC existence
+// transitions or template-validity changes.
+func (dp *digestedPolicy) lppNamesRefByLC(lcName string) []string {
+	var names []string
+	for name, lppd := range dp.lpps {
+		if lppd == nil || lppd.object == nil {
+			continue
+		}
+		for _, cr := range lppd.object.Spec.CountForLauncher {
+			if cr.LauncherConfigName == lcName {
+				names = append(names, name)
+				break
+			}
+		}
+	}
+	return names
+}
+
+// getEntry returns the digestEntry for the given key, or nil if absent.
+func (dp *digestedPolicy) getEntry(nodeName, lcName string) *digestEntry {
+	if nodeMap, ok := dp.digest[nodeName]; ok {
+		return nodeMap[lcName]
+	}
+	return nil
+}
+
+// setEntry sets or replaces the digestEntry for the given key.
+func (dp *digestedPolicy) setEntry(nodeName, lcName string, entry *digestEntry) {
+	nodeMap, ok := dp.digest[nodeName]
+	if !ok {
+		nodeMap = make(map[string]*digestEntry)
+		dp.digest[nodeName] = nodeMap
+	}
+	nodeMap[lcName] = entry
+}
+
+// removeNode removes all digest entries for a node and returns the removed keys.
+func (dp *digestedPolicy) removeNode(nodeName string) []NodeLauncherKey {
+	nodeMap, ok := dp.digest[nodeName]
+	if !ok {
+		return nil
+	}
+	keys := make([]NodeLauncherKey, 0, len(nodeMap))
+	for lcName := range nodeMap {
+		keys = append(keys, NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName})
+	}
+	delete(dp.digest, nodeName)
+	return keys
+}
+
+// keysForLC returns all NodeLauncherKeys that reference the given LC name.
+func (dp *digestedPolicy) keysForLC(lcName string) []NodeLauncherKey {
+	var keys []NodeLauncherKey
+	for nodeName, nodeMap := range dp.digest {
+		if _, ok := nodeMap[lcName]; ok {
+			keys = append(keys, NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName})
+		}
+	}
+	return keys
+}
+
+// allKeys returns all NodeLauncherKeys in the digest.
+func (dp *digestedPolicy) allKeys() []NodeLauncherKey {
+	var keys []NodeLauncherKey
+	for nodeName, nodeMap := range dp.digest {
+		for lcName := range nodeMap {
+			keys = append(keys, NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName})
+		}
+	}
+	return keys
+}
+
+// snapshotForKey returns a value-typed snapshot of the digestEntry and its
+// LC's templateHash, taken under RLock. Concurrency-safe; callers must drop
+// the snapshot before treating any pointer fields (spec) as still belonging
+// to the digest.
+func (dp *digestedPolicy) snapshotForKey(key NodeLauncherKey) keySnapshot {
+	dp.mu.RLock()
+	defer dp.mu.RUnlock()
+	var snap keySnapshot
+	if entry := dp.getEntry(key.NodeName, key.LauncherConfigName); entry != nil {
+		snap.exists = true
+		snap.handsOff = entry.handsOff
+		snap.count = entry.count
+		snap.spec = entry.spec
+		snap.ownerRef = entry.ownerRef
+	}
+	if lcd := dp.lcs[key.LauncherConfigName]; lcd != nil {
+		snap.templateHash = lcd.templateHash
+	}
+	return snap
+}

--- a/pkg/controller/launcher-populator/digested-policy.go
+++ b/pkg/controller/launcher-populator/digested-policy.go
@@ -17,7 +17,6 @@ limitations under the License.
 package launcherpopulator
 
 import (
-	"iter"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,25 +135,6 @@ func (dp *digestedPolicy) setEntry(nodeName, lcName string, entry *digestEntry) 
 		dp.digest[nodeName] = nodeMap
 	}
 	nodeMap[lcName] = entry
-}
-
-// entriesForLC yields every (key, entry) pair that references lcName. Each
-// yielded entry is non-nil. The caller must not insert into or delete from
-// dp.digest while iterating; mutating fields on the yielded *digestEntry is
-// allowed.
-func (dp *digestedPolicy) entriesForLC(lcName string) iter.Seq2[NodeLauncherKey, *digestEntry] {
-	return func(yield func(NodeLauncherKey, *digestEntry) bool) {
-		for nodeName, nodeMap := range dp.digest {
-			entry, ok := nodeMap[lcName]
-			if !ok {
-				continue
-			}
-			key := NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}
-			if !yield(key, entry) {
-				return
-			}
-		}
-	}
 }
 
 // allKeys returns all NodeLauncherKeys in the digest.

--- a/pkg/controller/launcher-populator/digested-policy.go
+++ b/pkg/controller/launcher-populator/digested-policy.go
@@ -137,17 +137,6 @@ func (dp *digestedPolicy) setEntry(nodeName, lcName string, entry *digestEntry) 
 	nodeMap[lcName] = entry
 }
 
-// allKeys returns all NodeLauncherKeys in the digest.
-func (dp *digestedPolicy) allKeys() []NodeLauncherKey {
-	var keys []NodeLauncherKey
-	for nodeName, nodeMap := range dp.digest {
-		for lcName := range nodeMap {
-			keys = append(keys, NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName})
-		}
-	}
-	return keys
-}
-
 // snapshotForKey returns a value-typed snapshot of the digestEntry and its
 // LC's templateHash, taken under RLock. Concurrency-safe; callers must drop
 // the snapshot before treating any pointer fields (spec) as still belonging

--- a/pkg/controller/launcher-populator/digested-policy.go
+++ b/pkg/controller/launcher-populator/digested-policy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package launcherpopulator
 
 import (
+	"iter"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -137,29 +138,23 @@ func (dp *digestedPolicy) setEntry(nodeName, lcName string, entry *digestEntry) 
 	nodeMap[lcName] = entry
 }
 
-// removeNode removes all digest entries for a node and returns the removed keys.
-func (dp *digestedPolicy) removeNode(nodeName string) []NodeLauncherKey {
-	nodeMap, ok := dp.digest[nodeName]
-	if !ok {
-		return nil
-	}
-	keys := make([]NodeLauncherKey, 0, len(nodeMap))
-	for lcName := range nodeMap {
-		keys = append(keys, NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName})
-	}
-	delete(dp.digest, nodeName)
-	return keys
-}
-
-// keysForLC returns all NodeLauncherKeys that reference the given LC name.
-func (dp *digestedPolicy) keysForLC(lcName string) []NodeLauncherKey {
-	var keys []NodeLauncherKey
-	for nodeName, nodeMap := range dp.digest {
-		if _, ok := nodeMap[lcName]; ok {
-			keys = append(keys, NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName})
+// entriesForLC yields every (key, entry) pair that references lcName. Each
+// yielded entry is non-nil. The caller must not insert into or delete from
+// dp.digest while iterating; mutating fields on the yielded *digestEntry is
+// allowed.
+func (dp *digestedPolicy) entriesForLC(lcName string) iter.Seq2[NodeLauncherKey, *digestEntry] {
+	return func(yield func(NodeLauncherKey, *digestEntry) bool) {
+		for nodeName, nodeMap := range dp.digest {
+			entry, ok := nodeMap[lcName]
+			if !ok {
+				continue
+			}
+			key := NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}
+			if !yield(key, entry) {
+				return
+			}
 		}
 	}
-	return keys
 }
 
 // allKeys returns all NodeLauncherKeys in the digest.

--- a/pkg/controller/launcher-populator/helpers.go
+++ b/pkg/controller/launcher-populator/helpers.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcherpopulator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+
+	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
+)
+
+// makeLCOwnerRef builds a non-controlling OwnerReference for a LauncherConfig.
+func makeLCOwnerRef(lc *fmav1alpha1.LauncherConfig) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         fmav1alpha1.SchemeGroupVersion.String(),
+		Kind:               "LauncherConfig",
+		Name:               lc.Name,
+		UID:                lc.UID,
+		Controller:         ptr.To(false),
+		BlockOwnerDeletion: ptr.To(false),
+	}
+}
+
+// nonNilSlice returns a single-element slice if s is non-empty, or nil otherwise.
+func nonNilSlice(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return []string{s}
+}
+
+// getMatchingNodes returns nodes that match the EnhancedNodeSelector.
+// It returns three values: the matched nodes, user-facing selector errors (non-nil when the
+// LabelSelector itself is malformed — this is a user configuration error), and an internal
+// error (non-nil for unexpected infrastructure failures such as lister errors).
+// Callers should handle selectorErrs and err independently.
+func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha1.EnhancedNodeSelector) ([]corev1.Node, []string, error) {
+	// Convert the label selector. A failure here is a user error (malformed LabelSelector).
+	labelSelector, selectorErr := metav1.LabelSelectorAsSelector(&selector.LabelSelector)
+	if selectorErr != nil {
+		return nil, []string{fmt.Sprintf("invalid label selector: %v", selectorErr)}, nil
+	}
+	nodes, err := ctl.nodeLister.List(labelSelector)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list nodes using nodeLister: %w", err)
+	}
+
+	var matchedNodes []corev1.Node
+	for _, node := range nodes {
+		if matchesResourceConditions(node.Status.Allocatable, selector.AllocatableResources) {
+			matchedNodes = append(matchedNodes, *node)
+		}
+	}
+	return matchedNodes, nil, nil
+}
+
+// isLauncherBoundToServerRequestingPod checks if the launcher pod is bound to any server-requesting pod
+func (ctl *controller) isLauncherBoundToServerRequestingPod(launcherPod *corev1.Pod) (bool, string) {
+	// Check if the launcher pod has annotations indicating assignment to a server-requesting pod
+	requesterAnnotationValue, exists := launcherPod.Annotations[common.RequesterAnnotationKey]
+	if !exists {
+		return false, ""
+	}
+
+	// Verify the format of the annotation value: should be "UID name"
+	parts := strings.Split(requesterAnnotationValue, " ")
+	if len(parts) != 2 {
+		return false, "" // Invalid format
+	}
+
+	// Optionally verify that the referenced pod actually exists
+	// @TODO if need, we can append the check logic in further PR
+
+	return true, parts[1]
+}
+
+// listPodsFromCache reads launcher pods from the informer's local cache (cheap).
+func (ctl *controller) listPodsFromCache(key NodeLauncherKey) ([]*corev1.Pod, error) {
+	launcherLabels := map[string]string{
+		common.ComponentLabelKey:          common.LauncherComponentLabelValue,
+		common.LauncherConfigNameLabelKey: key.LauncherConfigName,
+		common.NodeNameLabelKey:           key.NodeName,
+	}
+	pods, err := ctl.podLister.List(labels.SelectorFromSet(launcherLabels))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods from cache: %w", err)
+	}
+	return pods, nil
+}
+
+// listPodsFromApiserver queries the apiserver directly for launcher pods.
+// This is more expensive than the cache but provides authoritative state.
+// Used as a fallback when expectations time out.
+func (ctl *controller) listPodsFromApiserver(ctx context.Context, key NodeLauncherKey) ([]*corev1.Pod, error) {
+	launcherLabels := map[string]string{
+		common.ComponentLabelKey:          common.LauncherComponentLabelValue,
+		common.LauncherConfigNameLabelKey: key.LauncherConfigName,
+		common.NodeNameLabelKey:           key.NodeName,
+	}
+	selector := labels.SelectorFromSet(launcherLabels).String()
+	podList, err := ctl.coreclient.Pods(ctl.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods from apiserver: %w", err)
+	}
+	result := make([]*corev1.Pod, 0, len(podList.Items))
+	for i := range podList.Items {
+		result = append(result, &podList.Items[i])
+	}
+	return result, nil
+}
+
+// createLaunchers creates the specified number of launcher pods on a node
+// using the given LauncherConfig spec, owner reference, and the precomputed
+// node-independent template hash (snapshotted by processKey under RLock).
+func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, lcSpec *fmav1alpha1.LauncherConfigSpec, lcOwnerRef metav1.OwnerReference, templateHash string) error {
+	logger := klog.FromContext(ctx)
+
+	// Create the specified number of launcher pods
+	for i := 0; i < count; i++ {
+		pod, err := utils.BuildLauncherPodFromTemplate(lcSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName, templateHash)
+		if err != nil {
+			return fmt.Errorf("failed to build launcher pod: %w", err)
+		}
+		pod.OwnerReferences = []metav1.OwnerReference{lcOwnerRef}
+
+		createdPod, err := ctl.coreclient.Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create launcher pod: %w", err)
+		}
+		// Record expectation for this specific Pod UID immediately after creation.
+		ctl.expectations.expectCreation(key, createdPod.UID)
+		logger.Info("Created launcher pod",
+			"pod", createdPod.Name,
+			"uid", createdPod.UID,
+			"resourceVersion", createdPod.ResourceVersion,
+			"node", node.Name)
+	}
+
+	return nil
+}

--- a/pkg/controller/launcher-populator/helpers.go
+++ b/pkg/controller/launcher-populator/helpers.go
@@ -61,7 +61,7 @@ func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha
 	// Convert the label selector. A failure here is a user error (malformed LabelSelector).
 	labelSelector, selectorErr := metav1.LabelSelectorAsSelector(&selector.LabelSelector)
 	if selectorErr != nil {
-		return nil, []string{fmt.Sprintf("invalid label selector: %v", selectorErr)}, nil
+		return nil, []string{fmt.Sprintf("invalid label selector %#v: %v", selector.LabelSelector, selectorErr)}, nil
 	}
 	nodes, err := ctl.nodeLister.List(labelSelector)
 	if err != nil {

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -223,13 +222,13 @@ func (ctl *controller) OnAdd(obj any, isInInitialList bool) {
 			"node", nodeName, "config", lcName)
 		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
 	case *corev1.Node:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to Node add", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing Node reference due to Node add", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: typed.Name})
 	case *fmav1alpha1.LauncherPopulationPolicy:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LPP add", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to LPP add", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: typed.Name})
 	case *fmav1alpha1.LauncherConfig:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LC add", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to LC add", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: typed.Name})
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of add of object of ignored type", "type", fmt.Sprintf("%T", obj))
@@ -256,13 +255,13 @@ func (ctl *controller) OnUpdate(prev, obj any) {
 			"node", nodeName, "config", lcName)
 		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
 	case *corev1.Node:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to Node update", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing Node reference due to Node update", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: typed.Name})
 	case *fmav1alpha1.LauncherPopulationPolicy:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LPP update", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to LPP update", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: typed.Name})
 	case *fmav1alpha1.LauncherConfig:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LC update", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to LC update", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: typed.Name})
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of update of object of ignored type", "type", fmt.Sprintf("%T", obj))
@@ -287,13 +286,13 @@ func (ctl *controller) OnDelete(obj any) {
 			"node", nodeName, "config", lcName)
 		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
 	case *corev1.Node:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to Node delete", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing Node reference due to Node delete", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: typed.Name})
 	case *fmav1alpha1.LauncherPopulationPolicy:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LPP delete", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to LPP delete", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: typed.Name})
 	case *fmav1alpha1.LauncherConfig:
-		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LC delete", "name", typed.Name)
+		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to LC delete", "name", typed.Name)
 		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: typed.Name})
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of delete of object of ignored type", "type", fmt.Sprintf("%T", obj))
@@ -306,55 +305,15 @@ func (ctl *controller) Start(ctx context.Context) error {
 		return fmt.Errorf("caches not synced before end of Start context")
 	}
 
-	// Enqueue all currently-known LCs/LPPs/Nodes into the digest queue. The
-	// initial batch is processed through the same incremental code paths
-	// (updateDigestForLC/LPP/Node) used at runtime, so there is no separate
-	// "initial digest" code path.
-	if err := ctl.enqueueInitialBatch(); err != nil {
-		return fmt.Errorf("failed to enqueue initial batch: %w", err)
-	}
-
 	// Start digest workers. KnowsProcessedSync appends sentinels behind the
 	// initial batch and invokes onDigestSyncProcessed when those sentinels are
 	// drained, which is when keyQueue starts its workers.
 	return ctl.digestQueue.StartWorkers(ctx)
 }
 
-// enqueueInitialBatch lists all currently-cached LCs, LPPs, and Nodes and
-// enqueues a digest funcItem for each. Required ordering (LCs before LPPs) is
-// not strictly necessary because LC processing re-enqueues dependent LPPs on
-// existence transitions; doing it anyway keeps the typical no-flap path
-// shorter.
-func (ctl *controller) enqueueInitialBatch() error {
-	lcs, err := ctl.lcLister.LauncherConfigs(ctl.namespace).List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("failed to list LauncherConfigs: %w", err)
-	}
-	for _, lc := range lcs {
-		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: lc.Name})
-	}
-
-	lpps, err := ctl.lppLister.LauncherPopulationPolicies(ctl.namespace).List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("failed to list LauncherPopulationPolicies: %w", err)
-	}
-	for _, lpp := range lpps {
-		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lpp.Name})
-	}
-
-	nodes, err := ctl.nodeLister.List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("failed to list Nodes: %w", err)
-	}
-	for _, n := range nodes {
-		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: n.Name})
-	}
-	return nil
-}
-
-// onDigestSyncProcessed is invoked once by KnowsProcessedSync after the
-// initial batch of digest items has been drained. It starts keyQueue workers,
-// which process per-NodeLauncherKey reconciliation requests.
+// onDigestSyncProcessed is invoked by KnowsProcessedSync after the initial
+// batch of digest items has been drained. It starts keyQueue workers, which
+// process per-NodeLauncherKey reconciliation requests.
 func (ctl *controller) onDigestSyncProcessed(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Initial digest batch processed; starting key workers",
@@ -424,7 +383,7 @@ func (ctl *controller) processKey(ctx context.Context, key NodeLauncherKey) (err
 }
 
 // reconcileKey adjusts launcher pods for a single NodeLauncherKey to match the desired count.
-func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, desiredCount int32, lcSpec *fmav1alpha1.LauncherConfigSpec, ownerRef metav1.OwnerReference, nominalHash string) (error, bool) {
+func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, desiredCount int32, lcSpec *fmav1alpha1.LauncherConfigSpec, ownerRef metav1.OwnerReference, templateHash string) (error, bool) {
 	logger := klog.FromContext(ctx)
 
 	// Check node existence.
@@ -449,7 +408,7 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	// Read the node-independent template hash from the snapshot taken in
 	// processKey under RLock. Empty when LC is missing or template invalid.
 	if lcSpec == nil {
-		nominalHash = ""
+		templateHash = ""
 	}
 
 	// Categorize pods.
@@ -468,10 +427,9 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 			liveBoundCount++
 			continue
 		}
-		if nominalHash != "" {
+		if templateHash != "" {
 			podHash := pod.Annotations[string(common.LauncherTemplateHashAnnotationKey)]
-			// Pre-rollout Pods lack this annotation; treat empty as drift-free to avoid mass replacement.
-			if podHash != "" && podHash != nominalHash {
+			if podHash != "" && podHash != templateHash {
 				staleUnboundPods = append(staleUnboundPods, pod)
 				continue
 			}
@@ -496,7 +454,7 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 				staleNotDeleted++
 				continue
 			}
-			return fmt.Errorf("failed to delete stale launcher pod %s: %w", pod.Name, err), false
+			return fmt.Errorf("failed to delete stale launcher pod %s: %w", pod.Name, err), true
 		}
 		ctl.expectations.expectDeletion(key, pod.UID)
 		logger.Info("Deleted stale launcher pod", "pod", pod.Name, "uid", pod.UID, "node", key.NodeName)
@@ -529,7 +487,7 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 				if apierrors.IsConflict(err) {
 					continue
 				}
-				return fmt.Errorf("failed to delete launcher pod %s: %w", pod.Name, err), false
+				return fmt.Errorf("failed to delete launcher pod %s: %w", pod.Name, err), true
 			}
 			ctl.expectations.expectDeletion(key, pod.UID)
 			logger.Info("Deleted excess launcher pod", "pod", pod.Name, "uid", pod.UID, "node", key.NodeName)
@@ -546,7 +504,7 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	// Create pods if needed.
 	if diff > 0 && lcSpec != nil {
 		node, _ := ctl.nodeLister.Get(key.NodeName)
-		if err := ctl.createLaunchers(ctx, *node, key, int(diff), lcSpec, ownerRef, nominalHash); err != nil {
+		if err := ctl.createLaunchers(ctx, *node, key, int(diff), lcSpec, ownerRef, templateHash); err != nil {
 			return err, true
 		}
 		logger.Info("Created launchers", "node", key.NodeName, "config", key.LauncherConfigName, "count", diff)

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -19,7 +19,6 @@ package launcherpopulator
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
@@ -29,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 
 	corev1preinformers "k8s.io/client-go/informers/core/v1"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -39,7 +37,6 @@ import (
 
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	genctlr "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic"
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
 	fmaclientv1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/clientset/versioned/typed/fma/v1alpha1"
 	fmainformers "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/informers/externalversions"
 	fmalisters "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/generated/listers/fma/v1alpha1"
@@ -77,10 +74,30 @@ func NewController(
 		lcLister:      fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
 		expectations:  newPendingExpectations(expectationTimeout),
 	}
+	ctl.policy = newDigestedPolicy()
 
-	// Use a single worker thread to ensure sequential processing of LauncherPopulationPolicy updates
-	// Prevents race conditions when multiple threads simultaneously modify the same node/configuration pairs
-	ctl.QueueAndWorkers = genctlr.NewQueueAndWorkers(ControllerName, 1, ctl.process)
+	// digestQueue carries funcItem (LC/LPP/Node references). One worker keeps
+	// digest mutations sequential and lock-free. KnowsProcessedSync emits the
+	// onDigestSyncProcessed hook after the initial batch drains, which is when
+	// keyQueue's workers start.
+	digestQueue := genctlr.NewKnowsProcessedSync[queueItem](
+		ControllerName+"-digest", 1,
+		ctl.processDigestItem,
+		makeDigestSentinel, isDigestSentinel,
+		ctl.onDigestSyncProcessed,
+	)
+	ctl.digestQueue = &digestQueue
+
+	// keyQueue carries keyItem (NodeLauncherKey reconciliation requests).
+	// Multiple workers process keys in parallel; concurrency safety relies on
+	// digestedPolicy.mu (RLock for snapshot reads, Lock for digest mutations
+	// performed by digestQueue's single worker).
+	keyQueue := genctlr.NewQueueAndWorkers[keyItem](
+		ControllerName+"-key", 4,
+		ctl.processKeyItem,
+	)
+	ctl.keyQueue = &keyQueue
+
 	_, err := ctl.podInformer.AddEventHandler(ctl)
 	if err != nil {
 		panic(err)
@@ -115,49 +132,73 @@ type controller struct {
 	lppLister     fmalisters.LauncherPopulationPolicyLister
 	lcInformer    cache.SharedIndexInformer
 	lcLister      fmalisters.LauncherConfigLister
-	genctlr.KnowsProcessedSync[queueItem]
+
+	// digestQueue processes API-object references (LC/LPP/Node). Single worker;
+	// the SOLE writer of ctl.policy.
+	digestQueue *genctlr.KnowsProcessedSync[queueItem]
+
+	// keyQueue processes per-NodeLauncherKey reconciliation. Started by
+	// onDigestSyncProcessed once the initial batch has drained.
+	keyQueue *genctlr.QueueAndWorkers[keyItem]
 
 	// expectations tracks pending Pod create/delete mutations not yet reflected
 	// in the informer's local cache. This prevents the controller from making
 	// decisions based on stale cache state between reconcile cycles.
 	expectations *pendingExpectations
+
+	// policy holds the digested view of all LauncherPopulationPolicies,
+	// LauncherConfigs, and their per-(node, LC) desired state.
+	// It is the single source of truth for per-key reconciliation.
+	// Written only by the digestQueue worker; read by keyQueue workers.
+	policy *digestedPolicy
 }
 
 var _ Controller = &controller{}
 
-// queueItem is the work-queue element type. Each concrete kind implements
-// process so that the dispatcher in (*controller).process can fan out to the
-// right reconciliation entry point.
-//
-// Why distinct types per source kind:
-//   - lppItem and lcItem carry a cache.ObjectName, anticipating issue #472,
-//     where LauncherPopulationPolicy and LauncherConfig events are expected
-//     to drive a more targeted reconciliation keyed by the affected object
-//     rather than always running a full reconcile.
-//   - Pod and Node events do not yet have a meaningful per-object
-//     reconciliation path, so they share a single reconcileAllSentinel.
-//     When #472 is resolved, this sentinel can be replaced with concrete
-//     object references analogous to lppItem / lcItem.
-type queueItem interface {
-	// process returns (err error, retry bool).
-	// There will be a retry iff `retry`, error logged if `err != nil`.
-	process(ctx context.Context, ctl *controller) (error, bool)
+// queueItem is the work-queue element type for the digest queue. Concrete
+// elements are funcItem (LPP/LC/Node references) plus sentinel funcItems
+// (kind=kindSentinel) emitted by KnowsProcessedSync. processDigestItem
+// dispatches on the dynamic type. The element type is a value-typed struct so
+// the workqueue can compare/hash entries safely; closures must NOT be embedded
+// because Go function values are not comparable and would panic at runtime
+// when the workqueue deduplicates entries.
+type queueItem interface{}
+
+// resourceKind identifies the kind of cluster resource a funcItem refers to.
+type resourceKind uint8
+
+const (
+	kindLPP resourceKind = iota
+	kindLC
+	kindNode
+	kindSentinel // emitted by KnowsProcessedSync to mark end of initial batch
+)
+
+// funcItem is a digest-level update request, identified by (kind, name).
+// Dispatch happens in processDigestItem.
+type funcItem struct {
+	kind resourceKind
+	name string
 }
 
-type lppItem struct {
-	cache.ObjectName
+// keyItem identifies a (node, LC) pair for per-key reconciliation.
+type keyItem struct {
+	NodeLauncherKey
 }
 
-type lcItem struct {
-	cache.ObjectName
+// makeDigestSentinel produces a unique sentinel funcItem per worker. The
+// distinguisher in the name keeps sentinels mutually distinct so they are not
+// deduplicated by the workqueue.
+func makeDigestSentinel(distinguisher int) queueItem {
+	return funcItem{kind: kindSentinel, name: fmt.Sprintf("sentinel-%d", distinguisher)}
 }
 
-// reconcileAllSentinel is the placeholder enqueued for Pod and Node events.
-// These event sources currently trigger a full reconciliation; the sentinel
-// lets the work queue deduplicate bursts of such events into a single cycle.
-// Once #472 introduces targeted, object-keyed reconciliation, the Pod and
-// Node paths can graduate to their own reference-bearing item types.
-type reconcileAllSentinel struct{}
+// isDigestSentinel reports whether item is a sentinel emitted by
+// KnowsProcessedSync.
+func isDigestSentinel(item queueItem) bool {
+	f, ok := item.(funcItem)
+	return ok && f.kind == kindSentinel
+}
 
 // isLauncherPod returns true if the Pod is a launcher pod managed by this controller.
 // It checks for the presence of the LauncherConfigNameLabelKey label, which is
@@ -175,20 +216,21 @@ func (ctl *controller) OnAdd(obj any, isInInitialList bool) {
 			ctl.enqueueLogger.V(5).Info("Ignored add of non-launcher Pod", "name", typed.Name)
 			return
 		}
-		// Pending creation expectations are reconciled lazily in check() against
-		// the informer cache, so no observation bookkeeping is required here.
-		ctl.enqueueLogger.V(5).Info("Enqueuing reconciliation due to launcher Pod add",
-			"name", typed.Name, "uid", typed.UID, "resourceVersion", typed.ResourceVersion)
-		ctl.Queue.Add(reconcileAllSentinel{})
+		nodeName := typed.Labels[common.NodeNameLabelKey]
+		lcName := typed.Labels[common.LauncherConfigNameLabelKey]
+		ctl.enqueueLogger.V(5).Info("Enqueuing key due to launcher Pod add",
+			"name", typed.Name, "uid", typed.UID, "resourceVersion", typed.ResourceVersion,
+			"node", nodeName, "config", lcName)
+		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
 	case *corev1.Node:
-		ctl.enqueueLogger.V(5).Info("Enqueuing reconciliation due to Node add", "name", typed.Name)
-		ctl.Queue.Add(reconcileAllSentinel{})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to Node add", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: typed.Name})
 	case *fmav1alpha1.LauncherPopulationPolicy:
-		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to notification of add", "name", typed.Name)
-		ctl.Queue.Add(lppItem{cache.MetaObjectToName(typed)})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LPP add", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: typed.Name})
 	case *fmav1alpha1.LauncherConfig:
-		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to notification of add", "name", typed.Name)
-		ctl.Queue.Add(lcItem{cache.MetaObjectToName(typed)})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LC add", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: typed.Name})
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of add of object of ignored type", "type", fmt.Sprintf("%T", obj))
 		return
@@ -202,23 +244,26 @@ func (ctl *controller) OnUpdate(prev, obj any) {
 			ctl.enqueueLogger.V(5).Info("Ignored update of non-launcher Pod", "name", typed.Name)
 			return
 		}
+		nodeName := typed.Labels[common.NodeNameLabelKey]
+		lcName := typed.Labels[common.LauncherConfigNameLabelKey]
 		prevRV := ""
 		if prevPod, ok := prev.(*corev1.Pod); ok {
 			prevRV = prevPod.ResourceVersion
 		}
-		ctl.enqueueLogger.V(5).Info("Enqueuing reconciliation due to launcher Pod update",
+		ctl.enqueueLogger.V(5).Info("Enqueuing key due to launcher Pod update",
 			"name", typed.Name, "uid", typed.UID,
-			"prevResourceVersion", prevRV, "resourceVersion", typed.ResourceVersion)
-		ctl.Queue.Add(reconcileAllSentinel{})
+			"prevResourceVersion", prevRV, "resourceVersion", typed.ResourceVersion,
+			"node", nodeName, "config", lcName)
+		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
 	case *corev1.Node:
-		ctl.enqueueLogger.V(5).Info("Enqueuing reconciliation due to Node update", "name", typed.Name)
-		ctl.Queue.Add(reconcileAllSentinel{})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to Node update", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: typed.Name})
 	case *fmav1alpha1.LauncherPopulationPolicy:
-		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to notification of update", "name", typed.Name)
-		ctl.Queue.Add(lppItem{cache.MetaObjectToName(typed)})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LPP update", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: typed.Name})
 	case *fmav1alpha1.LauncherConfig:
-		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherConfig reference due to notification of update", "name", typed.Name)
-		ctl.Queue.Add(lcItem{cache.MetaObjectToName(typed)})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LC update", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: typed.Name})
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of update of object of ignored type", "type", fmt.Sprintf("%T", obj))
 		return
@@ -235,17 +280,21 @@ func (ctl *controller) OnDelete(obj any) {
 			ctl.enqueueLogger.V(5).Info("Ignored delete of non-launcher Pod", "name", typed.Name)
 			return
 		}
-		// Pending deletion expectations are reconciled lazily in check() against
-		// the informer cache, so no observation bookkeeping is required here.
-		ctl.enqueueLogger.V(5).Info("Enqueuing reconciliation due to launcher Pod delete",
-			"name", typed.Name, "uid", typed.UID, "resourceVersion", typed.ResourceVersion)
-		ctl.Queue.Add(reconcileAllSentinel{})
+		nodeName := typed.Labels[common.NodeNameLabelKey]
+		lcName := typed.Labels[common.LauncherConfigNameLabelKey]
+		ctl.enqueueLogger.V(5).Info("Enqueuing key due to launcher Pod delete",
+			"name", typed.Name, "uid", typed.UID, "resourceVersion", typed.ResourceVersion,
+			"node", nodeName, "config", lcName)
+		ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
 	case *corev1.Node:
-		ctl.enqueueLogger.V(5).Info("Enqueuing reconciliation due to Node delete", "name", typed.Name)
-		ctl.Queue.Add(reconcileAllSentinel{})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to Node delete", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: typed.Name})
 	case *fmav1alpha1.LauncherPopulationPolicy:
-		ctl.enqueueLogger.V(5).Info("Enqueuing LauncherPopulationPolicy reference due to notification of delete", "name", typed.Name)
-		ctl.Queue.Add(lppItem{cache.MetaObjectToName(typed)})
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LPP delete", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: typed.Name})
+	case *fmav1alpha1.LauncherConfig:
+		ctl.enqueueLogger.V(5).Info("Enqueuing digest update due to LC delete", "name", typed.Name)
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: typed.Name})
 	default:
 		ctl.enqueueLogger.V(5).Info("Notified of delete of object of ignored type", "type", fmt.Sprintf("%T", obj))
 		return
@@ -256,463 +305,254 @@ func (ctl *controller) Start(ctx context.Context) error {
 	if !cache.WaitForNamedCacheSync(ControllerName, ctx.Done(), ctl.lppInformer.HasSynced, ctl.lcInformer.HasSynced, ctl.podInformer.HasSynced, ctl.nodeInformer.HasSynced) {
 		return fmt.Errorf("caches not synced before end of Start context")
 	}
-	err := ctl.QueueAndWorkers.StartWorkers(ctx)
+
+	// Enqueue all currently-known LCs/LPPs/Nodes into the digest queue. The
+	// initial batch is processed through the same incremental code paths
+	// (updateDigestForLC/LPP/Node) used at runtime, so there is no separate
+	// "initial digest" code path.
+	if err := ctl.enqueueInitialBatch(); err != nil {
+		return fmt.Errorf("failed to enqueue initial batch: %w", err)
+	}
+
+	// Start digest workers. KnowsProcessedSync appends sentinels behind the
+	// initial batch and invokes onDigestSyncProcessed when those sentinels are
+	// drained, which is when keyQueue starts its workers.
+	return ctl.digestQueue.StartWorkers(ctx)
+}
+
+// enqueueInitialBatch lists all currently-cached LCs, LPPs, and Nodes and
+// enqueues a digest funcItem for each. Required ordering (LCs before LPPs) is
+// not strictly necessary because LC processing re-enqueues dependent LPPs on
+// existence transitions; doing it anyway keeps the typical no-flap path
+// shorter.
+func (ctl *controller) enqueueInitialBatch() error {
+	lcs, err := ctl.lcLister.LauncherConfigs(ctl.namespace).List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("failed to start workers: %w", err)
+		return fmt.Errorf("failed to list LauncherConfigs: %w", err)
+	}
+	for _, lc := range lcs {
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLC, name: lc.Name})
+	}
+
+	lpps, err := ctl.lppLister.LauncherPopulationPolicies(ctl.namespace).List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list LauncherPopulationPolicies: %w", err)
+	}
+	for _, lpp := range lpps {
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lpp.Name})
+	}
+
+	nodes, err := ctl.nodeLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list Nodes: %w", err)
+	}
+	for _, n := range nodes {
+		ctl.digestQueue.Queue.Add(funcItem{kind: kindNode, name: n.Name})
 	}
 	return nil
 }
 
-// process returns (err error, retry bool).
-// There will be a retry iff `retry`, error logged if `err != nil`.
-func (ctl *controller) process(ctx context.Context, item queueItem) (error, bool) {
-	return item.process(ctx, ctl)
-}
-
-func (lppItem) process(ctx context.Context, ctl *controller) (error, bool) {
-	// Until #472 introduces targeted reconciliation keyed by policy,
-	// any LauncherPopulationPolicy event drives a full reconcile.
-	return ctl.reconcileFromPolicies(ctx)
-}
-
-func (lcItem) process(ctx context.Context, ctl *controller) (error, bool) {
-	// Until #472 introduces targeted reconciliation keyed by config,
-	// any LauncherConfig event drives a full reconcile. Missing
-	// LauncherConfigs are handled inside buildDesiredStateFromPolicies.
-	return ctl.reconcileFromPolicies(ctx)
-}
-
-func (reconcileAllSentinel) process(ctx context.Context, ctl *controller) (error, bool) {
-	// Pod and Node events trigger a full reconciliation: they may shift the
-	// effective population on a node or change which nodes match policies.
-	return ctl.reconcileFromPolicies(ctx)
-}
-
-// reconcileFromPolicies builds the desired state from all policies and reconciles
-// all launcher pods accordingly. It is the common implementation shared by
-// every queueItem.process method.
-func (ctl *controller) reconcileFromPolicies(ctx context.Context) (error, bool) {
+// onDigestSyncProcessed is invoked once by KnowsProcessedSync after the
+// initial batch of digest items has been drained. It starts keyQueue workers,
+// which process per-NodeLauncherKey reconciliation requests.
+func (ctl *controller) onDigestSyncProcessed(ctx context.Context) {
 	logger := klog.FromContext(ctx)
+	logger.V(1).Info("Initial digest batch processed; starting key workers",
+		"lpps", len(ctl.policy.lpps), "lcs", len(ctl.policy.lcs), "keys", len(ctl.policy.allKeys()))
+	if err := ctl.keyQueue.StartWorkers(ctx); err != nil {
+		logger.Error(err, "Failed to start key workers")
+	}
+}
 
-	// Build desired state from all policies
-	populationPolicy, err := ctl.buildDesiredStateFromPolicies(ctx)
+// processDigestItem is the work function for the digest queue. Sentinels are
+// intercepted by KnowsProcessedSync.earlySync and never reach this function.
+// Acquires the policy write lock for the duration of the dispatch so all
+// mutations within one updateDigestForX call appear atomic to keyQueue
+// workers reading via snapshotForKey.
+func (ctl *controller) processDigestItem(ctx context.Context, item queueItem) (error, bool) {
+	f, ok := item.(funcItem)
+	if !ok {
+		return fmt.Errorf("unknown digest queue item type: %T", item), false
+	}
+	ctl.policy.mu.Lock()
+	defer ctl.policy.mu.Unlock()
+	var err error
+	switch f.kind {
+	case kindLPP:
+		err = ctl.updateDigestForLPP(ctx, f.name)
+	case kindLC:
+		err = ctl.updateDigestForLC(ctx, f.name)
+	case kindNode:
+		err = ctl.updateDigestForNode(ctx, f.name)
+	default:
+		return fmt.Errorf("unknown funcItem kind: %d", f.kind), false
+	}
 	if err != nil {
-		logger.Error(err, "Failed to build desired state from policies")
 		return err, true
 	}
-
-	logger.Info("Final population policy", "policy", populationPolicy)
-
-	// Adjust launcher pods according to final requirements
-	needsRequeue, err := ctl.reconcileAllLaunchers(ctx, populationPolicy)
-	if err != nil {
-		logger.Error(err, "Failed to reconcile launchers")
-		return err, true
-	}
-
-	return nil, needsRequeue
+	return nil, false
 }
 
-// nodeDesiredGroup holds the per-node desired state with keys pre-collected
-// to avoid an extra iteration when passing to reconcileLaunchersOnSingleNode.
-type nodeDesiredGroup struct {
-	keys    []NodeLauncherKey
-	desired map[NodeLauncherKey]DesiredStateEntry
+// processKeyItem is the work function for the key queue.
+func (ctl *controller) processKeyItem(ctx context.Context, item keyItem) (error, bool) {
+	return ctl.processKey(ctx, item.NodeLauncherKey)
 }
 
-func (g *nodeDesiredGroup) String() string {
-	return fmt.Sprintf("keys=%v,desired=%v", g.keys, MapToLoggable(g.desired))
-}
-
-// buildDesiredStateFromPolicies builds the desired state map from all policies.
-// It reads each LauncherConfig from the informer's local cache to verify existence
-// and obtain the current spec. LauncherConfigs that do not exist are skipped.
-// The result is grouped by node with keys pre-collected so that the caller can
-// directly iterate over each node's desired LauncherConfigs without additional reshaping.
-func (ctl *controller) buildDesiredStateFromPolicies(ctx context.Context) (map[string]*nodeDesiredGroup, error) {
+// processKey reconciles launchers for a single NodeLauncherKey.
+// It snapshots the desired state from the digest under RLock, then drops the
+// lock before issuing K8s API calls so multiple workers can proceed in parallel.
+func (ctl *controller) processKey(ctx context.Context, key NodeLauncherKey) (error, bool) {
 	logger := klog.FromContext(ctx)
 
-	policies, err := ctl.lppLister.List(labels.Everything())
-	if err != nil {
-		return nil, fmt.Errorf("failed to list LauncherPopulationPolicies: %w", err)
+	snap := ctl.policy.snapshotForKey(key)
+	if !snap.exists {
+		// Key not in digest: no policy wants this (node, LC) pair.
+		// Clean up any orphaned launchers.
+		logger.V(4).Info("Key not in digest, cleaning up orphaned launchers",
+			"node", key.NodeName, "config", key.LauncherConfigName)
+		return ctl.reconcileKey(ctx, key, 0, nil, metav1.OwnerReference{}, "")
 	}
 
-	// lcStatusReported tracks LauncherConfigs whose Status has already been updated this
-	// reconcile cycle. A single LauncherConfig may be referenced by multiple policies or
-	// multiple count rules; we only need one Status update per LC per cycle.
-	lcStatusReported := make(map[string]struct{})
-
-	desiredByNode := make(map[string]*nodeDesiredGroup)
-	for _, lpp := range policies {
-		nodes, selectorErrs, err := ctl.getMatchingNodes(ctx, lpp.Spec.EnhancedNodeSelector)
-		// Ensure proper status for lpp.
-		if statusErr := ctl.setLPPStatusErrors(ctx, lpp, selectorErrs); statusErr != nil {
-			logger.Error(statusErr, "Failed to set Status for policy", "policy", lpp.Name)
-		}
-		if err != nil {
-			// This is an infrastructure error: the lister failed to list nodes.
-			logger.Error(err, "Failed to get matching nodes for policy", "policy", lpp.Name)
-			continue
-		}
-
-		for _, countRule := range lpp.Spec.CountForLauncher {
-			// Read the LauncherConfig from informer's local cache to verify existence
-			// and get the current spec (needed for A3: spec-change detection)
-			lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(countRule.LauncherConfigName)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					logger.Info("LauncherConfig referenced in policy does not exist, skipping",
-						"config", countRule.LauncherConfigName, "policy", lpp.Name)
-					continue
-				}
-				return nil, fmt.Errorf("failed to get LauncherConfig %s: %w", countRule.LauncherConfigName, err)
-			}
-
-			// Validate the PodTemplate once per LauncherConfig, not once per node.
-			// This is a user error if the inference server container is missing.
-			var lcTemplateErrs []string
-			if templateErr := utils.ValidateLauncherPodTemplate(lc.Spec.PodTemplate); templateErr != nil {
-				logger.Error(templateErr, "Invalid PodTemplate in LauncherConfig, reporting in Status",
-					"config", countRule.LauncherConfigName, "policy", lpp.Name)
-				lcTemplateErrs = []string{templateErr.Error()}
-			}
-			// Unconditionally ensure the LauncherConfig Status reflects the current state.
-			// setLCStatusErrors is idempotent and skips the API call if Status is already correct.
-			// Guard with lcStatusReported so that a LC referenced by multiple policies or
-			// multiple count rules only triggers one Status update per reconcile cycle.
-			if _, alreadyReported := lcStatusReported[lc.Name]; !alreadyReported {
-				if statusErr := ctl.setLCStatusErrors(ctx, lc, lcTemplateErrs); statusErr != nil {
-					logger.Error(statusErr, "Failed to set Status for LauncherConfig", "config", countRule.LauncherConfigName)
-				}
-				lcStatusReported[lc.Name] = struct{}{}
-			}
-			if len(lcTemplateErrs) > 0 {
-				continue
-			}
-
-			for _, node := range nodes {
-				key := NodeLauncherKey{
-					NodeName:           node.Name,
-					LauncherConfigName: countRule.LauncherConfigName,
-				}
-				ownerRef := metav1.OwnerReference{
-					APIVersion:         fmav1alpha1.SchemeGroupVersion.String(),
-					Kind:               "LauncherConfig",
-					Name:               lc.Name,
-					UID:                lc.UID,
-					Controller:         ptr.To(false),
-					BlockOwnerDeletion: ptr.To(false),
-				}
-
-				group, exists := desiredByNode[node.Name]
-				if !exists {
-					group = &nodeDesiredGroup{
-						desired: make(map[NodeLauncherKey]DesiredStateEntry),
-					}
-					desiredByNode[node.Name] = group
-				}
-				if entry, exists := group.desired[key]; !exists || countRule.LauncherCount > entry.Count {
-					if _, keyExists := group.desired[key]; !keyExists {
-						group.keys = append(group.keys, key)
-					}
-					group.desired[key] = DesiredStateEntry{
-						Count:                  countRule.LauncherCount,
-						LauncherConfigSpec:     &lc.Spec,
-						LauncherConfigOwnerRef: ownerRef,
-					}
-				}
-			}
-		}
+	if snap.handsOff {
+		// User error (LC missing or invalid template): take no action.
+		logger.V(4).Info("Key is handsOff due to user error, skipping",
+			"node", key.NodeName, "config", key.LauncherConfigName)
+		return nil, false
 	}
 
-	return desiredByNode, nil
+	return ctl.reconcileKey(ctx, key, snap.count, snap.spec, snap.ownerRef, snap.templateHash)
 }
 
-// getMatchingNodes returns nodes that match the EnhancedNodeSelector.
-// It returns three values: the matched nodes, user-facing selector errors (non-nil when the
-// LabelSelector itself is malformed — this is a user configuration error), and an internal
-// error (non-nil for unexpected infrastructure failures such as lister errors).
-// Callers should handle selectorErrs and err independently.
-func (ctl *controller) getMatchingNodes(ctx context.Context, selector fmav1alpha1.EnhancedNodeSelector) ([]corev1.Node, []string, error) {
-	// Convert the label selector. A failure here is a user error (malformed LabelSelector).
-	labelSelector, selectorErr := metav1.LabelSelectorAsSelector(&selector.LabelSelector)
-	if selectorErr != nil {
-		return nil, []string{fmt.Sprintf("invalid label selector: %v", selectorErr)}, nil
-	}
-	nodes, err := ctl.nodeLister.List(labelSelector)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list nodes using nodeLister: %w", err)
-	}
-
-	var matchedNodes []corev1.Node
-	for _, node := range nodes {
-		if matchesResourceConditions(node.Status.Allocatable, selector.AllocatableResources) {
-			matchedNodes = append(matchedNodes, *node)
-		}
-	}
-	return matchedNodes, nil, nil
-}
-
-// reconcileAllLaunchers adjusts all launcher pods according to final requirements.
-// It returns true if a requeue is needed (deletions were performed or are in progress),
-// so that creations happen only after deletions have taken effect.
-func (ctl *controller) reconcileAllLaunchers(ctx context.Context, desiredByNode map[string]*nodeDesiredGroup) (bool, error) {
+// reconcileKey adjusts launcher pods for a single NodeLauncherKey to match the desired count.
+func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, desiredCount int32, lcSpec *fmav1alpha1.LauncherConfigSpec, ownerRef metav1.OwnerReference, nominalHash string) (error, bool) {
 	logger := klog.FromContext(ctx)
 
-	anyRequeueNeeded := false
-	for nodeName, group := range desiredByNode {
-		needsRequeue, err := ctl.reconcileLaunchersOnSingleNode(ctx, nodeName, group.keys, group.desired)
-		if err != nil {
-			logger.Error(err, "Failed to reconcile launchers on node", "node", nodeName)
-			anyRequeueNeeded = true
-			continue
-		}
-		anyRequeueNeeded = anyRequeueNeeded || needsRequeue
-	}
-
-	return anyRequeueNeeded, nil
-}
-
-// reconcileLaunchersOnSingleNode handles all LauncherConfigs for a single node.
-// For each LauncherConfig, it does deletions immediately as they are identified
-// and remembers creations called for. If any deletions were performed (or are in
-// progress from a previous cycle), it returns true to request a requeue so that
-// creations happen only after deletions have taken effect, minimizing peak resource
-// consumption on the node.
-// So that when a LauncherConfig changes, each corresponding launcher Pod that is
-// not bound to a server-requesting Pod is deleted and replaced.
-func (ctl *controller) reconcileLaunchersOnSingleNode(ctx context.Context, nodeName string, keys []NodeLauncherKey, desired map[NodeLauncherKey]DesiredStateEntry) (bool, error) {
-	logger := klog.FromContext(ctx)
-
-	node, err := ctl.nodeLister.Get(nodeName)
-	if err != nil {
+	// Check node existence.
+	if _, err := ctl.nodeLister.Get(key.NodeName); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("Node no longer exists, skipping reconciliation", "node", nodeName)
-			return false, nil
+			logger.V(4).Info("Node no longer exists, skipping key reconciliation", "node", key.NodeName)
+			return nil, false
 		}
-		logger.Error(err, "Unexpected error from node lister (should be impossible), will retry", "node", nodeName)
-		return true, nil
+		return err, true
 	}
 
+	// Get current launchers and check expectations.
+	currentLaunchers, expectStatus, err := ctl.getCurrentLaunchersOnNode(ctx, key)
+	if err != nil {
+		logger.Error(err, "Failed to get current launchers", "node", key.NodeName, "config", key.LauncherConfigName)
+		return err, true
+	}
+	if expectStatus == ExpectationsWaiting {
+		return nil, true // requeue
+	}
+
+	// Read the node-independent template hash from the snapshot taken in
+	// processKey under RLock. Empty when LC is missing or template invalid.
+	if lcSpec == nil {
+		nominalHash = ""
+	}
+
+	// Categorize pods.
+	var liveBoundCount int
+	var liveUnboundCurrentPods []*corev1.Pod
+	var staleUnboundPods []*corev1.Pod
+	deletionInProgress := false
+
+	for _, pod := range currentLaunchers {
+		if pod.DeletionTimestamp != nil {
+			deletionInProgress = true
+			continue
+		}
+		isBound, _ := ctl.isLauncherBoundToServerRequestingPod(pod)
+		if isBound {
+			liveBoundCount++
+			continue
+		}
+		if nominalHash != "" {
+			podHash := pod.Annotations[string(common.LauncherTemplateHashAnnotationKey)]
+			// Pre-rollout Pods lack this annotation; treat empty as drift-free to avoid mass replacement.
+			if podHash != "" && podHash != nominalHash {
+				staleUnboundPods = append(staleUnboundPods, pod)
+				continue
+			}
+		}
+		liveUnboundCurrentPods = append(liveUnboundCurrentPods, pod)
+	}
+
+	// Delete stale pods.
 	didDelete := false
-	deletionInProgress := false  // tracks pods already being deleted (DeletionTimestamp set)
-	deletionShortfall := false   // excess-pod deletion loop could not delete as many as needed
-	expectationsWaiting := false // at least one key has unsatisfied expectations
-
-	type creationInfo struct {
-		key   NodeLauncherKey
-		count int
-		spec  *fmav1alpha1.LauncherConfigSpec
-		owner metav1.OwnerReference
-	}
-	var creations []creationInfo
-
-	// Process each LauncherConfig on this node
-	for _, key := range keys {
-		entry := desired[key]
-
-		currentLaunchers, expectStatus, err := ctl.getCurrentLaunchersOnNode(ctx, key)
+	staleNotDeleted := 0
+	for _, pod := range staleUnboundPods {
+		err := ctl.coreclient.Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &pod.UID, ResourceVersion: &pod.ResourceVersion},
+		})
 		if err != nil {
-			// Log and skip this config rather than aborting the entire reconciliation.
-			logger.Error(err, "Failed to get current launchers for config",
-				"node", nodeName, "config", key.LauncherConfigName)
-			continue
-		}
-		if expectStatus == ExpectationsWaiting {
-			// Cache not yet up-to-date for this key; skip and request requeue.
-			expectationsWaiting = true
-			continue
-		}
-
-		// Compute the nominal hash for spec-change detection.
-		// BuildLauncherPodFromTemplate computes a hash of the fully built pod spec
-		// and stores it as the LauncherConfigHashAnnotationKey annotation.
-		// The PodTemplate has already been validated in buildDesiredStateFromPolicies;
-		// any LC with an invalid template is excluded from the desired map.
-		nominalHash := ""
-		if entry.LauncherConfigSpec != nil {
-			nominalPod, err := utils.BuildLauncherPodFromTemplate(
-				entry.LauncherConfigSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
-			if err != nil {
-				// Should not happen: template was already validated upstream.
-				logger.Error(err, "Unexpected error building nominal pod (template should have been validated)",
-					"node", nodeName, "config", key.LauncherConfigName)
-			} else {
-				nominalHash = nominalPod.Annotations[string(common.LauncherConfigHashAnnotationKey)]
-			}
-		}
-
-		// Categorize current pods: separate live unbound current-spec pods from stale/unbound ones
-		var liveBoundCount int
-		var liveUnboundCurrentPods []*corev1.Pod // live, unbound, spec matches current LauncherConfig
-		var staleUnboundPods []*corev1.Pod       // live, unbound, spec is stale
-
-		for _, pod := range currentLaunchers {
-			// Skip pods already being deleted
-			if pod.DeletionTimestamp != nil {
-				deletionInProgress = true
+			if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
+				ctl.expectations.expectDeletion(key, pod.UID)
+				logger.Info("Stale launcher pod already deleted", "pod", pod.Name, "uid", pod.UID)
 				continue
 			}
-
-			isBound, _ := ctl.isLauncherBoundToServerRequestingPod(pod)
-			if isBound {
-				liveBoundCount++
+			if apierrors.IsConflict(err) {
+				staleNotDeleted++
 				continue
 			}
-
-			// Check if pod spec is stale (LauncherConfig changed)
-			if nominalHash != "" {
-				podHash := pod.Annotations[string(common.LauncherConfigHashAnnotationKey)]
-				if podHash != nominalHash {
-					staleUnboundPods = append(staleUnboundPods, pod)
-					continue
-				}
-			}
-
-			liveUnboundCurrentPods = append(liveUnboundCurrentPods, pod)
+			return fmt.Errorf("failed to delete stale launcher pod %s: %w", pod.Name, err), false
 		}
+		ctl.expectations.expectDeletion(key, pod.UID)
+		logger.Info("Deleted stale launcher pod", "pod", pod.Name, "uid", pod.UID, "node", key.NodeName)
+		didDelete = true
+	}
 
-		// Delete stale pods immediately (spec changed → delete and replace)
-		staleNotDeleted := 0
-		for _, pod := range staleUnboundPods {
+	// Calculate diff.
+	effectiveRemaining := liveBoundCount + len(liveUnboundCurrentPods) + staleNotDeleted
+	diff := desiredCount - int32(effectiveRemaining)
+
+	logger.Info("Analyzed key",
+		"node", key.NodeName, "config", key.LauncherConfigName,
+		"current", effectiveRemaining, "stale", len(staleUnboundPods),
+		"desired", desiredCount, "diff", diff)
+
+	// Delete excess pods.
+	if diff < 0 {
+		numToDelete := int(-diff)
+		for i := len(liveUnboundCurrentPods) - 1; i >= 0 && numToDelete > 0; i-- {
+			pod := liveUnboundCurrentPods[i]
 			err := ctl.coreclient.Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{UID: &pod.UID, ResourceVersion: &pod.ResourceVersion},
 			})
 			if err != nil {
 				if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
-					// Pod is already gone from the apiserver, but the informer cache
-					// may not yet reflect that. Record the deletion expectation so the
-					// next reconcile waits for cache synchronization rather than trying
-					// to act on a Pod that no longer exists.
 					ctl.expectations.expectDeletion(key, pod.UID)
-					logger.Info("Stale launcher pod already deleted",
-						"pod", pod.Name, "uid", pod.UID, "resourceVersion", pod.ResourceVersion)
+					numToDelete--
 					continue
 				}
 				if apierrors.IsConflict(err) {
-					// Pod was modified (e.g. bound) since we read it; skip deletion.
-					staleNotDeleted++
-					logger.Info("Stale launcher pod was modified since read, skipping deletion",
-						"pod", pod.Name, "uid", pod.UID, "resourceVersion", pod.ResourceVersion)
 					continue
 				}
-				return false, fmt.Errorf("failed to delete stale launcher pod %s (uid=%s, resourceVersion=%s): %w",
-					pod.Name, pod.UID, pod.ResourceVersion, err)
+				return fmt.Errorf("failed to delete launcher pod %s: %w", pod.Name, err), false
 			}
-			// Record expectation for this specific Pod UID immediately after deletion.
 			ctl.expectations.expectDeletion(key, pod.UID)
-			logger.Info("Deleted stale launcher pod (spec changed)",
-				"pod", pod.Name,
-				"uid", pod.UID,
-				"resourceVersion", pod.ResourceVersion,
-				"node", nodeName,
-				"config", key.LauncherConfigName)
+			logger.Info("Deleted excess launcher pod", "pod", pod.Name, "uid", pod.UID, "node", key.NodeName)
 			didDelete = true
-		}
-
-		// Calculate diff based on effective remaining pods after stale deletion
-		effectiveRemaining := liveBoundCount + len(liveUnboundCurrentPods) + staleNotDeleted
-		diff := entry.Count - int32(effectiveRemaining)
-
-		logger.Info("Analyzed config on node",
-			"node", nodeName,
-			"config", key.LauncherConfigName,
-			"current", effectiveRemaining,
-			"stale", len(staleUnboundPods),
-			"desired", entry.Count,
-			"diff", diff)
-
-		if diff < 0 {
-			// Need to delete excess pods from live unbound current pods
-			numToDelete := int(-diff)
-			for i := len(liveUnboundCurrentPods) - 1; i >= 0 && numToDelete > 0; i-- {
-				pod := liveUnboundCurrentPods[i]
-				err := ctl.coreclient.Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
-					Preconditions: &metav1.Preconditions{UID: &pod.UID, ResourceVersion: &pod.ResourceVersion},
-				})
-				if err != nil {
-					if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
-						// Pod is already gone from the apiserver, but the informer cache
-						// may not yet reflect that. Record the deletion expectation so the
-						// next reconcile waits for cache synchronization rather than trying
-						// to act on a Pod that no longer exists.
-						ctl.expectations.expectDeletion(key, pod.UID)
-						logger.Info("Launcher pod already deleted",
-							"pod", pod.Name, "uid", pod.UID, "resourceVersion", pod.ResourceVersion)
-						numToDelete--
-						continue
-					}
-					if apierrors.IsConflict(err) {
-						// Pod was modified (e.g. bound) since we read it; skip deletion.
-						logger.Info("Launcher pod was modified since read, skipping deletion",
-							"pod", pod.Name, "uid", pod.UID, "resourceVersion", pod.ResourceVersion)
-						continue
-					}
-					return false, fmt.Errorf("failed to delete launcher pod %s (uid=%s, resourceVersion=%s): %w",
-						pod.Name, pod.UID, pod.ResourceVersion, err)
-				}
-				// Record expectation for this specific Pod UID immediately after deletion.
-				ctl.expectations.expectDeletion(key, pod.UID)
-				logger.Info("Deleted excess launcher pod",
-					"pod", pod.Name,
-					"uid", pod.UID,
-					"resourceVersion", pod.ResourceVersion,
-					"node", nodeName,
-					"config", key.LauncherConfigName)
-				didDelete = true
-				numToDelete--
-			}
-			if numToDelete > 0 {
-				deletionShortfall = true
-			}
-		} else if diff > 0 {
-			// Remember creations called for (will be executed only if no deletions)
-			creations = append(creations, creationInfo{
-				key:   key,
-				count: int(diff),
-				spec:  entry.LauncherConfigSpec,
-				owner: entry.LauncherConfigOwnerRef,
-			})
+			numToDelete--
 		}
 	}
 
-	// If any deletions were performed or are in progress, or the desired reduction
-	// in launcher count was not fully achieved, or expectations are still pending,
-	// requeue for later. This ensures that deletions take effect before any creations
-	// happen, so that freed resources are available for newly created pods.
-	if didDelete || deletionInProgress || deletionShortfall || expectationsWaiting {
-		logger.Info("Requeuing for creation later",
-			"node", nodeName,
-			"didDelete", didDelete,
-			"deletionInProgress", deletionInProgress,
-			"deletionShortfall", deletionShortfall,
-			"expectationsWaiting", expectationsWaiting)
-		return true, nil
+	// If any deletions happened or are in progress, requeue before creating.
+	if didDelete || deletionInProgress {
+		return nil, true
 	}
 
-	// No deletions needed, proceed with planned creations
-	totalCreated := 0
-	for _, creation := range creations {
-		if err := ctl.createLaunchers(ctx, *node, creation.key, creation.count, creation.spec, creation.owner); err != nil {
-			logger.Error(err, "Failed to create launchers for config",
-				"node", nodeName,
-				"config", creation.key.LauncherConfigName,
-				"count", creation.count)
-			return false, err
+	// Create pods if needed.
+	if diff > 0 && lcSpec != nil {
+		node, _ := ctl.nodeLister.Get(key.NodeName)
+		if err := ctl.createLaunchers(ctx, *node, key, int(diff), lcSpec, ownerRef, nominalHash); err != nil {
+			return err, true
 		}
-		totalCreated += creation.count
-		logger.Info("Created launchers for config",
-			"node", nodeName,
-			"config", creation.key.LauncherConfigName,
-			"created", creation.count)
+		logger.Info("Created launchers", "node", key.NodeName, "config", key.LauncherConfigName, "count", diff)
 	}
 
-	logger.Info("Completed reconciliation for node",
-		"node", nodeName,
-		"configs_processed", len(keys),
-		"created", totalCreated)
-
-	return false, nil
+	return nil, false
 }
 
 // getCurrentLaunchersOnNode returns launcher pods for a specific config on a specific node.
@@ -759,90 +599,4 @@ func (ctl *controller) getCurrentLaunchersOnNode(ctx context.Context, key NodeLa
 
 	// unreachable
 	return nil, ExpectationsSatisfied, nil
-}
-
-// listPodsFromCache reads launcher pods from the informer's local cache (cheap).
-func (ctl *controller) listPodsFromCache(key NodeLauncherKey) ([]*corev1.Pod, error) {
-	launcherLabels := map[string]string{
-		common.ComponentLabelKey:          common.LauncherComponentLabelValue,
-		common.LauncherConfigNameLabelKey: key.LauncherConfigName,
-		common.NodeNameLabelKey:           key.NodeName,
-	}
-	pods, err := ctl.podLister.List(labels.SelectorFromSet(launcherLabels))
-	if err != nil {
-		return nil, fmt.Errorf("failed to list pods from cache: %w", err)
-	}
-	return pods, nil
-}
-
-// listPodsFromApiserver queries the apiserver directly for launcher pods.
-// This is more expensive than the cache but provides authoritative state.
-// Used as a fallback when expectations time out.
-func (ctl *controller) listPodsFromApiserver(ctx context.Context, key NodeLauncherKey) ([]*corev1.Pod, error) {
-	launcherLabels := map[string]string{
-		common.ComponentLabelKey:          common.LauncherComponentLabelValue,
-		common.LauncherConfigNameLabelKey: key.LauncherConfigName,
-		common.NodeNameLabelKey:           key.NodeName,
-	}
-	selector := labels.SelectorFromSet(launcherLabels).String()
-	podList, err := ctl.coreclient.Pods(ctl.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: selector,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list pods from apiserver: %w", err)
-	}
-	result := make([]*corev1.Pod, 0, len(podList.Items))
-	for i := range podList.Items {
-		result = append(result, &podList.Items[i])
-	}
-	return result, nil
-}
-
-// createLaunchers creates the specified number of launcher pods on a node
-// using the given LauncherConfig spec and owner reference directly (no additional lookup needed).
-func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, lcSpec *fmav1alpha1.LauncherConfigSpec, lcOwnerRef metav1.OwnerReference) error {
-	logger := klog.FromContext(ctx)
-
-	// Create the specified number of launcher pods
-	for i := 0; i < count; i++ {
-		pod, err := utils.BuildLauncherPodFromTemplate(lcSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName)
-		if err != nil {
-			return fmt.Errorf("failed to build launcher pod: %w", err)
-		}
-		pod.OwnerReferences = []metav1.OwnerReference{lcOwnerRef}
-
-		createdPod, err := ctl.coreclient.Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to create launcher pod: %w", err)
-		}
-		// Record expectation for this specific Pod UID immediately after creation.
-		ctl.expectations.expectCreation(key, createdPod.UID)
-		logger.Info("Created launcher pod",
-			"pod", createdPod.Name,
-			"uid", createdPod.UID,
-			"resourceVersion", createdPod.ResourceVersion,
-			"node", node.Name)
-	}
-
-	return nil
-}
-
-// isLauncherBoundToServerRequestingPod checks if the launcher pod is bound to any server-requesting pod
-func (ctl *controller) isLauncherBoundToServerRequestingPod(launcherPod *corev1.Pod) (bool, string) {
-	// Check if the launcher pod has annotations indicating assignment to a server-requesting pod
-	requesterAnnotationValue, exists := launcherPod.Annotations[common.RequesterAnnotationKey]
-	if !exists {
-		return false, ""
-	}
-
-	// Verify the format of the annotation value: should be "UID name"
-	parts := strings.Split(requesterAnnotationValue, " ")
-	if len(parts) != 2 {
-		return false, "" // Invalid format
-	}
-
-	// Optionally verify that the referenced pod actually exists
-	// @TODO if need, we can append the check logic in further PR
-
-	return true, parts[1]
 }

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -75,8 +75,8 @@ func NewController(
 	}
 	ctl.policy = newDigestedPolicy()
 
-	// digestQueue carries funcItem (LC/LPP/Node references). One worker keeps
-	// digest mutations sequential and lock-free. KnowsProcessedSync emits the
+	// digestQueue carries funcItem (LC/LPP/Node references). Single worker, so
+	// digest mutations are serial. KnowsProcessedSync emits the
 	// onDigestSyncProcessed hook after the initial batch drains, which is when
 	// keyQueue's workers start.
 	digestQueue := genctlr.NewKnowsProcessedSync[queueItem](
@@ -317,7 +317,7 @@ func (ctl *controller) Start(ctx context.Context) error {
 func (ctl *controller) onDigestSyncProcessed(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Initial digest batch processed; starting key workers",
-		"lpps", len(ctl.policy.lpps), "lcs", len(ctl.policy.lcs), "keys", len(ctl.policy.allKeys()))
+		"lpps", len(ctl.policy.lpps), "lcs", len(ctl.policy.lcs), "keys", ctl.keyQueue.Queue.Len())
 	if err := ctl.keyQueue.StartWorkers(ctx); err != nil {
 		logger.Error(err, "Failed to start key workers")
 	}

--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -25,10 +25,11 @@ import (
 	"maps"
 	"regexp"
 	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
@@ -156,9 +157,79 @@ func IsPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// BuildLauncherPodFromTemplate creates a launcher pod from a LauncherConfig object's
-// Spec.PodTemplate and assigns the built launcher pod to a node
-func BuildLauncherPodFromTemplate(template v1alpha1.EmbeddedPodTemplateSpec, ns, nodeName, launcherConfigName string) (*corev1.Pod, error) {
+// ComputeLauncherTemplateHash returns a deterministic, node-independent hash of the launcher Pod template.
+func ComputeLauncherTemplateHash(template v1alpha1.EmbeddedPodTemplateSpec) (string, error) {
+	canonical := canonicalizeTemplateForHash(template)
+	bytes, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal template for hashing: %w", err)
+	}
+	sum := sha256.Sum256(bytes)
+	return base64.RawStdEncoding.EncodeToString(sum[:]), nil
+}
+
+// canonicalizeTemplateForHash returns a deep-copied template with order-independent slices sorted, suitable for stable serialization.
+func canonicalizeTemplateForHash(template v1alpha1.EmbeddedPodTemplateSpec) v1alpha1.EmbeddedPodTemplateSpec {
+	out := v1alpha1.EmbeddedPodTemplateSpec{
+		Metadata: *template.Metadata.DeepCopy(),
+		Spec:     *DeIndividualize(template.Spec.DeepCopy()),
+	}
+	for i := range out.Spec.Containers {
+		canonicalizeContainer(&out.Spec.Containers[i])
+	}
+	for i := range out.Spec.InitContainers {
+		canonicalizeContainer(&out.Spec.InitContainers[i])
+	}
+	slices.SortStableFunc(out.Spec.Volumes, func(a, b corev1.Volume) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	slices.SortStableFunc(out.Spec.Tolerations, func(a, b corev1.Toleration) int {
+		if c := strings.Compare(a.Key, b.Key); c != 0 {
+			return c
+		}
+		if c := strings.Compare(string(a.Operator), string(b.Operator)); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Value, b.Value); c != 0 {
+			return c
+		}
+		return strings.Compare(string(a.Effect), string(b.Effect))
+	})
+	slices.SortStableFunc(out.Spec.ImagePullSecrets, func(a, b corev1.LocalObjectReference) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return out
+}
+
+func canonicalizeContainer(c *corev1.Container) {
+	slices.SortStableFunc(c.Env, func(a, b corev1.EnvVar) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	slices.SortStableFunc(c.VolumeMounts, func(a, b corev1.VolumeMount) int {
+		if cmp := strings.Compare(a.Name, b.Name); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.MountPath, b.MountPath)
+	})
+	slices.SortStableFunc(c.Ports, func(a, b corev1.ContainerPort) int {
+		if cmp := strings.Compare(a.Name, b.Name); cmp != 0 {
+			return cmp
+		}
+		if a.ContainerPort != b.ContainerPort {
+			if a.ContainerPort < b.ContainerPort {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(string(a.Protocol), string(b.Protocol))
+	})
+	slices.SortStableFunc(c.EnvFrom, func(a, b corev1.EnvFromSource) int {
+		return strings.Compare(a.Prefix, b.Prefix)
+	})
+}
+
+// BuildLauncherPodFromTemplate builds a launcher Pod for nodeName from the given template; templateHash (typically cached per LC.ResourceVersion) is recorded under LauncherTemplateHashAnnotationKey for spec-drift detection, alongside the legacy node-aware LauncherConfigHashAnnotationKey used by the dual-pods indexer.
+func BuildLauncherPodFromTemplate(template v1alpha1.EmbeddedPodTemplateSpec, ns, nodeName, launcherConfigName, templateHash string) (*corev1.Pod, error) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      maps.Clone(template.Metadata.Labels),
@@ -191,7 +262,10 @@ func BuildLauncherPodFromTemplate(template v1alpha1.EmbeddedPodTemplateSpec, ns,
 	if pod.Annotations == nil {
 		pod.Annotations = make(map[string]string)
 	}
+	// Legacy node-aware hash for the dual-pods indexer.
 	pod.Annotations = MapSet(pod.Annotations, string(common.LauncherConfigHashAnnotationKey), nominalHash)
+	// Node-independent template fingerprint for spec-drift detection; empty value is recorded as-is.
+	pod.Annotations = MapSet(pod.Annotations, string(common.LauncherTemplateHashAnnotationKey), templateHash)
 
 	cIdx, err := GetInferenceServerContainerIndex(pod)
 	if err != nil {

--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -251,10 +251,6 @@ func BuildLauncherPodFromTemplate(template v1alpha1.EmbeddedPodTemplateSpec, ns,
 	hasher := sha256.New()
 	modifiedJSON, _ := json.Marshal(pod)
 	hasher.Write(modifiedJSON)
-	hasher.Write([]byte(";gpus="))
-	hasher.Write([]byte("all")) //@TODO will be refined
-	hasher.Write([]byte(";node="))
-	hasher.Write([]byte(nodeName))
 	var modifiedHash [sha256.Size]byte
 	modifiedHashSl := hasher.Sum(modifiedHash[:0])
 	nominalHash := base64.RawStdEncoding.EncodeToString(modifiedHashSl)
@@ -262,10 +258,10 @@ func BuildLauncherPodFromTemplate(template v1alpha1.EmbeddedPodTemplateSpec, ns,
 	if pod.Annotations == nil {
 		pod.Annotations = make(map[string]string)
 	}
-	// Legacy node-aware hash for the dual-pods indexer.
-	pod.Annotations = MapSet(pod.Annotations, string(common.LauncherConfigHashAnnotationKey), nominalHash)
+	// Legacy Pod hash for the dual-pods indexer (SHA256 of the Pod JSON above).
+	pod.Annotations[string(common.LauncherConfigHashAnnotationKey)] = nominalHash
 	// Node-independent template fingerprint for spec-drift detection; empty value is recorded as-is.
-	pod.Annotations = MapSet(pod.Annotations, string(common.LauncherTemplateHashAnnotationKey), templateHash)
+	pod.Annotations[string(common.LauncherTemplateHashAnnotationKey)] = templateHash
 
 	cIdx, err := GetInferenceServerContainerIndex(pod)
 	if err != nil {

--- a/pkg/controller/utils/pod-helper_test.go
+++ b/pkg/controller/utils/pod-helper_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/api"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
+)
+
+// makeTemplate returns a representative EmbeddedPodTemplateSpec used as the shared fixture for the determinism / order-independence / node-independence tests.
+func makeTemplate() v1alpha1.EmbeddedPodTemplateSpec {
+	return v1alpha1.EmbeddedPodTemplateSpec{
+		Metadata: v1alpha1.EmbeddedObjectMeta{
+			Labels: map[string]string{
+				"app":     "launcher",
+				"version": "v1",
+				"team":    "fma",
+			},
+			Annotations: map[string]string{
+				"note":  "alpha",
+				"owner": "tester",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"role":     "worker",
+				"zone":     "us-west-1",
+				"hardware": "gpu",
+			},
+			Tolerations: []corev1.Toleration{
+				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "registry-a"},
+				{Name: "registry-b"},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  api.InferenceServerContainerName,
+					Image: "fake/launcher:latest",
+					Env: []corev1.EnvVar{
+						{Name: "FOO", Value: "1"},
+						{Name: "BAR", Value: "2"},
+						{Name: "BAZ", Value: "3"},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "config", MountPath: "/etc/config"},
+						{Name: "cache", MountPath: "/var/cache"},
+						{Name: "data", MountPath: "/var/data"},
+					},
+					Ports: []corev1.ContainerPort{
+						{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+						{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+					ReadinessProbe: &corev1.Probe{},
+				},
+			},
+		},
+	}
+}
+
+// TestComputeLauncherTemplateHash_Deterministic asserts that the same template hashes identically across repeated calls.
+func TestComputeLauncherTemplateHash_Deterministic(t *testing.T) {
+	tpl := makeTemplate()
+
+	first, err := ComputeLauncherTemplateHash(tpl)
+	if err != nil {
+		t.Fatalf("first ComputeLauncherTemplateHash returned error: %v", err)
+	}
+	if first == "" {
+		t.Fatalf("expected non-empty hash, got empty string")
+	}
+
+	for i := 0; i < 50; i++ {
+		got, err := ComputeLauncherTemplateHash(tpl)
+		if err != nil {
+			t.Fatalf("iter %d: ComputeLauncherTemplateHash returned error: %v", i, err)
+		}
+		if got != first {
+			t.Fatalf("iter %d: hash drift: got %q, want %q", i, got, first)
+		}
+	}
+}
+
+// TestComputeLauncherTemplateHash_OrderIndependent asserts that reordering order-independent slices (Env / VolumeMounts / Ports / Volumes / Tolerations / ImagePullSecrets) does not change the hash.
+func TestComputeLauncherTemplateHash_OrderIndependent(t *testing.T) {
+	base := makeTemplate()
+	baseHash, err := ComputeLauncherTemplateHash(base)
+	if err != nil {
+		t.Fatalf("base hash error: %v", err)
+	}
+
+	shuffled := makeTemplate()
+	c := &shuffled.Spec.Containers[0]
+	c.Env = []corev1.EnvVar{
+		{Name: "BAZ", Value: "3"},
+		{Name: "BAR", Value: "2"},
+		{Name: "FOO", Value: "1"},
+	}
+	c.VolumeMounts = []corev1.VolumeMount{
+		{Name: "data", MountPath: "/var/data"},
+		{Name: "cache", MountPath: "/var/cache"},
+		{Name: "config", MountPath: "/etc/config"},
+	}
+	c.Ports = []corev1.ContainerPort{
+		{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+		{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+	}
+	shuffled.Spec.Volumes = []corev1.Volume{
+		{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}
+	shuffled.Spec.Tolerations = []corev1.Toleration{
+		{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+		{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+	}
+	shuffled.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+		{Name: "registry-b"},
+		{Name: "registry-a"},
+	}
+
+	shuffledHash, err := ComputeLauncherTemplateHash(shuffled)
+	if err != nil {
+		t.Fatalf("shuffled hash error: %v", err)
+	}
+	if shuffledHash != baseHash {
+		t.Fatalf("hash changed under permutation of order-independent slices:\n base = %q\n shuf = %q", baseHash, shuffledHash)
+	}
+}
+
+// TestComputeLauncherTemplateHash_DifferentContentDiffers asserts that genuine content changes (e.g. image) yield distinct hashes.
+func TestComputeLauncherTemplateHash_DifferentContentDiffers(t *testing.T) {
+	a := makeTemplate()
+	b := makeTemplate()
+	b.Spec.Containers[0].Image = "fake/launcher:other"
+
+	ha, err := ComputeLauncherTemplateHash(a)
+	if err != nil {
+		t.Fatalf("hash a error: %v", err)
+	}
+	hb, err := ComputeLauncherTemplateHash(b)
+	if err != nil {
+		t.Fatalf("hash b error: %v", err)
+	}
+	if ha == hb {
+		t.Fatalf("expected distinct hashes for distinct image, both = %q", ha)
+	}
+}
+
+// TestBuildLauncherPodFromTemplate_NodeIndependentTemplateHash asserts that LauncherTemplateHashAnnotationKey is node-independent while the legacy LauncherConfigHashAnnotationKey differs between nodes.
+func TestBuildLauncherPodFromTemplate_NodeIndependentTemplateHash(t *testing.T) {
+	tpl := makeTemplate()
+
+	tplHash, err := ComputeLauncherTemplateHash(tpl)
+	if err != nil {
+		t.Fatalf("ComputeLauncherTemplateHash error: %v", err)
+	}
+
+	podA, err := BuildLauncherPodFromTemplate(tpl, "ns", "node-a", "lc1", tplHash)
+	if err != nil {
+		t.Fatalf("build pod A error: %v", err)
+	}
+	podB, err := BuildLauncherPodFromTemplate(tpl, "ns", "node-b", "lc1", tplHash)
+	if err != nil {
+		t.Fatalf("build pod B error: %v", err)
+	}
+
+	gotA := podA.Annotations[string(common.LauncherTemplateHashAnnotationKey)]
+	gotB := podB.Annotations[string(common.LauncherTemplateHashAnnotationKey)]
+	if gotA != tplHash {
+		t.Fatalf("podA template-hash annotation = %q, want %q", gotA, tplHash)
+	}
+	if gotB != tplHash {
+		t.Fatalf("podB template-hash annotation = %q, want %q", gotB, tplHash)
+	}
+	if gotA != gotB {
+		t.Fatalf("template-hash should be node-independent, got A=%q B=%q", gotA, gotB)
+	}
+
+	legacyA := podA.Annotations[string(common.LauncherConfigHashAnnotationKey)]
+	legacyB := podB.Annotations[string(common.LauncherConfigHashAnnotationKey)]
+	if legacyA == "" || legacyB == "" {
+		t.Fatalf("legacy launcher-config-hash must be set on both pods, got A=%q B=%q", legacyA, legacyB)
+	}
+	if legacyA == legacyB {
+		t.Fatalf("legacy launcher-config-hash must differ between nodes, both = %q", legacyA)
+	}
+}


### PR DESCRIPTION
fixes #472 
Replaced the full-sweep reconciliation with targeted, per-event reconciliation.： podItem, nodeItem, lppItem and lcItem.

reconcileFromPolicies is retained as a fallback for edge cases that need global cleanup: LPP deletion (orphaned desired state), LC deletion (orphaned pods). The targeted methods detect IsNotFound and fall back internally.