### PR TITLE
Fix inconsistency wrt ctl.gpuMap holding nil

### DIFF
--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -186,7 +186,6 @@ func (config ControllerConfig) NewController(
 		accelMemoryLimitMiB: config.AcceleratorSleepingMemoryLimitMiB,
 		nodeNameToData:      map[string]*nodeData{},
 	}
-	ctl.gpuMap.Store(&map[string]GpuLocation{})
 	err := ctl.podInformer.AddIndexers(cache.Indexers{
 		inferenceServerConfigIndexName: inferenceServerConfigIndexFunc,
 		launcherConfigHashIndexName:    launcherConfigHashIndexFunc,

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -2020,9 +2020,12 @@ func getGPUUUIDs(ctx context.Context, url string) ([]string, error) {
 // findGPUIndices maps GPU UUIDs to GPU indices.
 // This func will be moved into the launcher in milestone 3
 func (ctl *controller) mapToGPUIndices(nodeName string, gpuUUIDs []string) ([]string, error) {
-	gpuMap := *ctl.gpuMap.Load()
+	gpuMapPtr := ctl.gpuMap.Load()
+	if gpuMapPtr == nil {
+		return nil, fmt.Errorf("GPU map ConfigMap %s is not available", GPUMapName)
+	}
 	indices, errs := utils.SliceMap(gpuUUIDs, func(uuid string) (string, error) {
-		loc, have := gpuMap[uuid]
+		loc, have := (*gpuMapPtr)[uuid]
 		if !have {
 			return "", fmt.Errorf("UUID %s is not known", uuid)
 		} else if loc.Node != nodeName {


### PR DESCRIPTION
Consistently allow `ctl.gpuMap` to hold `nil`.

Fixes #573 