### PR TITLE
Remove confusing wipe from recomputeDigestForNode

### DIFF
--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -115,10 +115,7 @@ func (ctl *controller) updateDigestForLPP(ctx context.Context, lppName string) e
 
 	prevDigest := ctl.policy.lpps[lppName]
 	var currentMatchedNodeNames sets.Set[string]
-	var prevDigested, digested map[string]int // lcName to count, for this LPP
-	if prevDigest != nil {
-		prevDigested = prevDigest.digested
-	}
+	var digested map[string]int // lcName to count, for this LPP
 	if lpp, err := ctl.lppLister.LauncherPopulationPolicies(ctl.namespace).Get(lppName); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get LPP %s: %w", lppName, err)
@@ -175,12 +172,12 @@ func (ctl *controller) updateDigestForLPP(ctx context.Context, lppName string) e
 		if currentMatchedNodeNames.Has(nodeName) {
 			continue
 		}
-		ctl.applyLPPToDigestForNode(lppName, prevDigested, nil, nodeName)
+		ctl.applyLPPToDigestForNode(lppName, nil, nodeName)
 	}
 
 	// Apply LPP to each matched node and enqueue affected keys.
 	for nodeName := range currentMatchedNodeNames {
-		ctl.applyLPPToDigestForNode(lppName, prevDigested, digested, nodeName)
+		ctl.applyLPPToDigestForNode(lppName, digested, nodeName)
 	}
 
 	return nil
@@ -209,14 +206,13 @@ func (ctl *controller) updateDigestForNode(ctx context.Context, nodeName string)
 // recomputeDigestForNode rebuilds digest entries for a single node by replaying
 // every cached LPP. Pure read of ctl.policy.lpps + ctl.policy.lcs.
 func (ctl *controller) recomputeDigestForNode(node *corev1.Node) {
-	ctl.policy.digest[node.Name] = make(map[string]*digestEntry)
 	for lppName, lppd := range ctl.policy.lpps {
 		newDigested := lppd.digested
 		matches := lppd.selectorErr == nil && lppd.labelSelector.Matches(labels.Set(node.Labels)) && matchesResourceConditions(node.Status.Allocatable, lppd.object.Spec.EnhancedNodeSelector.AllocatableResources)
 		if !matches {
 			newDigested = nil
 		}
-		ctl.applyLPPToDigestForNode(lppName, lppd.digested, newDigested, node.Name)
+		ctl.applyLPPToDigestForNode(lppName, newDigested, node.Name)
 	}
 
 	if len(ctl.policy.digest[node.Name]) == 0 {
@@ -225,11 +221,11 @@ func (ctl *controller) recomputeDigestForNode(node *corev1.Node) {
 }
 
 // applyLPPToDigestForNode updates the digested policy map regarding
-// a particular node and LPP, given the previous and new result of digesting
+// a particular node and LPP, given the new result of digesting
 // that LPP.
 // It never validates templates, writes Status, or fetches from listers.
 // Enqueues keys for which this made a difference.
-func (ctl *controller) applyLPPToDigestForNode(lppName string, prevLCToCount, lcToCount map[string]int, nodeName string) {
+func (ctl *controller) applyLPPToDigestForNode(lppName string, lcToCount map[string]int, nodeName string) {
 	for lcName := range lcToCount {
 		entry := ctl.policy.getEntry(nodeName, lcName, true)
 		entry.lpps[lppName] = lcToCount
@@ -238,12 +234,12 @@ func (ctl *controller) applyLPPToDigestForNode(lppName string, prevLCToCount, lc
 			ctl.keyQueue.Queue.Add(keyItem{NodeLauncherKey{NodeName: nodeName, LauncherConfigName: lcName}})
 		}
 	}
-	for lcName := range prevLCToCount {
-		if _, has := lcToCount[lcName]; has {
+	nodeMap := ctl.policy.digest[nodeName]
+	for lcName, entry := range nodeMap {
+		if _, lcIsWanted := lcToCount[lcName]; lcIsWanted {
 			continue
 		}
-		entry := ctl.policy.getEntry(nodeName, lcName, false)
-		if entry == nil {
+		if _, lppWasWanted := entry.lpps[lppName]; !lppWasWanted {
 			continue
 		}
 		delete(entry.lpps, lppName)

--- a/pkg/controller/launcher-populator/digested-policy.go
+++ b/pkg/controller/launcher-populator/digested-policy.go
@@ -73,8 +73,16 @@ type lppDigest struct {
 // Concurrency: mu serializes write transactions performed by the (single)
 // digest worker against snapshot reads performed by the keyQueue workers. The
 // digest worker holds Lock() for the duration of one updateDigestForX call;
-// readers hold RLock() while taking a small value-typed snapshot, then drop
-// the lock before issuing K8s API calls.
+// readers hold RLock() while taking a small value-typed snapshot.
+//
+// In short, changes to this data structure are serialized.
+// Changes to LauncherPopulationPolicy objects enter through only one method, updateDigestForLPP.
+// Changes to LauncherConfig objects enter through only one method, updateDigestForLC.
+// Changes to Node objects enter through either of two methods,
+// updateDigestForLPP and updateDigestForNode.
+// There is some internal redundancy in this data structure;
+// each of those three methods consistently updates the whole
+// data structure for the change(s) it ingests.
 type digestedPolicy struct {
 	mu     sync.RWMutex
 	digest map[string]map[string]*digestEntry // node name → LC name → entry


### PR DESCRIPTION
Remove the clear of `ctl.policy.digest[node.Name]` at https://github.com/llm-d-incubation/llm-d-fast-model-actuation/blob/c844356bfd9d19929f78bb2e96da3113569800da/pkg/controller/launcher-populator/digest-updater.go#L212 .

Change `ctl.applyLPPToDigestForNode` so that it does not take the previous lcName-to-count mapping but rather reads that from `ctl.policy.digest`.

Add a bit more explanation on the `digestedPolicy` type, hoping to emphasize some points to facilitate clear reasoning about it.

This is hoped to address Issue #566 .