### PR TITLE
Simplify digestion of LauncherConfig's PodTemplate

### DIFF
--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -609,14 +609,11 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		)
 	}
 
-	desiredLauncherTemplateHash, err := utils.ComputeLauncherTemplateHash(lc.Spec.PodTemplate)
-	if err != nil {
-		return fmt.Errorf("failed to compute template hash for LauncherConfig %q: %w", lcName, err), true
-	}
-	desiredLauncherPod, err := utils.BuildLauncherPodFromTemplate(lc.Spec.PodTemplate, ctl.namespace, requestingPod.Spec.NodeName, lcName, desiredLauncherTemplateHash)
+	nodeIndependentLauncherTemplate, _, err := utils.BuildNodeIndependentLauncherTemplate(lc)
 	if err != nil {
 		return fmt.Errorf("failed to build launcher Pod from LauncherConfig %q: %w", lcName, err), true
 	}
+	desiredLauncherPod := utils.SpecializeLauncherTemplateToNode(nodeIndependentLauncherTemplate, requestingPod.Spec.NodeName)
 	lcHash := desiredLauncherPod.Annotations[ctlrcommon.LauncherConfigHashAnnotationKey]
 	logger.V(5).Info("LauncherConfig's hash", "hash", lcHash)
 	launcherPodAnys, err := ctl.podInformer.GetIndexer().ByIndex(launcherConfigHashIndexName, lcHash)

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -31,7 +31,7 @@ import (
 )
 
 // updateDigestForLC is the SOLE place that:
-//   - validates the LC PodTemplate (utils.ValidateLauncherPodTemplate);
+//   - validates the LC PodTemplate;
 //   - computes the node-independent template hash;
 //   - writes LauncherConfig.Status (via setLCStatusErrors);
 //   - records the per-LC derived data into ctl.policy.lcs[name].
