### PR TITLE
Align launcher image ENTRYPOINT with deployment command

### DIFF
--- a/dockerfiles/Dockerfile.launcher.benchmark
+++ b/dockerfiles/Dockerfile.launcher.benchmark
@@ -7,3 +7,6 @@ COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslat
 
 # Install uvicorn for serving the launcher API, nvidia-ml-py for gputranslator and kubernetes
 RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==34.1.0
+
+# This image is only intended to be run from a Pod that sets `command`.
+ENTRYPOINT []

--- a/dockerfiles/Dockerfile.launcher.benchmark
+++ b/dockerfiles/Dockerfile.launcher.benchmark
@@ -8,4 +8,4 @@ COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslat
 # Install uvicorn for serving the launcher API, nvidia-ml-py for gputranslator and kubernetes
 RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==34.1.0
 
-ENTRYPOINT ["uvicorn", "--app-dir", "/app", "launcher:app"]
+ENTRYPOINT ["python3", "/app/launcher.py"]

--- a/dockerfiles/Dockerfile.launcher.benchmark
+++ b/dockerfiles/Dockerfile.launcher.benchmark
@@ -7,5 +7,3 @@ COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslat
 
 # Install uvicorn for serving the launcher API, nvidia-ml-py for gputranslator and kubernetes
 RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==34.1.0
-
-ENTRYPOINT ["python3", "/app/launcher.py"]

--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -20,4 +20,4 @@ RUN chmod a+x /app/launcher.py
 # Install uvicorn for serving the launcher API and nvidia-ml-py for gputranslator
 RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==34.1.0
 
-ENTRYPOINT ["uvicorn", "--app-dir", "/app", "launcher:app"]
+ENTRYPOINT ["python3", "/app/launcher.py"]

--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -19,3 +19,6 @@ RUN chmod a+x /app/launcher.py
 
 # Install uvicorn for serving the launcher API and nvidia-ml-py for gputranslator
 RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==34.1.0
+
+# This image is only intended to be run from a Pod that sets `command`.
+ENTRYPOINT []

--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -19,5 +19,3 @@ RUN chmod a+x /app/launcher.py
 
 # Install uvicorn for serving the launcher API and nvidia-ml-py for gputranslator
 RUN pip install --root-user-action=ignore --no-cache-dir uvicorn nvidia-ml-py kubernetes==34.1.0
-
-ENTRYPOINT ["python3", "/app/launcher.py"]


### PR DESCRIPTION
This PR removes the obsolete launcher image `ENTRYPOINT`s. The issue was discovered during this [thread of discussion](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/559#discussion_r3404626669).