### PR TITLE
Use version 34.1.0 for kube python client in launcher in requirements-sans-vllm.txt

### DIFF
--- a/inference_server/launcher/requirements-sans-vllm.txt
+++ b/inference_server/launcher/requirements-sans-vllm.txt
@@ -4,4 +4,4 @@ uvicorn==0.42.0
 uvloop==0.22.1
 httpx==0.28.1
 nvidia-ml-py==13.590.48
-kubernetes==31.0.0
+kubernetes==34.1.0


### PR DESCRIPTION
As shown in the title.

This is a follow-up to #541 .