### PR TITLE
Document soak-period and bump-PR review checklist in CONTRIBUTING.md

### DIFF
--- a/.agents/skills/pr-security-review/SKILL.md
+++ b/.agents/skills/pr-security-review/SKILL.md
@@ -2,10 +2,10 @@ name: pr-security-review
 description: When reviewing PRs that bump dependencies or GitHub Actions, actively search for known vulnerabilities rather than reasoning abstractly
 ---
 
-When reviewing dependency bump PRs, verify security by actually checking external sources — don't just reason about it in the abstract.
+When reviewing dependency or GitHub Actions bump PRs, follow the checklist in
+the "Reviewing dependency and GitHub Actions bump PRs" subsection of
+[CONTRIBUTING.md](../../../CONTRIBUTING.md#reviewing-dependency-and-github-actions-bump-prs).
+That section is the source of truth.
 
-Checklist:
-1. Verify the pinned SHA matches the upstream tag
-2. Search github.com/advisories for the dependency
-3. Web search for CVEs/vulnerabilities in the specific new version being introduced
-4. Check the release notes for any security-relevant changes
+Verify security by actually checking external sources — don't just reason about
+it in the abstract.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,27 @@ The current testing documentation can be found within the respective components 
 * **All changes** must be reviewed and approved by a maintainer other than the author
 * **All repositories** must gate merges on compilation and passing tests
 
+### Reviewing dependency and GitHub Actions bump PRs
+
+When reviewing PRs that bump a dependency or a GitHub Actions version (e.g.,
+Dependabot PRs):
+
+* **Verify the pinned SHA matches the upstream tag** (for actions pinned
+  by SHA).
+* **Search [github.com/advisories](https://github.com/advisories)** for the
+  dependency.
+* **Search the web for CVEs/vulnerabilities** in the specific new version
+  being introduced.
+* **Read the upstream release notes** for security-relevant changes.
+* **Check the release age.** If the upstream release's publish timestamp
+  is less than 7 days ago (use the release's `published` field — for GitHub
+  releases, `gh release view <tag> --repo <owner>/<repo>`; not the PR's
+  creation date), flag this in the review and recommend waiting until the
+  7-day soak period has elapsed before merging. Newly published versions
+  have had little time for vulnerabilities or supply-chain compromises to
+  be discovered and reported. This applies to all dependency and GitHub
+  Actions bumps.
+
 ## Commit and Pull Request Style
 
 * **Pull requests** should describe the problem succinctly


### PR DESCRIPTION
## Summary
- Adds a "Reviewing dependency and GitHub Actions bump PRs" subsection
  to `CONTRIBUTING.md` as the single source of truth for human and
  agent reviewers of bump PRs.
- The checklist includes a 7-day release-age soak-period rule: PRs
  that bump to an upstream release published less than 7 days ago
  should be flagged and held until the soak period has elapsed.
  Source of the date: the upstream release's `published` timestamp
  (e.g., `gh release view <tag> --repo <owner>/<repo>`), not the PR's
  creation date. Scope: all dependency and GitHub Actions bumps.
- Rationale: newly published versions have had little time for
  vulnerabilities or supply-chain compromises to be discovered and
  reported.
- Shortens `.agents/skills/pr-security-review/SKILL.md` to defer to the
  CONTRIBUTING.md subsection rather than carry its own checklist,
  avoiding drift between the human-facing doc and the agent
  instruction file.

## Test plan
- [x] On the next dependency or GitHub Actions bump PR reviewed using
      the `pr-security-review` skill (or by a human following
      CONTRIBUTING.md) after this merges, confirm the reviewer executes
      the new step: looks up the upstream release's `published`
      timestamp, computes age, and — if under 7 days — flags it and
      recommends waiting before merging.
- [ ] If the next such PR's release is ≥7 days old, confirm the age
      check itself is still executed and the result is noted as
      "released N days ago, no soak-period concern."

Caveats: this isn't verifiable at merge time; it's an observation
deferred to the next applicable PR. It tests the reviewer's compliance
with the updated guidance, not the doc itself — there's no automated
mechanism to enforce it. A single observation isn't strong evidence;
the real signal is sustained behavior across several future bump-PR
reviews.