### PR TITLE
fixed gpu indices race bug

### DIFF
--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -354,16 +354,16 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		gpuIDsStr := strings.Join(gpuUUIDs, ",")
 		serverDat.GPUIDs = gpuUUIDs
 		serverDat.GPUIDsStr = &gpuIDsStr
+	}
 
-		if !launcherBased && serverDat.GPUIndicesStr == nil {
-			gpuIndices, err := ctl.mapToGPUIndices(requestingPod.Spec.NodeName, gpuUUIDs)
-			if err != nil {
-				return ctl.ensureReqStatus(ctx, requestingPod, serverDat, err.Error())
-			}
-			gpuIndicesStr := strings.Join(gpuIndices, ",")
-			serverDat.GPUIndices = gpuIndices
-			serverDat.GPUIndicesStr = &gpuIndicesStr
+	if !launcherBased && serverDat.GPUIndicesStr == nil {
+		gpuIndices, err := ctl.mapToGPUIndices(requestingPod.Spec.NodeName, serverDat.GPUIDs)
+		if err != nil {
+			return ctl.ensureReqStatus(ctx, requestingPod, serverDat, err.Error())
 		}
+		gpuIndicesStr := strings.Join(gpuIndices, ",")
+		serverDat.GPUIndices = gpuIndices
+		serverDat.GPUIndicesStr = &gpuIndicesStr
 	}
 
 	var desiredInstanceState *vllmInstanceState


### PR DESCRIPTION
The `GPUIndicesStr` mapping was nested inside the if `serverDat.GPUIDsStr == nil. block
During controller startup, the gpu-map ConfigMap and requester pods are processed concurrently by different workers.
If worker 0 processes the requester before worker 1 finishes parsing the gpu-map we will get nil pointer dereference panic.

Steps to reproduce:
1. Deploy the dual-pods controller with num-workers >= 2 (default is 2).
2. Create the gpu-map ConfigMap in the namespace with correct GPU UUID-to-index mappings
3. Create a requester pod (non-launcher-based, with server-patch annotation)
4. Restart the controller
5. Both the gpu-map ConfigMap and the requester pod are in the initial informer list and get processed concurrently
6. Controller panics with runtime error: invalid memory address or nil pointer dereference at inference-server.go:1624
```bash
I0616 20:43:20.477821       1 main.go:62] "Start" time="2026-06-16 20:43:20.477728775 +0000 UTC m=+0.011666933"
I0616 20:43:20.477861       1 main.go:65] "Flag" name="add_dir_header" value="false"
I0616 20:43:20.477867       1 main.go:65] "Flag" name="alsologtostderr" value="false"
I0616 20:43:20.477873       1 main.go:65] "Flag" name="cluster" value=""
I0616 20:43:20.477876       1 main.go:65] "Flag" name="context" value=""
I0616 20:43:20.477879       1 main.go:65] "Flag" name="debug-accelerator-memory" value="false"
I0616 20:43:20.477883       1 main.go:65] "Flag" name="debug-port" value="8003"
I0616 20:43:20.477886       1 main.go:65] "Flag" name="kubeconfig" value=""
I0616 20:43:20.477890       1 main.go:65] "Flag" name="log_backtrace_at" value=":0"
I0616 20:43:20.477894       1 main.go:65] "Flag" name="log_dir" value=""
I0616 20:43:20.477898       1 main.go:65] "Flag" name="log_file" value=""
I0616 20:43:20.477902       1 main.go:65] "Flag" name="log_file_max_size" value="1800"
I0616 20:43:20.477906       1 main.go:65] "Flag" name="logtostderr" value="true"
I0616 20:43:20.477909       1 main.go:65] "Flag" name="metrics-port" value="8002"
I0616 20:43:20.477913       1 main.go:65] "Flag" name="namespace" value="oaplaton-dev"
I0616 20:43:20.477917       1 main.go:65] "Flag" name="num-workers" value="2"
I0616 20:43:20.477921       1 main.go:65] "Flag" name="one_output" value="false"
I0616 20:43:20.477926       1 main.go:65] "Flag" name="skip_headers" value="false"
I0616 20:43:20.477931       1 main.go:65] "Flag" name="skip_log_headers" value="false"
I0616 20:43:20.477935       1 main.go:65] "Flag" name="sleeper-limit" value="1"
I0616 20:43:20.477939       1 main.go:65] "Flag" name="stderrthreshold" value="2"
I0616 20:43:20.477943       1 main.go:65] "Flag" name="user" value=""
I0616 20:43:20.477946       1 main.go:65] "Flag" name="v" value="5"
I0616 20:43:20.477951       1 main.go:65] "Flag" name="vmodule" value=""
I0616 20:43:20.477955       1 main.go:72] "Focusing on one namespace" name="oaplaton-dev"
I0616 20:43:20.478049       1 merged_client_builder.go:121] Using in-cluster configuration
I0616 20:43:20.478265       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0616 20:43:20.478273       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0616 20:43:20.478277       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0616 20:43:20.478281       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0616 20:43:20.478285       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0616 20:43:20.478803       1 shared_informer.go:349] "Waiting for caches to sync" controller="dual-pods-controller"
I0616 20:43:20.478904       1 reflector.go:358] "Starting reflector" type="*v1.Pod" resyncPeriod="0s" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.478923       1 reflector.go:404] "Listing and watching" type="*v1.Pod" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.478953       1 reflector.go:358] "Starting reflector" type="*v1alpha1.InferenceServerConfig" resyncPeriod="0s" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.478962       1 reflector.go:358] "Starting reflector" type="*v1.ConfigMap" resyncPeriod="0s" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.478987       1 reflector.go:404] "Listing and watching" type="*v1alpha1.InferenceServerConfig" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.478989       1 reflector.go:358] "Starting reflector" type="*v1alpha1.LauncherConfig" resyncPeriod="0s" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.479013       1 reflector.go:404] "Listing and watching" type="*v1.ConfigMap" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.479032       1 reflector.go:404] "Listing and watching" type="*v1alpha1.LauncherConfig" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.479036       1 reflector.go:358] "Starting reflector" type="*v1.Node" resyncPeriod="0s" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.479087       1 reflector.go:404] "Listing and watching" type="*v1.Node" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.484615       1 reflector.go:439] "Caches populated" type="*v1alpha1.InferenceServerConfig" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.485208       1 reflector.go:439] "Caches populated" type="*v1.ConfigMap" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.485346       1 controller.go:497] "Enqueuing ConfigMap reference due to notification of add" logger="dual-pods-controller" item="oaplaton-dev/gpu-map" isInInitialList=true resourceVersion="271353415"
I0616 20:43:20.485379       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/inference-perf-profiles"
I0616 20:43:20.485402       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/istio-ca-crl"
I0616 20:43:20.485410       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/istio-ca-root-cert"
I0616 20:43:20.485419       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/kube-root-ca.crt"
I0616 20:43:20.485433       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/prometheus-prom-kube-prometheus-stack-prometheus-rulefiles-0"
I0616 20:43:20.485498       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/prometheus-web-tls-ca"
I0616 20:43:20.485508       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/workload-variant-autoscaler-saturation-scaling-config"
I0616 20:43:20.485518       1 controller.go:493] "Ignoring ConfigMap that is not the GPU map" logger="dual-pods-controller" ref="oaplaton-dev/workload-variant-autoscaler-wva-variantautoscaling-config"
I0616 20:43:20.485914       1 reflector.go:439] "Caches populated" type="*v1alpha1.LauncherConfig" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.485934       1 reflector.go:439] "Caches populated" type="*v1.Pod" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.486535       1 controller.go:457] "Ignoring add of irrelevant Pod" logger="dual-pods-controller" name="fma-dual-pods-controller-b79c765fb-hbv95"
I0616 20:43:20.486621       1 controller.go:457] "Ignoring add of irrelevant Pod" logger="dual-pods-controller" name="fma-launcher-populator-648c9d75cc-445g9"
I0616 20:43:20.486816       1 controller.go:485] "Enqueuing inference server reference due to notification of add" logger="dual-pods-controller" nodeName="gd91fda" item={"UID":"027b9c71-0f6a-4132-8df3-fce1860a8920","RequesterName":"my-request-23-35-29-lprdp"} infSvrItemType="requester" isInInitialList=true resourceVersion="271361146"
I0616 20:43:20.486872       1 controller.go:457] "Ignoring add of irrelevant Pod" logger="dual-pods-controller" name="prometheus-prom-kube-prometheus-stack-prometheus-0"
I0616 20:43:20.489474       1 reflector.go:439] "Caches populated" type="*v1.Node" reflector="k8s.io/client-go@v0.34.8/tools/cache/reflector.go:290"
I0616 20:43:20.579115       1 shared_informer.go:356] "Caches are synced" controller="dual-pods-controller"
I0616 20:43:20.579211       1 queue-work.go:91] "Launching worker" worker=0
I0616 20:43:20.579222       1 queue-work.go:91] "Launching worker" worker=1
I0616 20:43:20.579227       1 queue-work.go:97] "Started workers" numWorkers=2
I0616 20:43:20.579264       1 queue-work.go:113] "Popped workqueue item" worker=1 item="oaplaton-dev/gpu-map" itemType="dualpods.cmItem"
I0616 20:43:20.579343       1 queue-work.go:113] "Popped workqueue item" worker=0 item={"NodeName":"gd91fda"} itemType="dualpods.nodeItem"
I0616 20:43:20.579372       1 inference-server.go:96] "Processing items for node" worker=0 node="gd91fda" count=1
I0616 20:43:20.579385       1 inference-server.go:98] "Processing node-local item" worker=0 node="gd91fda" item={"UID":"027b9c71-0f6a-4132-8df3-fce1860a8920","RequesterName":"my-request-23-35-29-lprdp"}
I0616 20:43:20.579543       1 inference-server.go:193] "Processing inference server" worker=0 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" requesterResourceVersion="271361146" requesterDeletionTimestamp=null requesterRCS={"State":{"running":{"startedAt":"2026-06-16T20:39:36Z"}},"LastTerminationState":{},"Ready":false,"RestartCount":0,"Started":true} providerResourceVersion="(non existent)" providerDeletionTimestamp=null providerRCS=null GPUIDs=null
I0616 20:43:20.579570       1 inference-server.go:338] "Querying accelerators" worker=0 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" ip="10.0.2.160" port="8081"
I0616 20:43:20.580718       1 inference-server.go:2016] "Got GPU UUIDs" worker=0 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" url="http://10.0.2.160:8081/v1/dual-pods/accelerators" httpCallStartTime="2026-06-16T20:43:20.57957712Z"
I0616 20:43:20.580746       1 inference-server.go:352] "Found GPUs" worker=0 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" gpuUUIDs=["GPU-0343f094-4d6d-38b9-2bff-d7681e77642d"]
I0616 20:43:20.580781       1 inference-server.go:1808] "No need to update status, accelerators, boundName, instanceID, or finalizers" worker=0 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" serverRequestingPod="my-request-23-35-29-lprdp" status={"Errors":["UUID GPU-0343f094-4d6d-38b9-2bff-d7681e77642d is not known"]} accelerators="GPU-0343f094-4d6d-38b9-2bff-d7681e77642d" boundName="" instanceID="" finalizers=null
I0616 20:43:20.580796       1 inference-server.go:107] "Finished processing node-local item" worker=0 node="gd91fda" item={"UID":"027b9c71-0f6a-4132-8df3-fce1860a8920","RequesterName":"my-request-23-35-29-lprdp"} willRetry=false
I0616 20:43:20.580804       1 inference-server.go:114] "Done processing items for node" worker=0 node="gd91fda" numToRetry=0
I0616 20:43:20.580816       1 queue-work.go:129] "Processed workqueue item successfully." worker=0 item={"NodeName":"gd91fda"}
I0616 20:43:20.580834       1 queue-work.go:113] "Popped workqueue item" worker=0 item="Senti Nel/0" itemType="dualpods.cmItem"
I0616 20:43:20.580841       1 knows-processed-sync.go:74] "Done processing initial batch of items; waiting for others" worker=0 sentinel="Senti Nel/0"
I0616 20:43:20.581117       1 controller.go:708] "Parsed GPU map" worker=1 numNodes=1 numGPUs=1 additions=1
I0616 20:43:20.581153       1 controller.go:733] "Enqueuing inference server because of change to GPU map" worker=1 node="gd91fda" item={"UID":"027b9c71-0f6a-4132-8df3-fce1860a8920","RequesterName":"my-request-23-35-29-lprdp"}
I0616 20:43:20.581184       1 queue-work.go:129] "Processed workqueue item successfully." worker=1 item="oaplaton-dev/gpu-map"
I0616 20:43:20.581198       1 queue-work.go:113] "Popped workqueue item" worker=1 item="Senti Nel/1" itemType="dualpods.cmItem"
I0616 20:43:20.581207       1 knows-processed-sync.go:74] "Done processing initial batch of items; waiting for others" worker=1 sentinel="Senti Nel/1"
I0616 20:43:20.581218       1 knows-processed-sync.go:77] "Resuming normal processing of items" worker=1 sentinel="Senti Nel/1"
I0616 20:43:20.581227       1 queue-work.go:113] "Popped workqueue item" worker=1 item={"NodeName":"gd91fda"} itemType="dualpods.nodeItem"
I0616 20:43:20.581234       1 knows-processed-sync.go:89] "All workers have finished processing initial items"
I0616 20:43:20.581251       1 controller.go:212] "All initial items processed"
I0616 20:43:20.581238       1 inference-server.go:96] "Processing items for node" worker=1 node="gd91fda" count=1
I0616 20:43:20.581253       1 knows-processed-sync.go:77] "Resuming normal processing of items" worker=0 sentinel="Senti Nel/0"
I0616 20:43:20.581266       1 inference-server.go:98] "Processing node-local item" worker=1 node="gd91fda" item={"UID":"027b9c71-0f6a-4132-8df3-fce1860a8920","RequesterName":"my-request-23-35-29-lprdp"}
I0616 20:43:20.581304       1 inference-server.go:193] "Processing inference server" worker=1 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" requesterResourceVersion="271361146" requesterDeletionTimestamp=null requesterRCS={"State":{"running":{"startedAt":"2026-06-16T20:39:36Z"}},"LastTerminationState":{},"Ready":false,"RestartCount":0,"Started":true} providerResourceVersion="(non existent)" providerDeletionTimestamp=null providerRCS=null GPUIDs=["GPU-0343f094-4d6d-38b9-2bff-d7681e77642d"]
I0616 20:43:20.581321       1 inference-server.go:1586] "Building server-providing pod from patch" worker=1 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" patch=<
	metadata:
	  labels: {
	    "model-reg": "ibm-granite",
	    "model-repo": "granite-3.3-2b-instruct",
	    "app": null}
	spec:
	  containers:
	  - name: inference-server
	    image: docker.io/vllm/vllm-openai:v0.23.0
	    command:
	    - vllm
	    - serve
	    - --port=8000
	    - ibm-granite/granite-3.3-2b-instruct
	    - --enable-sleep-mode
	    - --max-model-len=32768
	    - --gpu-memory-utilization=0.8
	    env:
	    - name: VLLM_SERVER_DEV_MODE
	      value: "1"
	    - name: VLLM_CACHE_ROOT
	      value: /tmp/vllm
	    - name: FLASHINFER_WORKSPACE_BASE
	      value: /tmp/vllm
	    - name: XDG_CONFIG_HOME
	      value: /tmp
	    - name: TRITON_HOME
	      value: /tmp
	    resources:
	      limits:
	        cpu: "2"
	        memory: 9Gi
	    readinessProbe:
	      httpGet:
	        path: /health
	        port: 8000
	      initialDelaySeconds: 60
	      periodSeconds: 5
 >
