### PR TITLE
Add typos cli into workflow and pre-commit

### DIFF
--- a/.github/workflows/typos-check.yml
+++ b/.github/workflows/typos-check.yml
@@ -1,0 +1,15 @@
+name: typos-check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,9 +35,3 @@ repos:
     hooks:
       - id: flake8
         args: ["--max-line-length=88", "--extend-ignore=E203,W503"]
-
-  # Typo checking
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.47.2
-    hooks:
-      - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,9 @@ repos:
     hooks:
       - id: flake8
         args: ["--max-line-length=88", "--extend-ignore=E203,W503"]
+
+  # Typo checking
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.47.2
+    hooks:
+      - id: typos


### PR DESCRIPTION
## Summary

Add a deterministic typo check using the [`typos`](https://github.com/crate-ci/typos) CLI tool.

## What changed

- **Added** `.github/workflows/typos-check.yml` — a standard GitHub Actions workflow that runs `typos .` on every PR and push to `main`. Uses the pinned `crate-ci/typos` action (`v1.47.2`). Typo findings are a hard CI failure, consistent with how `golangci-lint` and `black` work in this repo.

The existing `_typos.toml` (with `drawio.svg` exclusion and domain-term overrides) is auto-detected by `typos` at the repo root — no extra flags needed. The repo currently has zero typo findings.