@@ -42,12 +42,18 @@ import (
 // re-apply to the digest.
 func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error {
 	logger := klog.FromContext(ctx)
+	var templateErr, templateHash, prevTemplateHash string
+	var nodeIndep *corev1.Pod
+	var good bool
 
-	prev := ctl.policy.lcs[name]
-	prevExists := prev != nil && prev.object != nil
+	prevDigest := ctl.policy.lcs[name]
+	prevExists := prevDigest != nil && prevDigest.object != nil
+	if prevDigest != nil {
+		prevTemplateHash = prevDigest.templateHash
+	}
+	prevGood := prevExists && prevDigest.templateErr == ""
 
-	lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(name)
-	if err != nil {
+	if lc, err := ctl.lcLister.LauncherConfigs(ctl.namespace).Get(name); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get LC %s: %w", name, err)
 		}
@@ -56,47 +62,26 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 		}
 		logger.Info("LC deleted, requeuing referencing LPPs", "config", name)
 		delete(ctl.policy.lcs, name)
-		for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
-			ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
-		}
-		return nil
-	}
-
-	// LC exists: validate and produce the lcDigest.
-	var templateErr string
-	if vErr := utils.ValidateLauncherPodTemplate(lc.Spec.PodTemplate); vErr != nil {
-		templateErr = vErr.Error()
-		logger.Error(vErr, "Invalid PodTemplate in LC, reporting in Status", "config", name)
-	}
-	var templateHash string
-	if templateErr == "" {
-		h, hashErr := utils.ComputeLauncherTemplateHash(lc.Spec.PodTemplate)
-		if hashErr != nil {
-			templateErr = hashErr.Error()
-			logger.Error(hashErr, "Failed to hash PodTemplate, reporting in Status", "config", name)
+	} else { // LC exists: digest it
+		nodeIndep, templateHash, err = utils.BuildNodeIndependentLauncherTemplate(lc)
+		if err != nil {
+			templateErr = err.Error()
+			logger.Info("Invalid PodTemplate in LC, reporting in Status", "config", name, "err", templateErr)
 		} else {
-			templateHash = h
+			good = true
+		}
+		if statusErr := ctl.setLCStatusErrors(ctx, lc, nonNilSlice(templateErr)); statusErr != nil {
+			return fmt.Errorf("failed to set Status for LC %s: %w", name, statusErr)
+		}
+		ctl.policy.lcs[name] = &lcDigest{
+			object:          lc,
+			templateErr:     templateErr,
+			templateHash:    templateHash,
+			nodeIndependent: nodeIndep,
 		}
 	}
-	if statusErr := ctl.setLCStatusErrors(ctx, lc, nonNilSlice(templateErr)); statusErr != nil {
-		return fmt.Errorf("failed to set Status for LC %s: %w", name, statusErr)
-	}
 
-	prevTemplateErr := ""
-	prevTemplateHash := ""
-	if prev != nil {
-		prevTemplateErr = prev.templateErr
-		prevTemplateHash = prev.templateHash
-	}
-
-	ctl.policy.lcs[name] = &lcDigest{
-		object:       lc,
-		templateErr:  templateErr,
-		templateHash: templateHash,
-		ownerRef:     makeLCOwnerRef(lc),
-	}
-
-	if !prevExists || prevTemplateErr != templateErr || prevTemplateHash != templateHash {
+	if prevGood != good || good && (prevTemplateHash != templateHash) {
 		for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
 			ctl.digestQueue.Queue.Add(funcItem{kind: kindLPP, name: lppName})
 		}
@@ -304,7 +289,6 @@ func (ctl *controller) removeLPPFromEntry(entry *digestEntry, lppName string) {
 	delete(entry.lpps, lppName)
 	if len(entry.lpps) == 0 {
 		entry.count = 0
-		entry.spec = nil
 		entry.handsOff = false
 	}
 }
@@ -334,7 +318,6 @@ func (ctl *controller) detachLPPFromEntry(nodeMap map[string]*digestEntry, lppNa
 func (ctl *controller) recomputeEntryFromLPPs(entry *digestEntry, lcName string) {
 	if len(entry.lpps) == 0 {
 		entry.count = 0
-		entry.spec = nil
 		entry.handsOff = false
 		return
 	}
@@ -353,15 +336,11 @@ func (ctl *controller) recomputeEntryFromLPPs(entry *digestEntry, lcName string)
 	case lcd == nil || lcd.object == nil:
 		entry.handsOff = true
 		entry.count = maxCount
-		entry.spec = nil
 	case lcd.templateErr != "":
 		entry.handsOff = true
 		entry.count = maxCount
-		entry.spec = nil
 	default:
 		entry.handsOff = false
 		entry.count = maxCount
-		entry.spec = &lcd.object.Spec
-		entry.ownerRef = lcd.ownerRef
 	}
 }

--- a/pkg/controller/launcher-populator/digested-policy.go
+++ b/pkg/controller/launcher-populator/digested-policy.go
@@ -19,7 +19,7 @@ package launcherpopulator
 import (
 	"sync"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 )
@@ -28,20 +28,18 @@ import (
 // It holds the digested desired count and supporting details needed for
 // creating launcher Pods.
 type digestEntry struct {
-	handsOff bool   // true when user error (LC missing or invalid template) precludes action
-	count    int32  // max over relevant (existing, well-formed) CountForLauncher
-	spec     *fmav1alpha1.LauncherConfigSpec
-	ownerRef metav1.OwnerReference
+	handsOff bool                                             // true when user error (LC missing or invalid template) precludes action
+	count    int32                                            // max over relevant (existing, well-formed) CountForLauncher
 	lpps     map[string]*fmav1alpha1.LauncherPopulationPolicy // LPPs contributing to this entry
 }
 
 // lcDigest holds all node-independent derived data for a LauncherConfig.
 // Written exclusively by updateDigestForLC; read by all other paths.
 type lcDigest struct {
-	object       *fmav1alpha1.LauncherConfig // nil iff the LC API object does not exist
-	templateErr  string                      // empty when ValidateLauncherPodTemplate passes
-	templateHash string                      // populated only when templateErr == ""
-	ownerRef     metav1.OwnerReference       // populated only when object != nil
+	object          *fmav1alpha1.LauncherConfig // nil iff the LC API object does not exist
+	templateErr     string                      // empty when no error
+	nodeIndependent *corev1.Pod
+	templateHash    string // populated only when templateErr == ""
 }
 
 // lppDigest holds all derived data for a LauncherPopulationPolicy.
@@ -73,16 +71,14 @@ type digestedPolicy struct {
 }
 
 // keySnapshot is a value-typed view of one digestEntry plus the LC's template
-// hash, captured under digestedPolicy.mu.RLock(). Once returned, the snapshot
-// is safe to read outside the lock; underlying *fmav1alpha1.LauncherConfigSpec
-// points into the informer cache, which Kubernetes does not mutate in place.
+// hash and node-independent Pod template, captured under digestedPolicy.mu.RLock().
+// Nothing modifies any part of the Pod template.
 type keySnapshot struct {
-	exists       bool
-	handsOff     bool
-	count        int32
-	spec         *fmav1alpha1.LauncherConfigSpec
-	ownerRef     metav1.OwnerReference
-	templateHash string
+	exists                          bool
+	handsOff                        bool
+	count                           int32
+	templateHash                    string
+	nodeIndependentLauncherTemplate *corev1.Pod
 }
 
 // newDigestedPolicy creates an empty digestedPolicy.
@@ -149,11 +145,10 @@ func (dp *digestedPolicy) snapshotForKey(key NodeLauncherKey) keySnapshot {
 		snap.exists = true
 		snap.handsOff = entry.handsOff
 		snap.count = entry.count
-		snap.spec = entry.spec
-		snap.ownerRef = entry.ownerRef
 	}
 	if lcd := dp.lcs[key.LauncherConfigName]; lcd != nil {
 		snap.templateHash = lcd.templateHash
+		snap.nodeIndependentLauncherTemplate = lcd.nodeIndependent
 	}
 	return snap
 }

--- a/pkg/controller/launcher-populator/helpers.go
+++ b/pkg/controller/launcher-populator/helpers.go
@@ -22,27 +22,13 @@ import (
 	"strings"
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
-	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 )
-
-// makeLCOwnerRef builds a non-controlling OwnerReference for a LauncherConfig.
-func makeLCOwnerRef(lc *fmav1alpha1.LauncherConfig) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion:         fmav1alpha1.SchemeGroupVersion.String(),
-		Kind:               "LauncherConfig",
-		Name:               lc.Name,
-		UID:                lc.UID,
-		Controller:         ptr.To(false),
-		BlockOwnerDeletion: ptr.To(false),
-	}
-}
 
 // nonNilSlice returns a single-element slice if s is non-empty, or nil otherwise.
 func nonNilSlice(s string) []string {
@@ -135,20 +121,14 @@ func (ctl *controller) listPodsFromApiserver(ctx context.Context, key NodeLaunch
 }
 
 // createLaunchers creates the specified number of launcher pods on a node
-// using the given LauncherConfig spec, owner reference, and the precomputed
-// node-independent template hash (snapshotted by processKey under RLock).
-func (ctl *controller) createLaunchers(ctx context.Context, node corev1.Node, key NodeLauncherKey, count int, lcSpec *fmav1alpha1.LauncherConfigSpec, lcOwnerRef metav1.OwnerReference, templateHash string) error {
+// using the given node-specific template Pod template.
+func (ctl *controller) createLaunchers(ctx context.Context, node *corev1.Node, key NodeLauncherKey, count int, launcherPodTemplate *corev1.Pod) error {
 	logger := klog.FromContext(ctx)
 
 	// Create the specified number of launcher pods
 	for i := 0; i < count; i++ {
-		pod, err := utils.BuildLauncherPodFromTemplate(lcSpec.PodTemplate, ctl.namespace, key.NodeName, key.LauncherConfigName, templateHash)
-		if err != nil {
-			return fmt.Errorf("failed to build launcher pod: %w", err)
-		}
-		pod.OwnerReferences = []metav1.OwnerReference{lcOwnerRef}
 
-		createdPod, err := ctl.coreclient.Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+		createdPod, err := ctl.coreclient.Pods(ctl.namespace).Create(ctx, launcherPodTemplate.DeepCopy(), metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create launcher pod: %w", err)
 		}

--- a/pkg/controller/launcher-populator/pending_expectations_test.go
+++ b/pkg/controller/launcher-populator/pending_expectations_test.go
@@ -26,7 +26,7 @@ import (
 
 // uidSet is a small helper to build the presentUIDs argument tersely.
 func uidSet(uids ...types.UID) sets.Set[types.UID] {
-	return sets.New[types.UID](uids...)
+	return sets.New(uids...)
 }
 
 func TestPendingExpectations_BasicCreation(t *testing.T) {

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -369,7 +370,7 @@ func (ctl *controller) processKey(ctx context.Context, key NodeLauncherKey) (err
 		// Clean up any orphaned launchers.
 		logger.V(4).Info("Key not in digest, cleaning up orphaned launchers",
 			"node", key.NodeName, "config", key.LauncherConfigName)
-		return ctl.reconcileKey(ctx, key, 0, nil, metav1.OwnerReference{}, "")
+		return ctl.reconcileKey(ctx, key, 0, snap.templateHash, nil)
 	}
 
 	if snap.handsOff {
@@ -379,15 +380,16 @@ func (ctl *controller) processKey(ctx context.Context, key NodeLauncherKey) (err
 		return nil, false
 	}
 
-	return ctl.reconcileKey(ctx, key, snap.count, snap.spec, snap.ownerRef, snap.templateHash)
+	return ctl.reconcileKey(ctx, key, snap.count, snap.templateHash, snap.nodeIndependentLauncherTemplate)
 }
 
 // reconcileKey adjusts launcher pods for a single NodeLauncherKey to match the desired count.
-func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, desiredCount int32, lcSpec *fmav1alpha1.LauncherConfigSpec, ownerRef metav1.OwnerReference, templateHash string) (error, bool) {
+func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, desiredCount int32, templateHash string, nodeIndependentLauncherTemplate *corev1.Pod) (error, bool) {
 	logger := klog.FromContext(ctx)
 
 	// Check node existence.
-	if _, err := ctl.nodeLister.Get(key.NodeName); err != nil {
+	node, err := ctl.nodeLister.Get(key.NodeName)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.V(4).Info("Node no longer exists, skipping key reconciliation", "node", key.NodeName)
 			return nil, false
@@ -403,12 +405,6 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	}
 	if expectStatus == ExpectationsWaiting {
 		return nil, true // requeue
-	}
-
-	// Read the node-independent template hash from the snapshot taken in
-	// processKey under RLock. Empty when LC is missing or template invalid.
-	if lcSpec == nil {
-		templateHash = ""
 	}
 
 	// Categorize pods.
@@ -427,12 +423,9 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 			liveBoundCount++
 			continue
 		}
-		if templateHash != "" {
-			podHash := pod.Annotations[string(common.LauncherTemplateHashAnnotationKey)]
-			if podHash != "" && podHash != templateHash {
-				staleUnboundPods = append(staleUnboundPods, pod)
-				continue
-			}
+		if templateHash != pod.Annotations[common.LauncherTemplateHashAnnotationKey] {
+			staleUnboundPods = append(staleUnboundPods, pod)
+			continue
 		}
 		liveUnboundCurrentPods = append(liveUnboundCurrentPods, pod)
 	}
@@ -502,9 +495,9 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	}
 
 	// Create pods if needed.
-	if diff > 0 && lcSpec != nil {
-		node, _ := ctl.nodeLister.Get(key.NodeName)
-		if err := ctl.createLaunchers(ctx, *node, key, int(diff), lcSpec, ownerRef, templateHash); err != nil {
+	if diff > 0 {
+		nodeSpecificLauncherTemplate := utils.SpecializeLauncherTemplateToNode(nodeIndependentLauncherTemplate, node.Name)
+		if err := ctl.createLaunchers(ctx, node, key, int(diff), nodeSpecificLauncherTemplate); err != nil {
 			return err, true
 		}
 		logger.Info("Created launchers", "node", key.NodeName, "config", key.LauncherConfigName, "count", diff)

--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	v1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/api"
@@ -134,20 +135,6 @@ func GetInferenceServerContainerIndex(pod *corev1.Pod) (int, error) {
 	return cIdx, nil
 }
 
-// ValidateLauncherPodTemplate checks whether the given EmbeddedPodTemplateSpec is valid
-// for use as a launcher pod template. It returns an error if the template is missing the
-// required inference server container. This check does not depend on any node-specific
-// information and is safe to call once per LauncherConfig rather than once per node.
-func ValidateLauncherPodTemplate(template v1alpha1.EmbeddedPodTemplateSpec) error {
-	cIdx := slices.IndexFunc(template.Spec.Containers, func(c corev1.Container) bool {
-		return c.Name == api.InferenceServerContainerName
-	})
-	if cIdx == -1 {
-		return fmt.Errorf("container %q not found", api.InferenceServerContainerName)
-	}
-	return nil
-}
-
 func IsPodReady(pod *corev1.Pod) bool {
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
@@ -155,17 +142,6 @@ func IsPodReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
-}
-
-// ComputeLauncherTemplateHash returns a deterministic, node-independent hash of the launcher Pod template.
-func ComputeLauncherTemplateHash(template v1alpha1.EmbeddedPodTemplateSpec) (string, error) {
-	canonical := canonicalizeTemplateForHash(template)
-	bytes, err := json.Marshal(canonical)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal template for hashing: %w", err)
-	}
-	sum := sha256.Sum256(bytes)
-	return base64.RawStdEncoding.EncodeToString(sum[:]), nil
 }
 
 // canonicalizeTemplateForHash returns a deep-copied template with order-independent slices sorted, suitable for stable serialization.
@@ -228,44 +204,58 @@ func canonicalizeContainer(c *corev1.Container) {
 	})
 }
 
-// BuildLauncherPodFromTemplate builds a launcher Pod for nodeName from the given template; templateHash (typically cached per LC.ResourceVersion) is recorded under LauncherTemplateHashAnnotationKey for spec-drift detection, alongside the legacy node-aware LauncherConfigHashAnnotationKey used by the dual-pods indexer.
-func BuildLauncherPodFromTemplate(template v1alpha1.EmbeddedPodTemplateSpec, ns, nodeName, launcherConfigName, templateHash string) (*corev1.Pod, error) {
+// BuildNodeIndependentLauncherTemplate does most of the work of building a Pod
+// template for a launcher from a LauncherConfig.
+// The omitted work is specializing it to a particular Node. Pass the result
+// and the Node's name to SpecializeLauncherTemplateToNode to accomplish that.
+// A hash of this template is recorded under LauncherTemplateHashAnnotationKey
+// for spec-drift detection, and also returned.
+func BuildNodeIndependentLauncherTemplate(lc *v1alpha1.LauncherConfig) (*corev1.Pod, string, error) {
+	template := canonicalizeTemplateForHash(lc.Spec.PodTemplate)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      maps.Clone(template.Metadata.Labels),
-			Annotations: maps.Clone(template.Metadata.Annotations),
+			Labels:       maps.Clone(template.Metadata.Labels),
+			Annotations:  maps.Clone(template.Metadata.Annotations),
+			Namespace:    lc.Namespace,
+			GenerateName: fmt.Sprintf("launcher-%s-", lc.Name),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+				Kind:               "LauncherConfig",
+				Name:               lc.Name,
+				UID:                lc.UID,
+				Controller:         ptr.To(false),
+				BlockOwnerDeletion: ptr.To(false),
+			}},
 		},
-		Spec: *DeIndividualize(template.Spec.DeepCopy()),
+		Spec: template.Spec,
 	}
-	pod.Namespace = ns
-	pod.GenerateName = fmt.Sprintf("launcher-%s-", launcherConfigName)
 	// Ensure labels are set
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
 	pod.Labels[common.ComponentLabelKey] = common.LauncherComponentLabelValue
-	pod.Labels[common.LauncherConfigNameLabelKey] = launcherConfigName
-	pod.Labels[common.NodeNameLabelKey] = nodeName
+	pod.Labels[common.LauncherConfigNameLabelKey] = lc.Name
 	pod.Labels[api.SleepingLabelName] = "false"
 
 	hasher := sha256.New()
-	modifiedJSON, _ := json.Marshal(pod)
+	modifiedJSON, err := json.Marshal(pod)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal template for hashing: %w", err)
+	}
 	hasher.Write(modifiedJSON)
 	var modifiedHash [sha256.Size]byte
 	modifiedHashSl := hasher.Sum(modifiedHash[:0])
-	nominalHash := base64.RawStdEncoding.EncodeToString(modifiedHashSl)
+	templateHash := base64.RawStdEncoding.EncodeToString(modifiedHashSl)
 
 	if pod.Annotations == nil {
 		pod.Annotations = make(map[string]string)
 	}
-	// Legacy Pod hash for the dual-pods indexer (SHA256 of the Pod JSON above).
-	pod.Annotations[string(common.LauncherConfigHashAnnotationKey)] = nominalHash
 	// Node-independent template fingerprint for spec-drift detection; empty value is recorded as-is.
 	pod.Annotations[string(common.LauncherTemplateHashAnnotationKey)] = templateHash
 
 	cIdx, err := GetInferenceServerContainerIndex(pod)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	container := &pod.Spec.Containers[cIdx]
 
@@ -313,13 +303,30 @@ func BuildLauncherPodFromTemplate(template v1alpha1.EmbeddedPodTemplateSpec, ns,
 	if pod.Spec.Overhead != nil {
 		delete(pod.Spec.Overhead, corev1.ResourceName("nvidia.com/gpu"))
 	}
-
-	if pod.Spec.NodeSelector == nil {
-		pod.Spec.NodeSelector = make(map[string]string)
-	}
-	pod.Spec.NodeSelector["kubernetes.io/hostname"] = nodeName
 	addLauncherNotifierSidecar(pod, container.Image, container.ImagePullPolicy)
-	return pod, nil
+	return pod, templateHash, nil
+}
+
+// alongside the legacy node-aware LauncherConfigHashAnnotationKey used by the dual-pods indexer.
+func SpecializeLauncherTemplateToNode(nodeIndependent *corev1.Pod, nodeName string) *corev1.Pod {
+	nodeDependent := nodeIndependent.DeepCopy()
+	nodeDependent.Labels[common.NodeNameLabelKey] = nodeName
+	if nodeDependent.Spec.NodeSelector == nil {
+		nodeDependent.Spec.NodeSelector = make(map[string]string)
+	}
+	nodeDependent.Spec.NodeSelector["kubernetes.io/hostname"] = nodeName
+
+	hasher := sha256.New()
+	hasher.Write([]byte(nodeDependent.Annotations[string(common.LauncherTemplateHashAnnotationKey)]))
+	hasher.Write([]byte(";node="))
+	hasher.Write([]byte(nodeName))
+	var modifiedHash [sha256.Size]byte
+	modifiedHashSl := hasher.Sum(modifiedHash[:0])
+	nominalHash := base64.RawStdEncoding.EncodeToString(modifiedHashSl)
+
+	// Legacy Pod hash for the dual-pods indexer (takes Node name into account).
+	nodeDependent.Annotations[string(common.LauncherConfigHashAnnotationKey)] = nominalHash
+	return nodeDependent
 }
 
 // configureRequiredEnvVars adds or updates required environment variables

--- a/pkg/controller/utils/pod-helper_test.go
+++ b/pkg/controller/utils/pod-helper_test.go
@@ -21,6 +21,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	machtypes "k8s.io/apimachinery/pkg/types"
 
 	v1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/api"
@@ -28,67 +30,76 @@ import (
 )
 
 // makeTemplate returns a representative EmbeddedPodTemplateSpec used as the shared fixture for the determinism / order-independence / node-independence tests.
-func makeTemplate() v1alpha1.EmbeddedPodTemplateSpec {
-	return v1alpha1.EmbeddedPodTemplateSpec{
-		Metadata: v1alpha1.EmbeddedObjectMeta{
-			Labels: map[string]string{
-				"app":     "launcher",
-				"version": "v1",
-				"team":    "fma",
-			},
-			Annotations: map[string]string{
-				"note":  "alpha",
-				"owner": "tester",
-			},
+func makeLC() *v1alpha1.LauncherConfig {
+	return &v1alpha1.LauncherConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "testn",
+			UID:       machtypes.UID("you-ID"),
 		},
-		Spec: corev1.PodSpec{
-			NodeSelector: map[string]string{
-				"role":     "worker",
-				"zone":     "us-west-1",
-				"hardware": "gpu",
-			},
-			Tolerations: []corev1.Toleration{
-				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-				{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-			},
-			ImagePullSecrets: []corev1.LocalObjectReference{
-				{Name: "registry-a"},
-				{Name: "registry-b"},
-			},
-			Volumes: []corev1.Volume{
-				{Name: "config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-				{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-				{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:  api.InferenceServerContainerName,
-					Image: "fake/launcher:latest",
-					Env: []corev1.EnvVar{
-						{Name: "FOO", Value: "1"},
-						{Name: "BAR", Value: "2"},
-						{Name: "BAZ", Value: "3"},
+		Spec: v1alpha1.LauncherConfigSpec{
+			PodTemplate: v1alpha1.EmbeddedPodTemplateSpec{
+				Metadata: v1alpha1.EmbeddedObjectMeta{
+					Labels: map[string]string{
+						"app":     "launcher",
+						"version": "v1",
+						"team":    "fma",
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "config", MountPath: "/etc/config"},
-						{Name: "cache", MountPath: "/var/cache"},
-						{Name: "data", MountPath: "/var/data"},
+					Annotations: map[string]string{
+						"note":  "alpha",
+						"owner": "tester",
 					},
-					Ports: []corev1.ContainerPort{
-						{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
-						{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"role":     "worker",
+						"zone":     "us-west-1",
+						"hardware": "gpu",
 					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("1"),
-							corev1.ResourceMemory: resource.MustParse("1Gi"),
+					Tolerations: []corev1.Toleration{
+						{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+					},
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{Name: "registry-a"},
+						{Name: "registry-b"},
+					},
+					Volumes: []corev1.Volume{
+						{Name: "config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  api.InferenceServerContainerName,
+							Image: "fake/launcher:latest",
+							Env: []corev1.EnvVar{
+								{Name: "FOO", Value: "1"},
+								{Name: "BAR", Value: "2"},
+								{Name: "BAZ", Value: "3"},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "config", MountPath: "/etc/config"},
+								{Name: "cache", MountPath: "/var/cache"},
+								{Name: "data", MountPath: "/var/data"},
+							},
+							Ports: []corev1.ContainerPort{
+								{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+								{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							},
+							ReadinessProbe: &corev1.Probe{},
 						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("2"),
-							corev1.ResourceMemory: resource.MustParse("2Gi"),
-						},
 					},
-					ReadinessProbe: &corev1.Probe{},
 				},
 			},
 		},
@@ -97,9 +108,9 @@ func makeTemplate() v1alpha1.EmbeddedPodTemplateSpec {
 
 // TestComputeLauncherTemplateHash_Deterministic asserts that the same template hashes identically across repeated calls.
 func TestComputeLauncherTemplateHash_Deterministic(t *testing.T) {
-	tpl := makeTemplate()
+	lc := makeLC()
 
-	first, err := ComputeLauncherTemplateHash(tpl)
+	_, first, err := BuildNodeIndependentLauncherTemplate(lc)
 	if err != nil {
 		t.Fatalf("first ComputeLauncherTemplateHash returned error: %v", err)
 	}
@@ -108,7 +119,7 @@ func TestComputeLauncherTemplateHash_Deterministic(t *testing.T) {
 	}
 
 	for i := 0; i < 50; i++ {
-		got, err := ComputeLauncherTemplateHash(tpl)
+		_, got, err := BuildNodeIndependentLauncherTemplate(lc)
 		if err != nil {
 			t.Fatalf("iter %d: ComputeLauncherTemplateHash returned error: %v", i, err)
 		}
@@ -120,14 +131,15 @@ func TestComputeLauncherTemplateHash_Deterministic(t *testing.T) {
 
 // TestComputeLauncherTemplateHash_OrderIndependent asserts that reordering order-independent slices (Env / VolumeMounts / Ports / Volumes / Tolerations / ImagePullSecrets) does not change the hash.
 func TestComputeLauncherTemplateHash_OrderIndependent(t *testing.T) {
-	base := makeTemplate()
-	baseHash, err := ComputeLauncherTemplateHash(base)
+	base := makeLC()
+	_, baseHash, err := BuildNodeIndependentLauncherTemplate(base)
 	if err != nil {
 		t.Fatalf("base hash error: %v", err)
 	}
 
-	shuffled := makeTemplate()
-	c := &shuffled.Spec.Containers[0]
+	shuffled := makeLC()
+	shuffPodSpec := &shuffled.Spec.PodTemplate.Spec
+	c := &shuffPodSpec.Containers[0]
 	c.Env = []corev1.EnvVar{
 		{Name: "BAZ", Value: "3"},
 		{Name: "BAR", Value: "2"},
@@ -142,21 +154,21 @@ func TestComputeLauncherTemplateHash_OrderIndependent(t *testing.T) {
 		{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
 		{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
 	}
-	shuffled.Spec.Volumes = []corev1.Volume{
+	shuffPodSpec.Volumes = []corev1.Volume{
 		{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: "config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	}
-	shuffled.Spec.Tolerations = []corev1.Toleration{
+	shuffPodSpec.Tolerations = []corev1.Toleration{
 		{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
 		{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
 	}
-	shuffled.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+	shuffPodSpec.ImagePullSecrets = []corev1.LocalObjectReference{
 		{Name: "registry-b"},
 		{Name: "registry-a"},
 	}
 
-	shuffledHash, err := ComputeLauncherTemplateHash(shuffled)
+	_, shuffledHash, err := BuildNodeIndependentLauncherTemplate(shuffled)
 	if err != nil {
 		t.Fatalf("shuffled hash error: %v", err)
 	}
@@ -167,15 +179,15 @@ func TestComputeLauncherTemplateHash_OrderIndependent(t *testing.T) {
 
 // TestComputeLauncherTemplateHash_DifferentContentDiffers asserts that genuine content changes (e.g. image) yield distinct hashes.
 func TestComputeLauncherTemplateHash_DifferentContentDiffers(t *testing.T) {
-	a := makeTemplate()
-	b := makeTemplate()
-	b.Spec.Containers[0].Image = "fake/launcher:other"
+	a := makeLC()
+	b := makeLC()
+	b.Spec.PodTemplate.Spec.Containers[0].Image = "fake/launcher:other"
 
-	ha, err := ComputeLauncherTemplateHash(a)
+	_, ha, err := BuildNodeIndependentLauncherTemplate(a)
 	if err != nil {
 		t.Fatalf("hash a error: %v", err)
 	}
-	hb, err := ComputeLauncherTemplateHash(b)
+	_, hb, err := BuildNodeIndependentLauncherTemplate(b)
 	if err != nil {
 		t.Fatalf("hash b error: %v", err)
 	}
@@ -186,36 +198,27 @@ func TestComputeLauncherTemplateHash_DifferentContentDiffers(t *testing.T) {
 
 // TestBuildLauncherPodFromTemplate_NodeIndependentTemplateHash asserts that LauncherTemplateHashAnnotationKey is node-independent while the legacy LauncherConfigHashAnnotationKey differs between nodes.
 func TestBuildLauncherPodFromTemplate_NodeIndependentTemplateHash(t *testing.T) {
-	tpl := makeTemplate()
+	lc := makeLC()
 
-	tplHash, err := ComputeLauncherTemplateHash(tpl)
+	nodeDep, tplHash, err := BuildNodeIndependentLauncherTemplate(lc)
 	if err != nil {
 		t.Fatalf("ComputeLauncherTemplateHash error: %v", err)
 	}
 
-	podA, err := BuildLauncherPodFromTemplate(tpl, "ns", "node-a", "lc1", tplHash)
-	if err != nil {
-		t.Fatalf("build pod A error: %v", err)
-	}
-	podB, err := BuildLauncherPodFromTemplate(tpl, "ns", "node-b", "lc1", tplHash)
-	if err != nil {
-		t.Fatalf("build pod B error: %v", err)
-	}
+	podA := SpecializeLauncherTemplateToNode(nodeDep, "node-a")
+	podB := SpecializeLauncherTemplateToNode(nodeDep, "node-b")
 
-	gotA := podA.Annotations[string(common.LauncherTemplateHashAnnotationKey)]
-	gotB := podB.Annotations[string(common.LauncherTemplateHashAnnotationKey)]
+	gotA := podA.Annotations[common.LauncherTemplateHashAnnotationKey]
+	gotB := podB.Annotations[common.LauncherTemplateHashAnnotationKey]
 	if gotA != tplHash {
 		t.Fatalf("podA template-hash annotation = %q, want %q", gotA, tplHash)
 	}
 	if gotB != tplHash {
 		t.Fatalf("podB template-hash annotation = %q, want %q", gotB, tplHash)
 	}
-	if gotA != gotB {
-		t.Fatalf("template-hash should be node-independent, got A=%q B=%q", gotA, gotB)
-	}
 
-	legacyA := podA.Annotations[string(common.LauncherConfigHashAnnotationKey)]
-	legacyB := podB.Annotations[string(common.LauncherConfigHashAnnotationKey)]
+	legacyA := podA.Annotations[common.LauncherConfigHashAnnotationKey]
+	legacyB := podB.Annotations[common.LauncherConfigHashAnnotationKey]
 	if legacyA == "" || legacyB == "" {
 		t.Fatalf("legacy launcher-config-hash must be set on both pods, got A=%q B=%q", legacyA, legacyB)
 	}


### PR DESCRIPTION
This PR refactors the way that the launcher population controller digests LauncherConfig Pod templates, to remove unnecessary steps and complexity for callers.