### PR TITLE
Typo check in pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,9 @@ repos:
     hooks:
       - id: flake8
         args: ["--max-line-length=88", "--extend-ignore=E203,W503"]
+
+# Typo checking
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.47.2
+    hooks:
+      - id: typos


### PR DESCRIPTION
## Summary

Add a deterministic typo check using the [`typos`](https://github.com/crate-ci/typos) for pre-commit.

## What changed

- **Updated** `.pre-commit-config.yaml` — added the `typos` hook so developers catch typos locally before pushing, using the same version (`v1.47.2`).

## Test

```
(llm-d-fast-model-actuation) diego@macbookpro ~/Documents/my_stuff/llm-d-fast-model-actuation (pre-commit-typo) $ git add docs/metrics.md
(llm-d-fast-model-actuation) diego@macbookpro ~/Documents/my_stuff/llm-d-fast-model-actuation (pre-commit-typo) $ git commit -s -S -m"test"
trim trailing whitespace.................................................Passed
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing docs/metrics.md

check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check for added large files..............................................Passed
check docstring is first.............................(no files to check)Skipped
debug statements (python)............................(no files to check)Skipped
black................................................(no files to check)Skipped
isort................................................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
typos....................................................................Failed
- hook id: typos
- files were modified by this hook
```
