### PR TITLE
Remove envar setting VLLM_USE_V1=1

### DIFF
--- a/docs/e2e-recipe.md
+++ b/docs/e2e-recipe.md
@@ -529,7 +529,6 @@ spec:
     options: "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --enable-sleep-mode"
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
-      VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
       example.fma.llm-d.ai/isc-label: example-value

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -721,7 +721,7 @@ Pydantic model (data class) defining the configuration for a vLLM instance.
 
 Ex:
 
-```yaml
+```json
 {
   "options": "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --port 8005",
   "gpu_uuids": ["GPU-33", "GPU-86"],

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -726,7 +726,7 @@ Ex:
   "options": "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --port 8005",
   "gpu_uuids": ["GPU-33", "GPU-86"],
   "env_vars": {
-    "VLLM_USE_V1": "1",
+    "VLLM_SERVER_DEV_MODE": "1",
     "VLLM_LOGGING_LEVEL": "DEBUG"
   }
 }

--- a/inference_server/launcher/howto.md
+++ b/inference_server/launcher/howto.md
@@ -23,7 +23,7 @@ Send commands (using HTTPie or cURL) with the following payload:
 {
   "options": "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --port 8005",
   "env_vars": {
-    "VLLM_USE_V1": "1",
+    "VLLM_SERVER_DEV_MODE": "1",
     "VLLM_LOGGING_LEVEL": "DEBUG"
   }
 }
@@ -35,7 +35,7 @@ curl -X POST http://localhost:8001/v2/vllm/instances \
   -d '{
     "options": "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --port 8005",
     "env_vars": {
-      "VLLM_USE_V1": "1",
+      "VLLM_SERVER_DEV_MODE": "1",
       "VLLM_LOGGING_LEVEL": "DEBUG"
     }
   }'

--- a/test/e2e/demo-fma-hpa/demo-fma-hpa-ocp.sh
+++ b/test/e2e/demo-fma-hpa/demo-fma-hpa-ocp.sh
@@ -303,7 +303,6 @@ spec:
     port: 8000
     options: "--model ${MODEL} --enable-sleep-mode"
     env_vars:
-      VLLM_USE_V1: "1"
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -115,7 +115,6 @@ spec:
     options: "--model HuggingFaceTB/SmolLM2-360M-Instruct --enable-sleep-mode"
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
-      VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
       e2e-test.fma.llm-d.ai/isc-label: test-value
@@ -135,7 +134,6 @@ spec:
     options: "--model Qwen/Qwen2.5-0.5B-Instruct --enable-sleep-mode"
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
-      VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
       e2e-test.fma.llm-d.ai/isc-label: test-value
@@ -155,7 +153,6 @@ spec:
     options: "--model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --enable-sleep-mode"
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
-      VLLM_USE_V1: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
     labels:
       e2e-test.fma.llm-d.ai/isc-label: test-value


### PR DESCRIPTION
.. because that is so obsolete that it causes a warning message.

Also added some missing settings of VLLM_SERVER_DEV_MODE=1 .

Fixes #597 