### PR TITLE
Close uvicorn-side sockets in forked vLLM children

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -24,6 +24,7 @@ import multiprocessing
 import os
 import re
 import signal
+import stat
 import sys
 import uuid
 from contextlib import asynccontextmanager
@@ -43,14 +44,6 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 MAX_LOG_RESPONSE_BYTES = 1 * 1024 * 1024  # 1 MB default for API response
 _MAX_BROADCASTER_EVENTS = 1000
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-
-# Use 'spawn' so child vLLM processes do not inherit open file descriptors
-# from the launcher — including the listening socket on port 8001 and any
-# in-flight TCP connections served by uvicorn. With the default 'fork' on
-# Linux a forked child holds duplicate fds for those sockets, which keeps
-# the kernel socket alive after uvicorn closes its end and produces wedged
-# connections (see issue #550).
-multiprocessing.set_start_method("spawn", force=True)
 
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, force=True)
 
@@ -812,6 +805,33 @@ async def get_vllm_instance_logs(
 ######################################################################
 
 
+def _close_inherited_sockets():
+    """Close every socket fd inherited from the parent across fork().
+
+    Iterates /proc/self/fd and uses fstat to identify sockets, leaving
+    pipes, regular files, character devices, and anything else
+    untouched. fd 0/1/2 are skipped on principle even if they happened
+    to be sockets.
+    """
+    try:
+        fd_names = os.listdir("/proc/self/fd")
+    except OSError:
+        return
+    for name in fd_names:
+        try:
+            fd = int(name)
+        except ValueError:
+            continue
+        if fd <= 2:
+            continue
+        try:
+            if stat.S_ISSOCK(os.fstat(fd).st_mode):
+                os.close(fd)
+        except OSError:
+            # fd was already closed or unstatable; ignore.
+            pass
+
+
 # Function to be executed by the child process
 def vllm_kickoff(vllm_config: VllmConfig, log_file_path: str):
     """
@@ -824,6 +844,17 @@ def vllm_kickoff(vllm_config: VllmConfig, log_file_path: str):
     # signals (SIGINT/SIGTERM) sent to the launcher's group do not
     # propagate to the vLLM server or its EngineCore child process.
     os.setpgrp()
+
+    # Close socket fds inherited from the launcher across fork(). The
+    # child must not hold duplicate references to uvicorn's listening
+    # socket on :8001 nor to any in-flight TCP connections — the kernel
+    # keeps a socket open as long as any process has an fd to it, so a
+    # leaked client fd in this child wedges the connection long after
+    # uvicorn has closed its own end (see issue #550). Pipes (including
+    # multiprocessing's parent-child sentinel pipe used by
+    # start_sentinel_watcher) and regular files are deliberately left
+    # alone.
+    _close_inherited_sockets()
 
     # Redirect stdout and stderr at the OS level using dup2 so that
     # all output (including from vLLM/uvicorn internal logging and any

--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -44,6 +44,14 @@ MAX_LOG_RESPONSE_BYTES = 1 * 1024 * 1024  # 1 MB default for API response
 _MAX_BROADCASTER_EVENTS = 1000
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
+# Use 'spawn' so child vLLM processes do not inherit open file descriptors
+# from the launcher — including the listening socket on port 8001 and any
+# in-flight TCP connections served by uvicorn. With the default 'fork' on
+# Linux a forked child holds duplicate fds for those sockets, which keeps
+# the kernel socket alive after uvicorn closes its end and produces wedged
+# connections (see issue #550).
+multiprocessing.set_start_method("spawn", force=True)
+
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, force=True)
 
 


### PR DESCRIPTION
This PR is the 4th approach to address #550. It is mutually exclusive with PR #551, #557, or #559.

In a forked vLLM child, close every TCP socket inherited from the launcher so the kernel-side refcount on those sockets drops to 1 immediately, which lets a later `transport.close()` in the parent drive the refcount to 0 and produce a normal `FIN`.

I will deliberately keep two initial commits (not having them squashed, pushing them one after another and let the CI finish for each commit) to demonstrate how the hypothesis is validated (by examining the `workqueue_unfinished_work_seconds` metric).
