### PR TITLE
Remove maxSleepingInstances from LauncherConfig v1alpha1 (#484)

### DIFF
--- a/api/fma/v1alpha1/launcherconfig_types.go
+++ b/api/fma/v1alpha1/launcherconfig_types.go
@@ -45,28 +45,15 @@ type EmbeddedPodTemplateSpec struct {
 }
 
 // LauncherConfigSpec defines the configuration to manage the nominal server-providing pod definition.
-// At most one of `maxSleepingInstances` and `maxInstances` may be positive; setting both to positive
-// values is rejected. Either may be zero or omitted.
-// +kubebuilder:validation:XValidation:rule="!(has(self.maxInstances) && has(self.maxSleepingInstances) && self.maxInstances > 0 && self.maxSleepingInstances > 0)",message="maxInstances and maxSleepingInstances must not both be positive"
 type LauncherConfigSpec struct {
 	// PodTemplate defines the pod specification for the server-providing pod.
 	// +optional
 	PodTemplate EmbeddedPodTemplateSpec `json:"podTemplate,omitempty"`
 
-	// MaxSleepingInstances caps the number of sleeping inference-engine instances per launcher pod
-	// when an awake instance is also present. When no instance is awake, one additional sleeping
-	// instance is permitted — i.e., a launcher pod can hold up to `MaxSleepingInstances + 1`
-	// instances in total.
-	// Deprecated: use MaxInstances, which simply caps the total number of instances per launcher pod.
-	// +optional
-	// +kubebuilder:validation:Minimum=0
-	MaxSleepingInstances int32 `json:"maxSleepingInstances,omitempty"`
-
 	// MaxInstances caps the total number of inference-engine instances per launcher pod.
-	// A value of zero means unset.
-	// +optional
-	// +kubebuilder:validation:Minimum=0
-	MaxInstances int32 `json:"maxInstances,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Minimum=1
+	MaxInstances int32 `json:"maxInstances"`
 }
 
 // LauncherConfigStatus represents the current status

--- a/config/crd/fma.llm-d.ai_launcherconfigs.yaml
+++ b/config/crd/fma.llm-d.ai_launcherconfigs.yaml
@@ -44,21 +44,10 @@ spec:
             description: Spec defines the desired state of the LauncherConfig.
             properties:
               maxInstances:
-                description: |-
-                  MaxInstances caps the total number of inference-engine instances per launcher pod.
-                  A value of zero means unset.
+                description: MaxInstances caps the total number of inference-engine
+                  instances per launcher pod.
                 format: int32
-                minimum: 0
-                type: integer
-              maxSleepingInstances:
-                description: |-
-                  MaxSleepingInstances caps the number of sleeping inference-engine instances per launcher pod
-                  when an awake instance is also present. When no instance is awake, one additional sleeping
-                  instance is permitted — i.e., a launcher pod can hold up to `MaxSleepingInstances + 1`
-                  instances in total.
-                  Deprecated: use MaxInstances, which simply caps the total number of instances per launcher pod.
-                format: int32
-                minimum: 0
+                minimum: 1
                 type: integer
               podTemplate:
                 description: PodTemplate defines the pod specification for the server-providing
@@ -8485,11 +8474,9 @@ spec:
                     - containers
                     type: object
                 type: object
+            required:
+            - maxInstances
             type: object
-            x-kubernetes-validations:
-            - message: maxInstances and maxSleepingInstances must not both be positive
-              rule: '!(has(self.maxInstances) && has(self.maxSleepingInstances) &&
-                self.maxInstances > 0 && self.maxSleepingInstances > 0)'
           status:
             description: Status represents the observed status of the LauncherConfig.
             properties:

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -633,7 +633,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		// then those with capacity for new instances.
 		// Note that multiple vLLM instances could exist in one launcher Pod, but at most one instance could be awake at a time.
 
-		launcherPod, hasSleepingInstance, retry, err := ctl.selectOrReclaimLauncherPod(ctx, launcherPodAnys, desiredInstanceState.instanceID, desiredPort, effectiveMaxInstances(lc)-1, nodeDat)
+		launcherPod, hasSleepingInstance, retry, err := ctl.selectOrReclaimLauncherPod(ctx, launcherPodAnys, desiredInstanceState.instanceID, desiredPort, int(lc.Spec.MaxInstances)-1, nodeDat)
 		if err != nil {
 			return err, true
 		}
@@ -901,16 +901,6 @@ func compareLastUsed(a string, aTime time.Time, b string, bTime time.Time) int {
 		return 1
 	}
 	return strings.Compare(a, b)
-}
-
-// effectiveMaxInstances returns the cap on the total number of inference-engine instances
-// per launcher pod. If MaxInstances is positive, it is used directly; otherwise the legacy
-// MaxSleepingInstances semantics apply and the cap is MaxSleepingInstances + 1.
-func effectiveMaxInstances(lc *fmav1alpha1.LauncherConfig) int {
-	if lc.Spec.MaxInstances > 0 {
-		return int(lc.Spec.MaxInstances)
-	}
-	return int(lc.Spec.MaxSleepingInstances) + 1
 }
 
 // configInferenceServer computes the VllmConfig.

--- a/pkg/generated/applyconfiguration/fma/v1alpha1/launcherconfigspec.go
+++ b/pkg/generated/applyconfiguration/fma/v1alpha1/launcherconfigspec.go
@@ -20,9 +20,8 @@ package v1alpha1
 // LauncherConfigSpecApplyConfiguration represents a declarative configuration of the LauncherConfigSpec type for use
 // with apply.
 type LauncherConfigSpecApplyConfiguration struct {
-	PodTemplate          *EmbeddedPodTemplateSpecApplyConfiguration `json:"podTemplate,omitempty"`
-	MaxSleepingInstances *int32                                     `json:"maxSleepingInstances,omitempty"`
-	MaxInstances         *int32                                     `json:"maxInstances,omitempty"`
+	PodTemplate  *EmbeddedPodTemplateSpecApplyConfiguration `json:"podTemplate,omitempty"`
+	MaxInstances *int32                                     `json:"maxInstances,omitempty"`
 }
 
 // LauncherConfigSpecApplyConfiguration constructs a declarative configuration of the LauncherConfigSpec type for use with
@@ -36,14 +35,6 @@ func LauncherConfigSpec() *LauncherConfigSpecApplyConfiguration {
 // If called multiple times, the PodTemplate field is set to the value of the last call.
 func (b *LauncherConfigSpecApplyConfiguration) WithPodTemplate(value *EmbeddedPodTemplateSpecApplyConfiguration) *LauncherConfigSpecApplyConfiguration {
 	b.PodTemplate = value
-	return b
-}
-
-// WithMaxSleepingInstances sets the MaxSleepingInstances field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the MaxSleepingInstances field is set to the value of the last call.
-func (b *LauncherConfigSpecApplyConfiguration) WithMaxSleepingInstances(value int32) *LauncherConfigSpecApplyConfiguration {
-	b.MaxSleepingInstances = &value
 	return b
 }
 


### PR DESCRIPTION
## Summary

Stage C of #471 — completes the rename of `MaxSleepingInstances` → `MaxInstances`.

- Delete the `MaxSleepingInstances` field and the transitional `XValidation` CEL rule from `LauncherConfigSpec`.
- Make `MaxInstances` required with `Minimum=1`; drop the JSON `omitempty` tag.
- Remove the `effectiveMaxInstances` helper in the dual-pods controller; the single callsite now uses `int(lc.Spec.MaxInstances) - 1` directly.
- Regenerate `config/crd/...` and `pkg/generated/applyconfiguration/...`.

The CRD now lists only `maxInstances` with `minimum: 1` and `required: [maxInstances]`, and carries no `x-kubernetes-validations`.

Stage A (#482, PR #487) and Stage B (#483, PR #516) are merged. Per the timing criteria in #484, all in-flight PRs that touch the shared test cluster have been confirmed rebased past Stage B.

## Test plan

- [x] `make manifests generate generate_client` is clean.
- [x] `go build ./...` and `go test ./...` pass.
- [ ] On a `kind` cluster, apply the new CRD and confirm:
  - [ ] `{maxInstances: 2}` is accepted.
  - [ ] `{maxSleepingInstances: 1}` is rejected under strict decoding (or silently dropped by non-strict clients).
  - [ ] `{}` is rejected by `required`.
  - [ ] `{maxInstances: 0}` is rejected by `minimum: 1`.
- [ ] Run the updated `docs/e2e-recipe.md` end-to-end on `kind`.

Closes #484.