I0616 20:43:20.582479       1 inference-server.go:1615] "Before StrategicMergePatch" worker=1 node="gd91fda" serverUID="027b9c71-0f6a-4132-8df3-fce1860a8920" requesterName="my-request-23-35-29-lprdp" reqPodName="my-request-23-35-29-lprdp" baseJSON="{\"metadata\":{\"namespace\":\"oaplaton-dev\",\"labels\":{\"app\":\"dp-example\",\"instance\":\"23-35-29\",\"topology.kubernetes.io/region\":\"US-EAST-04\",\"topology.kubernetes.io/zone\":\"374\"}},\"spec\":{\"containers\":[{\"name\":\"inference-server\",\"image\":\"omerap12/requester:latest\",\"ports\":[{\"name\":\"probes\",\"containerPort\":8080,\"protocol\":\"TCP\"},{\"name\":\"spi\",\"containerPort\":8081,\"protocol\":\"TCP\"}],\"resources\":{\"limits\":{\"cpu\":\"1\",\"memory\":\"250Mi\",\"nvidia.com/gpu\":\"1\"},\"requests\":{\"cpu\":\"1\",\"memory\":\"250Mi\",\"nvidia.com/gpu\":\"1\"}},\"readinessProbe\":{\"httpGet\":{\"path\":\"/ready\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":2,\"timeoutSeconds\":1,\"periodSeconds\":5,\"successThreshold\":1,\"failureThreshold\":3},\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"Always\"}],\"restartPolicy\":\"Always\",\"terminationGracePeriodSeconds\":30,\"dnsPolicy\":\"ClusterFirst\",\"serviceAccountName\":\"default\",\"serviceAccount\":\"default\",\"nodeName\":\"gd91fda\",\"securityContext\":{},\"schedulerName\":\"default-scheduler\",\"tolerations\":[{\"key\":\"node.kubernetes.io/not-ready\",\"operator\":\"Exists\",\"effect\":\"NoExecute\",\"tolerationSeconds\":300},{\"key\":\"node.kubernetes.io/unreachable\",\"operator\":\"Exists\",\"effect\":\"NoExecute\",\"tolerationSeconds\":300}],\"priority\":0,\"enableServiceLinks\":true,\"preemptionPolicy\":\"PreemptLowerPriority\"},\"status\":{}}"
I0616 20:43:20.582656       1 queue-work.go:129] "Processed workqueue item successfully." worker=1 item={"NodeName":"gd91fda"}
E0616 20:43:20.582735       1 panic.go:336] "Observed a panic" worker=1 panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
	goroutine 263 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x222fcf8, 0x38172b174ba0}, {0x1d8dda0, 0x3656c40})
		k8s.io/apimachinery@v0.34.8/pkg/util/runtime/runtime.go:132 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x222fcf8, 0x38172ae02c90}, {0x1d8dda0, 0x3656c40}, {0x0, 0x0, 0x38172affc5d8?})
		k8s.io/apimachinery@v0.34.8/pkg/util/runtime/runtime.go:107 +0x116
	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x222fcf8, 0x38172ae02c90}, {0x0, 0x0, 0x0})
		k8s.io/apimachinery@v0.34.8/pkg/util/runtime/runtime.go:78 +0x55
	panic({0x1d8dda0?, 0x3656c40?})
		runtime/panic.go:860 +0x13a
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.(*serverData).getNominalServerProvidingPod(0x38172b09a600, {0x222fcf8?, 0x38172ae03230?}, 0x38172a894488, {0x38172b9e6700, 0x350}, {{0x38172acd07c0, 0x7}, {0x0, 0x0}})
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/inference-server.go:1624 +0xa28
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.infSvrItem.process({{0x38172acc3200, 0x24}, {0x38172af3a3c0, 0x19}}, {0x222fcf8, 0x38172ada25a0}, 0x38172ab39980, 0x38172b61a040)
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/inference-server.go:551 +0x2cee
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.nodeItem.process({{0x38172acd07c0?, 0x38172ad36c40?}}, {0x222fcf8, 0x38172ae02c90}, 0x38172ab39980)
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/inference-server.go:99 +0x424
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.(*controller).process(...)
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/controller.go:674
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).processNextWorkItem(0x222fcc0, {0x222fcf8, 0x38172ae02c90})
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:139 +0x363
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).runWorker(...)
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:102
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).StartWorkers.func1.1()
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:93 +0x58
	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x222fcf8?, 0x38172ae02c90?}, 0x38172ae02cc0?)
		k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:255 +0x51
	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x222fcf8, 0x38172ae02c90}, 0x38172affdfb0, {0x220a760, 0x38172ae02cc0}, 0x1)
		k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:256 +0xe5
	k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x222fcf8, 0x38172ae02c90}, 0x38172aabc7b0, 0x3b9aca00, 0x0, 0x1)
		k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:223 +0x8f
	k8s.io/apimachinery/pkg/util/wait.UntilWithContext({0x222fcf8?, 0x38172ae02c90?}, 0x0?, 0x0?)
		k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:172 +0x25
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).StartWorkers.func1()
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:93 +0x65
	created by github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).StartWorkers in goroutine 1
		github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:92 +0x93
 >
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a13028]

