### PR TITLE
Stage B: migrate fixtures and docs from maxSleepingInstances to maxInstances

### DIFF
--- a/docs/e2e-recipe.md
+++ b/docs/e2e-recipe.md
@@ -542,7 +542,7 @@ kind: LauncherConfig
 metadata:
   name: my-launcher-config
 spec:
-  maxSleepingInstances: 3
+  maxInstances: 4
   podTemplate:
     spec:
       containers:

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -170,7 +170,7 @@ metadata:
   labels:
     fma-e2e-instance: "$inst"
 spec:
-  maxSleepingInstances: 3
+  maxInstances: 4
   podTemplate:
     metadata:
       labels:

--- a/test/e2e/mkobjs.sh
+++ b/test/e2e/mkobjs.sh
@@ -113,7 +113,7 @@ metadata:
     instance: "$inst"
     fma-e2e-instance: "$inst"
 spec:
-  maxSleepingInstances: 1
+  maxInstances: 2
   podTemplate:
     metadata:
       labels:


### PR DESCRIPTION
Stage B of #471 — closes #483.

Stage A (#482) was merged in #487 and added `maxInstances` alongside `maxSleepingInstances` in `LauncherConfigSpec` v1alpha1. This Stage B PR migrates all in-repo YAML fixtures and the e2e recipe to the new field. Stage C (#484) — removing `MaxSleepingInstances` from the API and generated code — is a separate follow-up.

## Changes

`maxInstances` is the total cap per launcher, whereas `maxSleepingInstances` was the cap *minus 1* (one extra sleeping instance is allowed when no awake instance is present). Each value is therefore bumped by 1 to preserve previous behavior:

- `test/e2e/mkobjs.sh`: `maxSleepingInstances: 1` → `maxInstances: 2`
- `test/e2e/mkobjs-openshift.sh`: `maxSleepingInstances: 3` → `maxInstances: 4`
- `docs/e2e-recipe.md`: `maxSleepingInstances: 3` → `maxInstances: 4`

After this PR, `grep -rn maxSleepingInstances` finds only:

- the `v1alpha1` type declaration and its CEL rule (`api/fma/v1alpha1/launcherconfig_types.go`)
- the generated CRD YAML (`config/crd/fma.llm-d.ai_launcherconfigs.yaml`)
- the generated applyconfiguration (`pkg/generated/applyconfiguration/fma/v1alpha1/launcherconfigspec.go`)

— all of which are deliberately deferred to Stage C.

## Verification

Per #483, this needs to be exercised on `kind` (via `mkobjs.sh`) and on the shared OpenShift cluster (via `mkobjs-openshift.sh` and the `docs/e2e-recipe.md` walkthrough), confirming the same instance counts as before the migration: up to 2 total per launcher in `mkobjs.sh`, up to 4 total per launcher in `mkobjs-openshift.sh` and the recipe.
