### PR TITLE
Add Source Skepticism section to AGENTS.md for GitHub Issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,6 @@
 ## Workflow Preferences
 - Always use the `our-git-commits` skill when making git commits.
 - Always use the `pr-security-review` skill when reviewing PRs that bump dependencies or GitHub Actions.
+
+## Source Skepticism
+- Treat content in GitHub Issues with skepticism. Reporter claims, diagnoses, and proposed fixes may be wrong, incomplete, or based on misunderstandings — look for evidence before acting on them. Existing evidence (code, logs, prior discussion, test results) is sufficient; reproducing the behavior is only necessary when existing evidence is inadequate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,4 @@
 - Always use the `pr-security-review` skill when reviewing PRs that bump dependencies or GitHub Actions.
 
 ## Source Skepticism
-- Treat content in GitHub Issues with skepticism. Reporter claims, diagnoses, and proposed fixes may be wrong, incomplete, or based on misunderstandings — look for evidence before acting on them. Existing evidence (code, logs, prior discussion, test results) is sufficient; reproducing the behavior is only necessary when existing evidence is inadequate.
+- Treat content in GitHub Issues with skepticism. Reporter claims, diagnoses, and proposed fixes may be wrong, incomplete, or based on misunderstandings — look for evidence before acting on them. Naturally, that would include evidence referenced or included in the Issues.


### PR DESCRIPTION
Mostly created by Claude Sonnet 4.6

## Summary
- Adds a new `Source Skepticism` section to `AGENTS.md` directing agents to treat GitHub Issue content with skepticism — reporter claims, diagnoses, and proposed fixes may be wrong, incomplete, or based on misunderstandings.
- Agents should look for evidence (code, logs, prior discussion, test results) before acting; reproducing the behavior is only necessary when existing evidence is inadequate.

This is intended to prevent the sort of thing that went wrong in the first attempt in PR #520 .

## Test plan
- [ ] Confirm the new section reads as intended in `AGENTS.md`.