### PR TITLE
Advance to go version 1.25

### DIFF
--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Run Go unit tests
         run: go test ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: check go mod tidy
         run: |

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24.2'
+          go-version: '1.25'
 
       - name: Install ko
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -7,7 +7,7 @@
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |-----------|-------------|----------|---------------|---------------|
-| **Go** | `1.24.2` | version | `go.mod` line 3 | [golang/go](https://github.com/golang/go) |
+| **Go** | `1.25` | version | `go.mod` line 3 | [golang/go](https://github.com/golang/go) |
 | **k8s.io/api** | `v0.34.9` | tag | `go.mod` line 8 | [kubernetes/api](https://github.com/kubernetes/api) |
 | **k8s.io/apimachinery** | `v0.34.9` | tag | `go.mod` line 9 | [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery) |
 | **k8s.io/client-go** | `v0.34.9` | tag | `go.mod` line 10 | [kubernetes/client-go](https://github.com/kubernetes/client-go) |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llm-d-incubation/llm-d-fast-model-actuation
 
-go 1.24.2
+go 1.25
 
 require (
 	github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
Go 1.24 is out of support.