### PR TITLE
Make the launcher, E2E, OpenShift workflow log two scrapes

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -641,6 +641,14 @@ jobs:
           sleep 10
           echo "Test objects cleaned up"
 
+      - name: dump scrape of first dual-pods controller
+        if: always()
+        run: cat scrape1.metrics || true
+
+      - name: dump scrape of final dual-pods controller
+        if: always()
+        run: cat scrape2.metrics || true
+
       - name: Cleanup infrastructure
         # Cleanup unless told not to
         if: always() && env.SKIP_CLEANUP != 'true'


### PR DESCRIPTION
The two that test-cases.sh takes, one for each run of the dual-pods-controller.

This is not a replacement for better infrastructure to come, just making two final scrapes easy to see.