### PR TITLE
Remove a stale TODO item

### DIFF
--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -1439,9 +1439,6 @@ func (ctl *controller) ensureUnbound(ctx context.Context, serverDat *serverData,
 			serverDat.Sleeping = ptr.To(true)
 		} else {
 			serverPort := serverDat.ServerPort
-			// TODO(waltforme): Is serverPort always set correctly for launcher-based server-providing Pods upon unbinding?
-			// E.g. What if requestingPod is deleted during a crash and restart of the dual-pods controller?
-			// In order to find the port in this case, I think the best effort is to recompute hash for all InferenceServerConfig objects and try to match.
 			if !launcherBased {
 				if serverDat.NominalProvidingPod == nil {
 					var err error


### PR DESCRIPTION
Removes a stale TODO in `ensureUnbound` about launcher-based provider port recovery. Current code persists the launcher server port on the bound provider Pod and recovers it via `recoverInstanceStateFromLauncherPod`.

In other words, the noted restart/unbind concern is already handled (by PR #492).