### PR TITLE
Log launcher receipt of create-instance request at subsecond precision

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -389,7 +389,13 @@ class VllmMultiProcessManager:
             instance_id = str(uuid.uuid4())
 
         if instance_id in self.instances:
+            logger.warning(
+                "Rejecting request to create vLLM instance: id=%s already exists",
+                instance_id,
+            )
             raise ValueError(f"Instance with ID {instance_id} already exists")
+
+        logger.info("Accepted request to create vLLM instance with id=%s", instance_id)
 
         instance = VllmInstance(
             instance_id, vllm_config, self.gpu_translator, self.log_dir


### PR DESCRIPTION
## Summary

- Adds `INFO` log in `VllmMultiProcessManager.create_instance` immediately after the instance ID is known and the duplicate-ID check passes, recording acceptance of the request.
- Adds `WARNING` log in the same method when the duplicate-ID check rejects the request.

Python's `%(asctime)s` log format already includes millisecond precision by default, so no format string change is needed.

Closes #497

## Test plan

- [x] Observe that the CI workflow for python code quality passes the unit tests.
- [x] Look at a launcher log from CI and verify expected content.

🤖 co-authored with [Claude Code](https://claude.com/claude-code)