### PR TITLE
Fix impatience in E2E test-cases.sh

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -562,6 +562,18 @@ jobs:
         if: always()
         run: kubectl get all -n "$FMA_NAMESPACE"
 
+      - name: Dump select node info after test
+        if: always()
+        run: |
+          for nodename in $(kubectl get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.items[*].metadata.name}'); do
+            echo "For ${nodename}:"
+            echo "taints: $(kubectl get node $nodename -o jsonpath='{.spec.taints}')"
+            echo "conditions: $(kubectl get node $nodename -o jsonpath='{.status.conditions}' | jq .)"
+            echo "FMA images: $(kubectl get node $nodename -o jsonpath='{.status.images}' | jq '[ .[] | select(.names | any(contains("fast-model-actuation"))) | {"names":.names, "sizeMB":(.sizeBytes/1048576|floor) } ]')"
+            echo
+          done
+        continue-on-error: true
+
       - name: Dump InferenceServerConfig objects
         if: always()
         run: kubectl get inferenceserverconfigs -n "$FMA_NAMESPACE" -o yaml

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -60,15 +60,15 @@ jobs:
       - name: Run launcher-based E2E test
         run: test/e2e/run-launcher-based.sh
 
-      - name: show all pods
+      - name: list all pods
         if: always()
         run: kubectl get pods -A -o wide
 
-      - name: show test pods with labels
+      - name: list test pods with labels
         if: always()
         run: kubectl get pods -L dual-pods.llm-d.ai/dual,dual-pods.llm-d.ai/sleeping,dual-pods.llm-d.ai/instance,dual-pods.llm-d.ai/launcher-config-name
 
-      - name: show ReplicaSets
+      - name: list ReplicaSets
         if: always()
         run: kubectl get rs -A
 
@@ -88,35 +88,35 @@ jobs:
           else echo The first dual-pods controller left no log
           fi
 
-      - name: show dual-pods controller log
+      - name: dump dual-pods controller log
         if: always()
         run: kubectl logs deploy/fma-dual-pods-controller
 
-      - name: show launcher-populator log
+      - name: dump launcher-populator log
         if: always()
         run: kubectl logs deploy/fma-launcher-populator || echo "launcher-populator not deployed"
 
-      - name: show GPU allocations
+      - name: dump GPU allocations
         if: always()
         run: kubectl get cm gpu-allocs -o yaml
 
-      - name: show GPU map
+      - name: dump GPU map
         if: always()
         run: kubectl get cm gpu-map -o yaml
 
-      - name: show InferenceServerConfigs
+      - name: dump InferenceServerConfigs
         if: always()
         run: kubectl get inferenceserverconfigs -o yaml
 
-      - name: show LauncherConfigs
+      - name: dump LauncherConfigs
         if: always()
         run: kubectl get launcherconfigs -o yaml
 
-      - name: show YAML of test pods
+      - name: dump YAML of test pods
         if: always()
         run: kubectl get pods -o yaml
 
-      - name: show launcher pod logs
+      - name: dump launcher pod logs
         if: always()
         run: |
           for pod in $(kubectl get pods -l dual-pods.llm-d.ai/launcher-config-name -o name); do
@@ -124,6 +124,6 @@ jobs:
             kubectl logs $pod || echo "Failed to get logs for $pod"
           done
 
-      - name: show vLLM instance logs from launchers
+      - name: dump vLLM instance logs from launchers
         if: always()
         run: scripts/dump-launcher-vllm-logs.sh

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -216,7 +216,7 @@ expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$inst | wc -l
 export req1=$(kubectl get pods -n "$NS" -o name -l app=dp-example,instance=$inst | sed s%pod/%%)
 echo "Server-requesting Pod is $req1"
 # Expect it to get scheduled to the chosen test node
-expect "kubectl get pod $req1 -n $NS -o jsonpath='{.spec.nodeName}' | grep -x $testnode"
+expect "kubectl get pod $req1 -n $NS -o jsonpath='{.spec.nodeName}' | fgrep -x $testnode"
 
 # Wait for launcher-to-requester binding, then capture the launcher name
 expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/dual=$req1 | wc -l | grep -w 1"
@@ -617,7 +617,7 @@ expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$inst | wc -l
 # Verify launcher set is unchanged and target launcher is unbound
 launcher_count_pre_restart=$(kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/launcher-config-name=$lc | wc -l)
 echo launcher_count_pre_restart = $launcher_count_pre_restart
-kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/launcher-config-name=$lc | grep -x "pod/$launcher1"
+kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/launcher-config-name=$lc | fgrep -x "pod/$launcher1"
 expect '[ "$(kubectl get pod -n '"$NS"' $launcher1 -o jsonpath={.metadata.labels.dual-pods\\.llm-d\\.ai/dual})" == "" ]'
 
 # Verify launcher has sleeping instances before restart
@@ -644,7 +644,7 @@ sleep 30
 
 # Verify launcher pod set size is unchanged and target launcher is still running
 expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/launcher-config-name=$lc | wc -l | grep -w $launcher_count_pre_restart"
-kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/launcher-config-name=$lc | grep -x "pod/$launcher1"
+kubectl get pods -n "$NS" -o name -l dual-pods.llm-d.ai/launcher-config-name=$lc | fgrep -x "pod/$launcher1"
 
 # Verify launcher still has the same number of instances after controller restart
 launcher_instances_after=$(kubectl exec -n "$NS" $launcher1 -- python3 -c 'import json,urllib.request; print(json.load(urllib.request.urlopen("http://127.0.0.1:8001/v2/vllm/instances"))["total_instances"])')

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -203,7 +203,8 @@ expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$inst | wc -l
 
 export req1=$(kubectl get pods -n "$NS" -o name -l app=dp-example,instance=$inst | sed s%pod/%%)
 echo "Server-requesting Pod is $req1"
-[ "$(kubectl get pod $req1 -n "$NS" -o jsonpath='{.spec.nodeName}')" = "$testnode" ]
+# Expect it to get scheduled to the chosen test node
+expect "kubectl get pod $req1 -n $NS -o jsonpath='{.spec.nodeName}' | grep -x $testnode"
 
 # Wait for launcher-to-requester binding, then capture the launcher name
 expect "kubectl get pods -n $NS -o name -l dual-pods.llm-d.ai/dual=$req1 | wc -l | grep -w 1"

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -108,6 +108,18 @@ get_launcher_total_instances() {
 }
 
 # ---------------------------------------------------------------------------
+# Echo the relevant environment variables
+# ---------------------------------------------------------------------------
+
+echo "FMA_NAMESPACE=${FMA_NAMESPACE:-«unset»}"
+echo "MKOBJS_SCRIPT=${MKOBJS_SCRIPT:-«unset»}"
+echo "FMA_CHART_INSTANCE_NAME=${FMA_CHART_INSTANCE_NAME:-«unset»}"
+echo "READY_TARGET=${READY_TARGET:-«unset»}"
+echo "POLICIES_ENABLED=${POLICIES_ENABLED:-«unset»}"
+echo "POLL_LIMIT_SECS=${POLL_LIMIT_SECS:-«unset»}"
+echo "FMA_DEBUG=${FMA_DEBUG:-«unset»}"
+
+# ---------------------------------------------------------------------------
 # Probe for a node with 2 free GPUs
 # ---------------------------------------------------------------------------
 # Create a throwaway Pod that requests 2 GPUs.  The scheduler will place it


### PR DESCRIPTION
Admit that scheduling the first server-requesting Pod may take some time.

Also, add dumping of Node state after the test, in the launcher-based E2E test on OpenShift.