### PR TITLE
Shorten the controller-side TCP connection lifetime

### DIFF
--- a/pkg/controller/dual-pods/launcherclient.go
+++ b/pkg/controller/dual-pods/launcherclient.go
@@ -47,11 +47,18 @@ func (e *launcherError) Error() string {
 const (
 	VllmConfigISCNameAnnotationKey       = "isc-name"
 	VllmConfigInferencePortAnnotationKey = "inference-port"
+	launcherHTTPIdleConnTimeout          = 4 * time.Second
 
 	// InstanceStatusStopped is the status value reported by the launcher
 	// when a vLLM instance's process has terminated.
 	InstanceStatusStopped = "stopped"
 )
+
+var launcherHTTPTransport = func() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.IdleConnTimeout = launcherHTTPIdleConnTimeout
+	return transport
+}()
 
 func NewLauncherClient(baseURL string) (*LauncherClient, error) {
 	parsedURL, err := url.Parse(baseURL)
@@ -62,7 +69,8 @@ func NewLauncherClient(baseURL string) (*LauncherClient, error) {
 	c := &LauncherClient{
 		baseURL: parsedURL,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout:   30 * time.Second,
+			Transport: launcherHTTPTransport,
 		},
 	}
 


### PR DESCRIPTION
This PR is another solution to #550. This solution and #551 are mutually exclusive.

This PR asks the dual-pods controller to enforce a shorter (comparing to the launcher) lifetime of the TCP connections. This way, the dual-pods controller becomes the only active maintainer of the connection pool thus eliminates racing betwen the launcher.

Close #550.