### PR TITLE
List is map

### DIFF
--- a/api/fma/v1alpha1/launcherpopulationpolicy_types.go
+++ b/api/fma/v1alpha1/launcherpopulationpolicy_types.go
@@ -79,6 +79,8 @@ type LauncherPopulationPolicySpec struct {
 	// CountForLauncher declares the desired number of launchers on the
 	// relevant Node, for various LauncherConfigs.
 	// +required
+	// +listType=map
+	// +listMapKey=launcherConfigName
 	CountForLauncher []CountForLauncher `json:"countForLauncher"`
 }
 

--- a/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml
+++ b/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml
@@ -78,6 +78,9 @@ spec:
                   - launcherCount
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - launcherConfigName
+                x-kubernetes-list-type: map
               enhancedNodeSelector:
                 description: |-
                   Selector describes the hardware characteristics of target nodes.

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -234,6 +234,39 @@ echo "Assigned GPU UUID(s): $assigned_gpu_uuids"
 cheer Successful launcher-based pod creation
 
 # ---------------------------------------------------------------------------
+# Test enforcement of LPP.Spec.CountForLauncher key uniqueness
+# ---------------------------------------------------------------------------
+
+intro_case Test enforcement of LPP.Spec.CountForLauncher key uniqueness
+echo Expect kubectl to complain
+
+if kubectl create -f - <<EOF
+apiVersion: fma.llm-d.ai/v1alpha1
+kind: LauncherPopulationPolicy
+metadata:
+  name: bad-$inst
+  labels:
+    instance: "$inst"
+    fma-e2e-instance: "$inst"
+spec:
+  enhancedNodeSelector:
+    labelSelector:
+      matchLabels:
+        nvidia.com/gpu.present: "true"
+  countForLauncher:
+    - launcherConfigName: foo
+      launcherCount: 1
+    - launcherConfigName: foo
+      launcherCount: 2
+EOF
+then
+    echo "A LauncherPopulationPolicy with non-unique keys was accepted!" >&2
+    exit 1
+fi
+
+cheer The malformed LauncherPopulationPolicy was properly rejected
+
+# ---------------------------------------------------------------------------
 # CEL policy verification (if enabled)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes an oversight in the Kubernetes API. The slice of CountForLauncher in a LauncherPopulationPolicy is intended to represent a map from LauncherConfig name to count. This PR updates the API source to say this.