goroutine 263 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x222fcf8, 0x38172ae02c90}, {0x1d8dda0, 0x3656c40}, {0x0, 0x0, 0x38172affc5d8?})
	k8s.io/apimachinery@v0.34.8/pkg/util/runtime/runtime.go:114 +0x1a9
k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x222fcf8, 0x38172ae02c90}, {0x0, 0x0, 0x0})
	k8s.io/apimachinery@v0.34.8/pkg/util/runtime/runtime.go:78 +0x55
panic({0x1d8dda0?, 0x3656c40?})
	runtime/panic.go:860 +0x13a
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.(*serverData).getNominalServerProvidingPod(0x38172b09a600, {0x222fcf8?, 0x38172ae03230?}, 0x38172a894488, {0x38172b9e6700, 0x350}, {{0x38172acd07c0, 0x7}, {0x0, 0x0}})
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/inference-server.go:1624 +0xa28
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.infSvrItem.process({{0x38172acc3200, 0x24}, {0x38172af3a3c0, 0x19}}, {0x222fcf8, 0x38172ada25a0}, 0x38172ab39980, 0x38172b61a040)
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/inference-server.go:551 +0x2cee
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.nodeItem.process({{0x38172acd07c0?, 0x38172ad36c40?}}, {0x222fcf8, 0x38172ae02c90}, 0x38172ab39980)
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/inference-server.go:99 +0x424
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods.(*controller).process(...)
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods/controller.go:674
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).processNextWorkItem(0x222fcc0, {0x222fcf8, 0x38172ae02c90})
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:139 +0x363
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).runWorker(...)
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:102
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).StartWorkers.func1.1()
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:93 +0x58
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x222fcf8?, 0x38172ae02c90?}, 0x38172ae02cc0?)
	k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:255 +0x51
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x222fcf8, 0x38172ae02c90}, 0x38172affdfb0, {0x220a760, 0x38172ae02cc0}, 0x1)
	k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:256 +0xe5
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x222fcf8, 0x38172ae02c90}, 0x38172aabc7b0, 0x3b9aca00, 0x0, 0x1)
	k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:223 +0x8f
k8s.io/apimachinery/pkg/util/wait.UntilWithContext({0x222fcf8?, 0x38172ae02c90?}, 0x0?, 0x0?)
	k8s.io/apimachinery@v0.34.8/pkg/util/wait/backoff.go:172 +0x25
github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).StartWorkers.func1()
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:93 +0x65
created by github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic.(*QueueAndWorkers[...]).StartWorkers in goroutine 1
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic/queue-work.go:92 +0x93
```

This reproduces consistently because worker ordering is deterministic. worker 0 always finishes the requester HTTP call before worker 1 finishes parsing the ConfigMap.