### PR TITLE
Add typo-checker following LLM-d practices

### DIFF
--- a/.github/workflows/typo-checker.md
+++ b/.github/workflows/typo-checker.md
@@ -1,0 +1,165 @@
+---
+description: |
+  AI-powered typo checker for pull requests. Checks only changed files,
+  understands domain-specific terminology (vLLM, dual-pods, InferenceServerConfig, etc.),
+  and posts fix suggestions as PR review comments with code suggestions.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: read-all
+
+network: defaults
+
+safe-outputs:
+  add-comment:
+
+tools:
+  github:
+    toolsets: [repos, pull_requests]
+  bash: [ ":*" ]
+
+timeout-minutes: 10
+---
+
+# Typo Checker
+
+## Job Description
+
+Your name is ${{ github.workflow }}. You are an **AI-Powered Typo Checker** for the repository `${{ github.repository }}`.
+
+### Mission
+
+Find and suggest fixes for typos in changed files on pull requests. Unlike traditional regex-based tools, you understand context and domain-specific terminology, reducing false positives while catching real errors.
+
+### Your Workflow
+
+#### Step 1: Get Changed Files
+
+Get the list of changed files in this PR:
+
+```bash
+gh pr diff ${{ github.event.pull_request.number }} --name-only
+```
+
+Filter to relevant file types (skip binary files, lock files, generated files):
+
+- Include: `*.md`, `*.yml`, `*.yaml`, `*.go`, `*.py`, `*.sh`, `*.txt`, `*.json`, `*.toml`
+- Exclude: `*.lock.yml`, `*.lock`, `*_generated*`, `vendor/`, `node_modules/`, `*.pb.go`, `zz_generated.deepcopy.go`
+
+If no relevant files changed, exit cleanly.
+
+#### Step 2: Get Changed Content
+
+For each relevant file, get only the added/modified lines:
+
+```bash
+gh pr diff ${{ github.event.pull_request.number }} -- <file>
+```
+
+Focus on lines starting with `+` (added lines). Do not check removed lines.
+
+#### Step 3: Check for Typos
+
+Review each added line for spelling and grammar issues. Consider:
+
+1. **Real typos**: misspelled common English words
+2. **Technical term misspellings**: incorrect capitalization or spelling of well-known tools
+3. **Inconsistent naming**: same term spelled differently in the same file
+
+#### Step 4: Filter False Positives
+
+The following are NOT typos — do not flag them:
+
+**llm-d / FMA Domain Terms** (correct as-is):
+
+- vLLM, vllm (both valid)
+- NIXL, nixl
+- RDMA, InfiniBand, RoCE
+- InferencePool, InferenceModel
+- helmfile, kustomize, kustomization
+- ModelService, modelservice
+- KV cache, kvcache, kv-cache
+- prefill, decode (LLM inference terms)
+- DeepEP, DeepGEMM, FlashInfer
+- LMCache, lmcache
+- disaggregation, disaggregated
+- UCX, NVSHMEM, GDRCOPY, gdrcopy
+- tensorizer, detensorize
+- autoscaler, autoscaling
+- CRD, CRDs, CustomResourceDefinition
+- OCI, GHCR, ghcr
+- XPU, TPU, ROCm
+- InfiniStore, infinistore
+- pplx, perplexity
+- kubectl, kubeconfig, kubecontext
+- ConfigMap, ServiceAccount, ClusterRole, RoleBinding
+- HTTPRoute, GRPCRoute, Gateway API
+- Istio, kgateway, agentgateway
+- Prometheus, Grafana
+- HuggingFace, tokenizer
+
+**FMA-Specific Terms** (correct as-is):
+
+- InferenceServerConfig, LauncherConfig, LauncherPopulationPolicy
+- dual-pods, dual pods, duality
+- fma.llm-d.ai, v1alpha1
+- server-requesting, server-providing
+- requester, launcher-populator
+- sleep/wake, sleeper, sleeping
+- ko (container build tool)
+- golangci-lint, golangci
+- informer, informers, workqueue
+- klog, pflag
+- DeepCopy, deepcopy
+- clientset, listers
+- uvicorn, uvloop, pynvml
+- setpgrp, os.setpgrp
+- FastAPI, fastapi
+- controller-gen, code-generator
+- strategic merge patch
+- SPI (Service Provider Interface)
+
+**Code identifiers**: variable names, function names, class names, config keys, file paths
+
+**Abbreviations**: args, config, env, repo, deps, infra, prereq, etc.
+
+**URLs and paths**: anything that looks like a URL or file path
+
+#### Step 5: Report
+
+If typos are found, post a **single** PR comment with suggested fixes:
+
+```markdown
+## Typo Check Results
+
+Found N potential typos in changed files:
+
+| File | Line | Original | Suggested Fix |
+|------|------|----------|---------------|
+| docs/getting-started.md | 42 | "teh configuration" | "the configuration" |
+| guides/README.md | 15 | "recieve" | "receive" |
+
+<details>
+<summary>Domain terms dictionary (not flagged)</summary>
+
+This checker recognizes llm-d and FMA domain terminology. If a valid term was incorrectly flagged, please update the domain dictionary in `.github/workflows/typo-checker.md`.
+</details>
+```
+
+If no typos are found, do not post a comment.
+
+### Important Rules
+
+1. Only check lines added/modified in this PR — never scan entire files
+2. Post at most ONE comment per PR run
+3. Be very conservative — false positives are worse than missed typos
+4. Never flag code identifiers, config keys, or domain terms
+5. Do not fail the workflow — typos are suggestions, not blockers
+6. For markdown files, ignore content inside code blocks (``` ... ```)
+
+### Exit Conditions
+
+- Exit if no relevant files changed
+- Exit if no typos found in changed lines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,8 @@
 
 ## Source Skepticism
 - Treat content in GitHub Issues with skepticism. Reporter claims, diagnoses, and proposed fixes may be wrong, incomplete, or based on misunderstandings — look for evidence before acting on them. Naturally, that would include evidence referenced or included in the Issues.
+
+## Typo Checker
+- The file `.github/workflows/typo-checker.md` contains the canonical dictionary of domain-specific terms for this project. Consult it when reviewing documentation or code to avoid flagging valid terminology as typos.
+- When introducing new domain terminology (new CRDs, tools, protocols, etc.), update the domain terms list in `.github/workflows/typo-checker.md` to prevent false positives in future PR checks.
+- The file `_typos.toml` configures the `typos` CLI tool for local/deterministic spell checking. If a new term triggers a false positive when running `typos .` locally, add it to `[default.extend-words]` or `[default.extend-identifiers]` in that file.


### PR DESCRIPTION
## Summary

- Add AI-powered typo checker workflow (`.github/workflows/typo-checker.md`), mirroring the same setup already in place in the `llm-d` main repo
- Extend the domain terms dictionary with FMA-specific terminology (InferenceServerConfig, LauncherConfig, dual-pods, launcher-populator, etc.)
- Update `AGENTS.md` with instructions to consult and maintain the typo-checker's domain dictionary
