### PR TITLE
Use version 34.1.0 for kube python client in launcher

### DIFF
--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -18,6 +18,6 @@ COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslat
 RUN chmod a+x /app/launcher.py
 
 # Install uvicorn for serving the launcher API and nvidia-ml-py for gputranslator
-RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==31.0.0
+RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==34.1.0
 
 ENTRYPOINT ["uvicorn", "--app-dir", "/app", "launcher:app"]

--- a/inference_server/launcher/requirements-sans-vllm.txt
+++ b/inference_server/launcher/requirements-sans-vllm.txt
@@ -4,4 +4,4 @@ uvicorn==0.42.0
 uvloop==0.22.1
 httpx==0.28.1
 nvidia-ml-py==13.590.48
-kubernetes==31.0.0
+kubernetes==34.1.0


### PR DESCRIPTION
As shown in the title. BTW there is no `34.0.0`.