### PR TITLE
Adjust and document logging of HTTP calls

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -156,6 +156,12 @@ The possible values of the `purpose` label are as follows.
 - `sleep`
 - `wake`
 
+**NOTE**: For every observation entered into this HistogramVec there is an associated log statement. It is at `V(5)`. At the time of this writing it appears in the `doHTTP` function in https://github.com/llm-d-incubation/llm-d-fast-model-actuation/blob/main/pkg/controller/dual-pods/inference-server.go and reads as follows.
+
+```go
+logger.V(5).Info("HTTP call done", "purpose", purpose, "method", method, "url", url, "httpCallStartTime", httpCallStartTime.Format(time.RFC3339Nano), "latencySecs", latencySecs, "statusCode", statusCode, "err", err)
+```
+
 ### fma_launcher_create_seconds
 
 Vector of histograms: Latency of kube API call to create launcher.

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -2042,7 +2042,7 @@ func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVe
 		}
 	}
 	logger := klog.FromContext(ctx)
-	logger.V(3).Info("HTTP call done", "purpose", purpose, "method", method, "url", url, "httpCallStartTime", httpCallStartTime.Format(time.RFC3339Nano), "latencySecs", latencySecs, "statusCode", statusCode, "err", err)
+	logger.V(5).Info("HTTP call done", "purpose", purpose, "method", method, "url", url, "httpCallStartTime", httpCallStartTime.Format(time.RFC3339Nano), "latencySecs", latencySecs, "statusCode", statusCode, "err", err)
 	latencyHistogramVec.WithLabelValues(purpose, method, strconv.FormatInt(int64(statusCode), 10)).Observe(latencySecs)
 	return statusCode, err
 }


### PR DESCRIPTION
Adjust V level to 5.

Document the logging in metrics.md (in lieu of a better place).

This responds to a comment in @rubambiza's review of #586 .