### PR TITLE
Log launcher receipt of create-instance request at subsecond precision

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -389,7 +389,13 @@ class VllmMultiProcessManager:
             instance_id = str(uuid.uuid4())
 
         if instance_id in self.instances:
+            logger.warning(
+                "Rejecting request to create vLLM instance: id=%s already exists",
+                instance_id,
+            )
             raise ValueError(f"Instance with ID {instance_id} already exists")
+
+        logger.info("Accepted request to create vLLM instance with id=%s", instance_id)
 
         instance = VllmInstance(
             instance_id, vllm_config, self.gpu_translator, self.log_dir
@@ -891,7 +897,7 @@ if __name__ == "__main__":
     # Configure root logger so launcher messages are visible before uvicorn
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        format="%(asctime)s,%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
     )
 
     # Get node name from environment variable


### PR DESCRIPTION
## Summary

- Adds `INFO` log in `VllmMultiProcessManager.create_instance` immediately after the instance ID is known and the duplicate-ID check passes, recording acceptance of the request.
- Adds `WARNING` log in the same method when the duplicate-ID check rejects the request.
- Updates the `logging.basicConfig` format string to include millisecond precision (`%(msecs)03d`), so all launcher log timestamps are at subsecond granularity.

Closes #497

## Test plan

- [ ] Existing launcher unit tests pass (`cd inference_server/launcher && python -m pytest tests/`)
- [ ] Start launcher in mock mode and issue `PUT /v2/vllm/instances/<id>`; confirm an `Accepted request` log line appears with a millisecond-precision timestamp.
- [ ] Issue the same `PUT` a second time; confirm a `Rejecting request` warning log line appears.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)