### PR TITLE
Dedicated Transport for each launcher client w/o keeping alives

### DIFF
--- a/pkg/controller/dual-pods/launcherclient.go
+++ b/pkg/controller/dual-pods/launcherclient.go
@@ -63,6 +63,9 @@ func NewLauncherClient(baseURL string) (*LauncherClient, error) {
 		baseURL: parsedURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				DisableKeepAlives: true,
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR assigns a dedicated Transport to each launcher client so that the clients don't use the shared default Transport. Also, the dedicated Transport disables the 'keeping alive' feature. This way, a launcher client never uses an obsolete TCP connection to the launcher.

Fixes #550

This PR and #557 are mutually exclusive.