### PR TITLE
Unify launcher and uvicorn log format

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -42,6 +42,9 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 MAX_LOG_RESPONSE_BYTES = 1 * 1024 * 1024  # 1 MB default for API response
 _MAX_BROADCASTER_EVENTS = 1000
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, force=True)
 
 
 class LogRangeNotAvailable(Exception):
@@ -894,11 +897,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # Configure root logger so launcher messages are visible before uvicorn
-    logging.basicConfig(
-        level=getattr(logging, args.log_level.upper()),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
+    logging.getLogger().setLevel(getattr(logging, args.log_level.upper()))
 
     # Get node name from environment variable
     node_name = os.getenv("NODE_NAME")
@@ -924,4 +923,6 @@ if __name__ == "__main__":
         namespace=namespace,
     )
 
-    uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level)
+    uvicorn.run(
+        app, host=args.host, port=args.port, log_level=args.log_level, log_config=None
+    )


### PR DESCRIPTION
# Unify launcher and uvicorn log format

## Problem

The launcher process emits logs from two sources with different formats:

1. **Launcher/gputranslator** (already formatted correctly via `basicConfig` in `__main__`):
   ```
   2026-05-26 15:28:17,787 - __main__ - INFO - Launcher starting with args: ...
   2026-05-26 15:28:17,788 - gputranslator - INFO - using package: nvidia-ml-py ...
   ```

2. **Uvicorn** (default format, no timestamp or logger name):
   ```
   INFO:     Started server process [1]
   INFO:     10.131.6.2:34340 - "GET /v2/vllm/instances HTTP/1.1" 200 OK
   ```

The uvicorn logs lack timestamps and logger names, making it harder to correlate events across sources when reading launcher pod logs.

## Solution

Three targeted changes in `launcher.py`, all scoped to the **parent process only** (vLLM child instances are unaffected — they run in separate subprocesses with their own process group and stdout/stderr redirected to log files):

1. **Define `LOG_FORMAT` constant** — single source of truth for the log format string.

2. **Module-level `logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, force=True)`** — configures the root logger after vLLM imports. The `force=True` ensures our format takes precedence regardless of how the app is started (`python launcher.py` or `uvicorn launcher:app`).

3. **Pass `log_config=None` to `uvicorn.run()`** — prevents uvicorn from installing its own logging handlers, so uvicorn loggers propagate to the root logger and use our unified format. No CLI options are disabled — `--log-level` continues to work identically.


## Result

All launcher-controlled logs now use a consistent format:
```
(llm-d-fast-model-actuation) diego@wecm-9-67-172-254 ~/Documents/my_stuff/llm-d-fast-model-actuation/inference_server/launcher (log-format) $ python launcher.py --port 8001 --log-level info
INFO 05-29 15:17:43 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
2026-05-29 15:17:43,962 - gputranslator - INFO - using package: nvidia-ml-py version: 13.590.48
2026-05-29 15:17:43,962 - gputranslator - ERROR - Failed to initialize pynvml: NVML Shared Library Not Found
2026-05-29 15:17:43,979 - __main__ - INFO - Launcher starting with args: mock_gpus=False, mock_gpu_count=8, host=0.0.0.0, port=8001, log_level=info, node_name=None, namespace=None
2026-05-29 15:17:43,979 - gputranslator - INFO - using package: nvidia-ml-py version: 13.590.48
2026-05-29 15:17:43,980 - gputranslator - ERROR - Failed to initialize pynvml: NVML Shared Library Not Found
2026-05-29 15:17:44,009 - uvicorn.error - INFO - Started server process [67710]
2026-05-29 15:17:44,009 - uvicorn.error - INFO - Waiting for application startup.
2026-05-29 15:17:44,009 - uvicorn.error - INFO - Application startup complete.
2026-05-29 15:17:44,009 - uvicorn.error - INFO - Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
2026-05-29 15:18:20,983 - __main__ - INFO - Accepted request to create vLLM instance with id=my_diego
2026-05-29 15:18:21,010 - uvicorn.access - INFO - 127.0.0.1:64331 - "PUT /v2/vllm/instances/my_diego HTTP/1.1" 201
INFO 05-29 15:18:23 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
2026-05-29 15:18:24,104 - gputranslator - INFO - using package: nvidia-ml-py version: 13.590.48
2026-05-29 15:18:24,104 - gputranslator - ERROR - Failed to initialize pynvml: NVML Shared Library Not Found
2026-05-29 15:19:02,210 - uvicorn.access - INFO - 127.0.0.1:64414 - "GET /v2/vllm/instances/my_diego/log HTTP/1.1" 200
2026-05-29 15:19:39,069 - uvicorn.access - INFO - 127.0.0.1:64432 - "DELETE /v2/vllm/instances HTTP/1.1" 200
^C2026-05-29 15:20:36,672 - uvicorn.error - INFO - Shutting down
2026-05-29 15:20:36,773 - uvicorn.error - INFO - Waiting for application shutdown.
2026-05-29 15:20:36,774 - __main__ - INFO - Launcher shutting down, stopping all vLLM instances...
2026-05-29 15:20:36,775 - uvicorn.error - INFO - Application shutdown complete.
2026-05-29 15:20:36,776 - uvicorn.error - INFO - Finished server process [67710]
```

vLLM's internal logs (`INFO 05-29 ...`) retain their own format since the `vllm` logger has `propagate: False` — this is expected and outside our control without modifying vLLM itself.