### PR TITLE
Fix typo in metrics.md

### DIFF
--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -9,18 +9,43 @@ on:
     paths:
       - ".github/workflows/launcher-based-e2e-test.yml"
       - Makefile
+      - api/**
+      - charts/**
       - cmd/dual-pods-controller/**
-      - cmd/test-requester/**
       - cmd/launcher-populator/**
+      - cmd/test-requester/**
+      - config/**
+      - '!config/examples/**'
+      - dockerfiles/Dockerfile.launcher.cpu
+      - go.*
       - inference_server/launcher/**
-      - dockerfiles/Dockerfile.launcher.benchmark
       - pkg/**
-      - test/e2e/run-launcher-based.sh
-      - test/e2e/mkobjs.sh
+      - scripts/*
+      - test/e2e/**
+      - '!test/e2e/*.md'
+      - '!test/e2e/demo-fma-hpa/**'
 
   pull_request:
     branches:
       - main
+    paths:
+      - ".github/workflows/launcher-based-e2e-test.yml"
+      - Makefile
+      - api/**
+      - charts/**
+      - cmd/dual-pods-controller/**
+      - cmd/launcher-populator/**
+      - cmd/test-requester/**
+      - config/**
+      - '!config/examples/**'
+      - dockerfiles/Dockerfile.launcher.cpu
+      - go.*
+      - inference_server/launcher/**
+      - pkg/**
+      - scripts/*
+      - test/e2e/**
+      - '!test/e2e/*.md'
+      - '!test/e2e/demo-fma-hpa/**'
 
 jobs:
   debug:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -99,7 +99,7 @@ as an SQL join. Following is an example of how this metric can be used
 to associate a DCGM metric about GPUs to the server-requesting Pod.
 
 ```
-fma_duality * on(UUID) group_left(exported_namspace,exported_pod) DCGM_FI_DEV_FB_USED{exported_namespace!=""}
+fma_duality * on(UUID) group_left(exported_namespace,exported_pod) DCGM_FI_DEV_FB_USED{exported_namespace!=""}
 ```
 
 The `{exported_namespace!=""}` qualifier filters out the time series


### PR DESCRIPTION
This addresses the typo reported in #581, leaving the CI enhancement for a separate PR.

This PR also updates the triggering conditions in `.github/workflows/launcher-based-e2e-test.yml` to:
1. mention the correct Dockerfile, and
2. also filter on file pathnames in the `on.pull_request` case.