### PR TITLE
Fix sleeping label value for empty launcher

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -122,6 +122,8 @@ const InstanceLabelName string = "dual-pods.llm-d.ai/instance"
 // maintains on server-providing Pods.
 // This value of this label is "true" or "false",
 // according to what the controller knows.
+// In the case of a launcher: the value is "false" when the controller knows
+// that the launcher has a vLLM instance that is awake, "true" otherwise.
 // This label is purely FYI emitted by the dual-pods controller
 // (it does not rely on this label for anything).
 const SleepingLabelName string = "dual-pods.llm-d.ai/sleeping"

--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -232,7 +232,7 @@ func BuildNodeIndependentLauncherTemplate(lc *v1alpha1.LauncherConfig) (*corev1.
 	}
 	pod.Labels[common.ComponentLabelKey] = common.LauncherComponentLabelValue
 	pod.Labels[common.LauncherConfigNameLabelKey] = lc.Name
-	pod.Labels[api.SleepingLabelName] = "false"
+	pod.Labels[api.SleepingLabelName] = "true"
 
 	hasher := sha256.New()
 	modifiedJSON, err := json.Marshal(pod)


### PR DESCRIPTION
sleeping = NOT awake;
awake = there exists an awake child.

This is intended to resolve #601 .