### PR TITLE
Independent item scheduling in DPC, 5-second polling of /is_sleeping

### DIFF
--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"reflect"
 	"strconv"
@@ -41,6 +40,7 @@ import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	kubemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
@@ -121,6 +121,7 @@ const ControllerName = "dual-pods-controller"
 const GPUMapName = "gpu-map"
 
 const GPUIndexName = "gpu"
+const controllerQueuePerItemRetryMaxDelay = 20 * time.Second
 
 func GPUIndexFunc(obj any) ([]string, error) {
 	pod := obj.(*corev1.Pod)
@@ -411,14 +412,32 @@ type nodeData struct {
 	// and for each the time at which it was first injected into this set.
 	// Hold ItemsMutex while accessing this.
 	LocalQueue localQueue
+
+	rateLimiter workqueue.TypedRateLimiter[itemOnNode]
 }
 
-type localQueue map[itemOnNode]time.Time
+type localQueue map[itemOnNode]*scheduledItem
 
 type itemOnNode interface {
 	// process returns (err error, retry bool).
 	// There will be a retry iff `retry`.
-	process(ctx context.Context, ctl *controller, nodeDat *nodeData) (error, bool)
+	process(ctx context.Context, ctl *controller, nodeDat *nodeData) processResult
+}
+
+type scheduledItem struct {
+	addTime      time.Time // when first enqueued (for queue duration metrics)
+	processAfter time.Time // earliest time to process this item
+}
+
+// processResult is returned by itemOnNode.process to signal outcome and retry intent.
+//   - err may be set with or without retry; a non-nil err with retry=false is a permanent failure.
+//   - retry requests that the item be re-queued for later processing.
+//   - retryAfter, if not zero, specifies the delay until the later processing,
+//     with zero meaning to use exponential backoff.
+type processResult struct {
+	err        error
+	retry      bool
+	retryAfter time.Duration
 }
 
 // Internal state about an inference server
@@ -992,9 +1011,13 @@ func (ctl *controller) getNodeData(nodeName string) *nodeData {
 	if ans == nil {
 		ans = &nodeData{
 			NodeName:         nodeName,
-			LocalQueue:       make(localQueue),
+			LocalQueue:       localQueue{},
 			InferenceServers: make(map[apitypes.UID]*serverData),
 			Launchers:        make(map[string]*launcherData),
+			rateLimiter: workqueue.NewTypedWithMaxWaitRateLimiter(
+				workqueue.DefaultTypedControllerRateLimiter[itemOnNode](),
+				controllerQueuePerItemRetryMaxDelay, // 20s, from queue-work.go
+			),
 		}
 		ctl.nodeNameToData[nodeName] = ans
 	}
@@ -1004,22 +1027,61 @@ func (ctl *controller) getNodeData(nodeName string) *nodeData {
 func (nodeDat *nodeData) add(item itemOnNode) {
 	nodeDat.ItemsMutex.Lock()
 	defer nodeDat.ItemsMutex.Unlock()
-	if _, found := nodeDat.LocalQueue[item]; !found {
-		nodeDat.LocalQueue[item] = time.Now()
-		addsCounters.WithLabelValues(nodeDat.NodeName).Inc()
-		queueDepthGauges.WithLabelValues(nodeDat.NodeName).Set(float64(len(nodeDat.LocalQueue)))
+	if _, exist := nodeDat.LocalQueue[item]; exist {
+		return // already queued
 	}
+	now := time.Now()
+	nodeDat.LocalQueue[item] = &scheduledItem{
+		addTime: now, processAfter: now,
+	}
+	addsCounters.WithLabelValues(nodeDat.NodeName).Inc()
+	queueDepthGauges.WithLabelValues(nodeDat.NodeName).Set(float64(len(nodeDat.LocalQueue)))
 }
 
-// yankItems returns the currently queued items and empties the queue.
-// Caller can access the returned value without synchronization.
-func (nodeDat *nodeData) yankItems() localQueue {
+func (nodeDat *nodeData) addAfter(item itemOnNode, after time.Time) {
 	nodeDat.ItemsMutex.Lock()
 	defer nodeDat.ItemsMutex.Unlock()
-	ans := maps.Clone(nodeDat.LocalQueue)
-	nodeDat.LocalQueue = make(localQueue)
-	queueDepthGauges.WithLabelValues(nodeDat.NodeName).Set(0)
-	return ans
+	if cur, exist := nodeDat.LocalQueue[item]; exist {
+		if after.Before(cur.processAfter) {
+			cur.processAfter = after
+		}
+		return
+	}
+	nodeDat.LocalQueue[item] = &scheduledItem{
+		addTime: time.Now(), processAfter: after,
+	}
+	addsCounters.WithLabelValues(nodeDat.NodeName).Inc()
+	queueDepthGauges.WithLabelValues(nodeDat.NodeName).Set(float64(len(nodeDat.LocalQueue)))
+}
+
+// takeReadyItems removes and returns items whose processAfter <= now.
+// Items not yet ready remain in the queue.
+func (nodeDat *nodeData) takeReadyItems(now time.Time) localQueue {
+	nodeDat.ItemsMutex.Lock()
+	defer nodeDat.ItemsMutex.Unlock()
+	ready := make(localQueue)
+	for item, scheduledItem := range nodeDat.LocalQueue {
+		if !scheduledItem.processAfter.After(now) {
+			ready[item] = scheduledItem
+			delete(nodeDat.LocalQueue, item)
+		}
+	}
+	queueDepthGauges.WithLabelValues(nodeDat.NodeName).Set(float64(len(nodeDat.LocalQueue)))
+	return ready
+}
+
+// earliestPending returns the earliest processAfter among remaining items,
+// or zero time if the queue is empty.
+func (nodeDat *nodeData) earliestPending() time.Time {
+	nodeDat.ItemsMutex.Lock()
+	defer nodeDat.ItemsMutex.Unlock()
+	var earliest time.Time
+	for _, si := range nodeDat.LocalQueue {
+		if earliest.IsZero() || si.processAfter.Before(earliest) {
+			earliest = si.processAfter
+		}
+	}
+	return earliest
 }
 
 func (ctl *controller) getServerData(nodeDat *nodeData, reqName string, reqUID apitypes.UID) *serverData {

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -93,36 +93,55 @@ func (ni nodeItem) process(ctx context.Context, ctl *controller) (error, bool) {
 	logger := klog.FromContext(ctx).WithValues("node", ni.NodeName)
 	ctx = klog.NewContext(ctx, logger)
 	nodeDat := ctl.getNodeData(ni.NodeName)
-	items := nodeDat.yankItems()
+	now := time.Now()
+	readyItems := nodeDat.takeReadyItems(now)
 	var retries int
-	logger.V(4).Info("Processing items for node", "count", len(items))
-	for localItem, addTime := range items {
-		logger.V(4).Info("Processing node-local item", "item", localItem, "enqueuedAt", addTime)
+	logger.V(4).Info("Processing items for node", "readyCount", len(readyItems))
+	for item, si := range readyItems {
+		logger.V(4).Info("Processing node-local item", "item", item, "enqueuedAt", si.addTime)
 		processStart := time.Now()
-		queueDurationHists.WithLabelValues(ni.NodeName).Observe(processStart.Sub(addTime).Seconds())
-		err, retry := localItem.process(ctx, ctl, nodeDat)
+		queueDurationHists.WithLabelValues(ni.NodeName).Observe(processStart.Sub(si.addTime).Seconds())
+		output := item.process(ctx, ctl, nodeDat)
+		err, retry, retryAfter := output.err, output.retry, output.retryAfter
 		processFin := time.Now()
 		workDurationHists.WithLabelValues(ni.NodeName).Observe(processFin.Sub(processStart).Seconds())
 		if err != nil {
 			if retry {
-				logger.Info("Processing node local item suffered transient error, will retry", "item", localItem, "err", err)
+				logger.Info("Processing node local item suffered transient error, will retry", "item", item, "err", err, "retryAfter", retryAfter)
 			} else {
-				logger.Error(err, "Processing node local item failed", "item", localItem)
+				logger.Error(err, "Processing node local item failed", "item", item)
 			}
 		} else {
-			logger.V(4).Info("Finished processing node-local item", "item", localItem, "willRetry", retry)
+			logger.V(4).Info("Finished processing node-local item", "item", item, "willRetry", retry, "retryAfter", retryAfter)
 		}
 		if retry {
-			nodeDat.add(localItem)
+			if retryAfter > 0 {
+				// Fixed delay (e.g. querySleeping 5s) — bypass exponential backoff
+				nodeDat.addAfter(item, time.Now().Add(retryAfter))
+				nodeDat.rateLimiter.Forget(item)
+			} else {
+				// Exponential backoff — per-item, via the local rate limiter
+				backoff := nodeDat.rateLimiter.When(item)
+				nodeDat.addAfter(item, time.Now().Add(backoff))
+			}
 			retriesCounters.WithLabelValues(ni.NodeName).Inc()
 			retries++
+		} else {
+			nodeDat.rateLimiter.Forget(item)
 		}
 	}
+	// we check if anything is pending in the local queue.
+	// if so, we call AddAfter so the item re-enter the queue
+	earliest := nodeDat.earliestPending()
+	if !earliest.IsZero() {
+		delay := max(time.Until(earliest), 0)
+		ctl.Queue.AddAfter(ni, delay)
+	}
 	logger.V(4).Info("Done processing items for node", "numToRetry", retries)
-	return nil, retries > 0
+	return nil, false
 }
 
-func (item unboundLauncherPodItem) process(ctx context.Context, ctl *controller, nodeDat *nodeData) (error, bool) {
+func (item unboundLauncherPodItem) process(ctx context.Context, ctl *controller, nodeDat *nodeData) processResult {
 	logger := klog.FromContext(ctx).WithValues("launcherPod", item.LauncherPodName, "node", item.NodeName)
 	ctx = klog.NewContext(ctx, logger)
 
@@ -132,9 +151,9 @@ func (item unboundLauncherPodItem) process(ctx context.Context, ctl *controller,
 			logger.V(2).Info("Launcher pod deleted, cleaning up launcher data")
 			ctl.clearLauncherData(nodeDat, item.LauncherPodName)
 			ctl.enqueueUnboundInfSvrItemsOnNode(ctx, item.NodeName, fmt.Sprintf("launcher pod %s deleted", item.LauncherPodName))
-			return nil, false
+			return processResult{}
 		}
-		return err, true
+		return processResult{err: err, retry: true}
 	}
 
 	// Sync launcher instances to keep internal state fresh and clean up stopped instances.
@@ -143,12 +162,12 @@ func (item unboundLauncherPodItem) process(ctx context.Context, ctl *controller,
 	ctl.enqueueUnboundInfSvrItemsOnNode(ctx, item.NodeName, fmt.Sprintf("launcher pod %s changed", item.LauncherPodName))
 
 	if syncErr != nil {
-		return fmt.Errorf("failed to sync launcher instances: %w", syncErr), syncRetry
+		return processResult{err: fmt.Errorf("failed to sync launcher instances: %w", syncErr), retry: syncRetry}
 	}
-	return nil, syncRetry
+	return processResult{retry: syncRetry}
 }
 
-func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *nodeData) (error, bool) {
+func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *nodeData) processResult {
 	// The `requesterName` value is relied upon by the log parser in benchmarking
 	logger := klog.FromContext(urCtx).WithValues("serverUID", item.UID, "requesterName", item.RequesterName)
 	serverDat := ctl.getServerData(nodeDat, item.RequesterName, item.UID)
@@ -168,7 +187,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			requestingPod = nil
 		} else { // BTW, impossible
 			logger.Error(err, "Failed to get Pod")
-			return err, true
+			return processResult{err: err, retry: true}
 		}
 	} else {
 		requesterRV = requestingPod.ResourceVersion
@@ -180,7 +199,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 	var providingPod *corev1.Pod
 	providingPodAnys, err := ctl.podInformer.GetIndexer().ByIndex(requesterIndexName, string(item.UID))
 	if err != nil { //impossible
-		return err, false
+		return processResult{}
 	}
 	switch len(providingPodAnys) {
 	case 0:
@@ -197,7 +216,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			pod := podAny.(*corev1.Pod)
 			return pod.Name, nil
 		})
-		return fmt.Errorf("found multiple bound server-running Pods: %v", providerNames), false
+		return processResult{err: fmt.Errorf("found multiple bound server-running Pods: %v", providerNames)}
 	}
 
 	logger.V(5).Info("Processing inference server",
@@ -219,7 +238,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		} else {
 			logger.V(2).Info("Not setting duality=0, because InstanceID is unknown")
 		}
-		return nil, false
+		return processResult{}
 	}
 
 	// Decide what to do about the finalizer on the server-requesting Pod,
@@ -228,7 +247,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 	if requestingPod != nil {
 		removed, shouldAdd, err, retry := ctl.maybeRemoveRequesterFinalizer(ctx, requestingPod, providingPod)
 		if removed || err != nil {
-			return err, retry
+			return processResult{err: err, retry: retry}
 		}
 		shouldAddRequesterFinalizer = shouldAdd
 	}
@@ -241,7 +260,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			if shouldAddRequesterFinalizer { // don't let delete complete too quickly
 				gonerRV, err = ctl.addRequesterFinalizer(ctx, requestingPod, providingPod.Name, serverDat.InstanceID)
 				if err != nil {
-					return err, true
+					return processResult{err: err, retry: true}
 				}
 			}
 			delStart := time.Now()
@@ -254,19 +273,19 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			} else if apierrors.IsGone(err) || apierrors.IsNotFound(err) {
 				logger.V(2).Info("The server-requesting Pod is already gone", "k8sCallStartTime", delStartStr)
 			} else {
-				return fmt.Errorf("failed to delete server-requesting Pod (started %s): %w", delStartStr, err), true
+				return processResult{err: fmt.Errorf("failed to delete server-requesting Pod (started %s): %w", delStartStr, err), retry: true}
 			}
 			serverDat.RequesterDeleteRequested = true
 		}
 		// Ensure finalizer is absent from server-providing Pod so that its deletion can complete
 		changed, err := ctl.removeProviderFinalizer(ctx, providingPod)
 		if err != nil {
-			return err, true
+			return processResult{err: err, retry: true}
 		}
 		if !changed {
 			logger.V(5).Info("Finalizer is absent from server-providing Pod, waiting for deletions to finish")
 		}
-		return nil, false
+		return processResult{}
 	}
 	// Assert: providingPod == nil || providingPod.DeletionTimestamp == nil
 
@@ -285,7 +304,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			if err == nil {
 				stJSON, marshalErr := json.Marshal(providingPod.Status)
 				logger.V(2).Info("Deleted server-providing Pod because it is in trouble", "providerName", providingPod.Name, "status", string(stJSON), "marshalErr", marshalErr, "k8sCallStartTime", delStartStr)
-				return nil, false
+				return processResult{}
 			} else if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
 				logger.V(2).Info("Troubled server-providing Pod was concurrently deleted", "providerName", providingPod.Name, "k8sCallStartTime", delStartStr)
 			} else {
@@ -300,12 +319,12 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		}
 		err := ctl.ensureUnbound(ctx, serverDat, iscName, nodeDat, providingPod, providingPodLauncherBased)
 		if err != nil {
-			return err, true
+			return processResult{err: err, retry: true}
 		}
 		if requestingPod != nil {
 			return ctl.ensureReqState(ctx, requestingPod, serverDat, false, true)
 		}
-		return nil, false
+		return processResult{}
 	}
 	// Assert: requestingPod != nil
 
@@ -315,7 +334,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 
 	if requestingPod.DeletionTimestamp != nil || serverDat.RequesterDeleteRequested {
 		logger.V(5).Info("Waiting for deletion of server-requesting Pod to finish")
-		return nil, false
+		return processResult{}
 	}
 
 	node, err := ctl.nodeLister.Get(requestingPod.Spec.NodeName)
@@ -323,14 +342,14 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		if apierrors.IsNotFound(err) {
 			node = nil
 		} else { // BTW, impossible
-			return err, true
+			return processResult{err: err, retry: true}
 		}
 	}
 
 	if node == nil || node.DeletionTimestamp != nil {
 		// Node is gone or going away, do nothing to maintain server-providing Pod.
 		logger.V(3).Info("Ignoring inference server on absent or departing Node")
-		return nil, false
+		return processResult{}
 	}
 
 	requesterIP := requestingPod.Status.PodIP
@@ -356,11 +375,8 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		gpuUUIDs, err := getGPUUUIDs(ctx, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), url)
 		if err != nil {
 			queryErr := fmt.Errorf("GET %q fails: %s", url, err.Error())
-			updateErr, _ := ctl.ensureReqStatus(ctx, requestingPod, serverDat, queryErr.Error())
-			if updateErr == nil {
-				return queryErr, true
-			}
-			return errors.Join(queryErr, updateErr), true
+			out := ctl.ensureReqStatus(ctx, requestingPod, serverDat, queryErr.Error())
+			return processResult{err: errors.Join(queryErr, out.err), retry: true}
 		}
 		if len(gpuUUIDs) == 0 {
 			return ctl.ensureReqStatus(ctx, requestingPod, serverDat, "the assigned set of GPUs is empty")
@@ -416,22 +432,22 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		} else {
 			_, serverPort, err = utils.GetInferenceServerContainerIndexAndPort(providingPod)
 			if err != nil { // Impossible, because such a providingPod would never be created by this controller
-				return fmt.Errorf("unable to wake up server because port not known: %w", err), true
+				return processResult{err: fmt.Errorf("unable to wake up server because port not known: %w", err), retry: true}
 			}
 		}
 		if launcherBased {
 			if providingPod.Status.PodIP == "" || !utils.IsPodReady(providingPod) {
 				logger.V(5).Info("Bound launcher pod not yet reachable, waiting", "podIP", providingPod.Status.PodIP, "ready", utils.IsPodReady(providingPod))
-				return nil, false
+				return processResult{}
 			}
 
 			syncResult, err, retry := ctl.syncLauncherInstances(ctx, nodeDat, serverDat.InstancesDeleted, providingPod)
 			if err != nil || retry {
 				if err != nil {
-					return fmt.Errorf("failed to sync launcher instances for bound launcher Pod: %w", err), retry
+					return processResult{err: fmt.Errorf("failed to sync launcher instances for bound launcher Pod: %w", err), retry: retry}
 				}
 				logger.V(5).Info("Launcher instance sync requested retry")
-				return nil, true
+				return processResult{retry: true}
 			}
 
 			_, instancePresent := findInstanceState(syncResult.instances.Instances, serverDat.InstanceID)
@@ -464,10 +480,10 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 					} else if apierrors.IsGone(err) || apierrors.IsNotFound(err) {
 						logger.V(2).Info("The server-requesting Pod is already gone", "k8sCallStartTime", delStartStr)
 					} else {
-						return fmt.Errorf("failed to delete server-requesting Pod for stopped instance (started %s): %w", delStartStr, err), true
+						return processResult{err: fmt.Errorf("failed to delete server-requesting Pod for stopped instance (started %s): %w", delStartStr, err), retry: true}
 					}
 					serverDat.RequesterDeleteRequested = true
-					return nil, false
+					return processResult{}
 				}
 				// InstanceKnownToExist is false and instance is absent (not stopped) —
 				// not yet created (bind-first path) or controller restarted and lost tracking.
@@ -476,11 +492,11 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				launcherBaseURL := fmt.Sprintf("http://%s:%d", providingPod.Status.PodIP, ctlrcommon.LauncherServicePort)
 				lClient, err := NewLauncherClient(launcherBaseURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}))
 				if err != nil {
-					return err, true
+					return processResult{err: err, retry: true}
 				}
 				result, err := lClient.CreateNamedInstance(ctx, serverDat.InstanceID, *serverDat.InstanceConfig)
 				if err != nil {
-					return fmt.Errorf("failed to create vLLM instance %q: %w", serverDat.InstanceID, err), true
+					return processResult{err: fmt.Errorf("failed to create vLLM instance %q: %w", serverDat.InstanceID, err), retry: true}
 				}
 				serverDat.InstanceKnownToExist = true
 				launcherDat := ctl.getLauncherData(nodeDat, providingPod.Name)
@@ -492,14 +508,14 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		if serverDat.Sleeping == nil {
 			sleeping, err := ctl.querySleeping(ctx, iscName, providingPod, serverPort)
 			if err != nil {
-				return err, true
+				return processResult{err: err, retry: true, retryAfter: 5 * time.Second}
 			}
 			logger.V(2).Info("Determined whether provider is sleeping", "isSleeping", sleeping)
 			serverDat.Sleeping = &sleeping
 		}
 		if *(serverDat.Sleeping) {
 			if err = ctl.wakeUp(ctx, serverDat, requestingPod, providingPod, serverPort, "discovered-bound"); err != nil {
-				return err, true
+				return processResult{err: err, retry: true}
 			}
 		}
 		// Reconcile the sleeping label; for a launcher this also applies the
@@ -509,16 +525,16 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		if launcherBased {
 			var stop bool
 			if providingPod, stop, err = ctl.applyBoundLauncherLabels(ctx, requestingPod, serverDat, providingPod); stop {
-				return err, err != nil
+				return processResult{err: err, retry: err != nil}
 			}
 		} else {
 			if providingPod, err = ctl.ensureSleepingLabel(ctx, providingPod, *(serverDat.Sleeping)); err != nil {
-				return err, true
+				return processResult{err: err, retry: true}
 			}
 		}
-		err, _ = ctl.ensureReqState(ctx, requestingPod, serverDat, shouldAddRequesterFinalizer, false)
-		if err != nil {
-			return err, true
+		out := ctl.ensureReqState(ctx, requestingPod, serverDat, shouldAddRequesterFinalizer, false)
+		if out.err != nil {
+			return processResult{err: out.err, retry: true}
 		}
 		// Relay readiness if not already done.
 		// For launcher-based providers, readiness follows the bound instance's
@@ -551,7 +567,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				_, err = doHTTP(ctx, "relay_"+readiness, "POST", url, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, nil)
 				if err != nil {
 					logger.Error(err, "Failed to relay the readiness", "name", providingPod.Name, "readiness", readiness, "url", url)
-					return err, true
+					return processResult{err: err, retry: true}
 				}
 				serverDat.ReadinessRelayed = &ready
 				if ready && !serverDat.FirstReadyRelayed {
@@ -580,7 +596,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		}
 		// TODO: sync desired and actual providingPod wrt labels (spec is mostly immutable, possible mutations are allowed)
 		logger.V(5).Info("Nothing more to do")
-		return nil, false
+		return processResult{}
 	}
 	// Assert: providingPod == nil && !shouldAddRequesterFinalizer
 
@@ -591,10 +607,10 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 		err := podOps.Delete(ctx, requestingPod.Name, metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationBackground)})
 		delStartStr := delStart.Format(time.RFC3339Nano)
 		if err != nil {
-			return fmt.Errorf("failed to delete server-requesting Pod on unschedulable Node (started %s): %w", delStartStr, err), false
+			return processResult{err: fmt.Errorf("failed to delete server-requesting Pod on unschedulable Node (started %s): %w", delStartStr, err)}
 		}
 		logger.V(2).Info("Deleted server-requesting Pod on unschedulable Node", "k8sCallStartTime", delStartStr)
-		return nil, false
+		return processResult{}
 	}
 	// What remains to be done is to wake or create a server-providing Pod
 
@@ -613,7 +629,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 
 		sleepingAnys, err := ctl.podInformer.GetIndexer().ByIndex(nominalHashIndexName, nominalHash)
 		if err != nil { // impossible
-			return err, false
+			return processResult{}
 		}
 		if len(sleepingAnys) > 0 {
 			// They have to be sleeping, the Kube scheduler and kubelet would not have assigned the same
@@ -628,7 +644,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 
 		err, retry := ctl.enforceSleeperBudget(ctx, serverDat, requestingPod, ctl.sleeperLimit)
 		if err != nil || retry {
-			return err, retry
+			return processResult{err: err, retry: retry}
 		}
 		// Sleeper budget is met. Make the new Pod.
 
@@ -643,11 +659,8 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				return ctl.ensureReqStatus(ctx, requestingPod, serverDat, "the nominal server-providing "+errMsg)
 			}
 			wrappedErr := fmt.Errorf("failed to create server-providing Pod (started %s): %w", createStartStr, err)
-			innerErr, _ := ctl.ensureReqStatus(ctx, requestingPod, serverDat, fmt.Sprintf("failed to create server-providing Pod: %s", errMsg))
-			if innerErr != nil {
-				return errors.Join(wrappedErr, innerErr), true
-			}
-			return wrappedErr, true
+			innerResult := ctl.ensureReqStatus(ctx, requestingPod, serverDat, fmt.Sprintf("failed to create server-providing Pod: %s", errMsg))
+			return processResult{err: errors.Join(wrappedErr, innerResult.err), retry: true}
 		}
 		serverDat.Sleeping = ptr.To(false)
 		logger.V(2).Info("Created server-providing pod", "name", echo.Name, "gpus", serverDat.GPUIndicesStr, "annotations", echo.Annotations, "labels", echo.Labels, "resourceVersion", echo.ResourceVersion, "k8sCallStartTime", createStartStr)
@@ -667,14 +680,14 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 
 	nodeIndependentLauncherTemplate, _, err := utils.BuildNodeIndependentLauncherTemplate(lc)
 	if err != nil {
-		return fmt.Errorf("failed to build launcher Pod from LauncherConfig %q: %w", lcName, err), true
+		return processResult{err: fmt.Errorf("failed to build launcher Pod from LauncherConfig %q: %w", lcName, err), retry: true}
 	}
 	desiredLauncherPod := utils.SpecializeLauncherTemplateToNode(nodeIndependentLauncherTemplate, requestingPod.Spec.NodeName)
 	lcHash := desiredLauncherPod.Annotations[ctlrcommon.LauncherConfigHashAnnotationKey]
 	logger.V(5).Info("LauncherConfig's hash", "hash", lcHash)
 	launcherPodAnys, err := ctl.podInformer.GetIndexer().ByIndex(launcherConfigHashIndexName, lcHash)
 	if err != nil {
-		return err, false
+		return processResult{err: err}
 	}
 
 	desiredPort := desiredInstanceState.serverPort
@@ -688,11 +701,11 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 
 		launcherPod, hasSleepingInstance, retry, err := ctl.selectOrReclaimLauncherPod(ctx, launcherPodAnys, desiredInstanceState.instanceID, desiredPort, int(lc.Spec.MaxInstances)-1, nodeDat, serverDat.InstancesDeleted)
 		if err != nil {
-			return err, true
+			return processResult{err: err, retry: true}
 		}
 		if retry {
 			logger.V(4).Info("Launcher Pod selection or reclaim requested retry")
-			return nil, true
+			return processResult{retry: true}
 		}
 		if launcherPod != nil {
 			// Bind first, then rely on informer notification to trigger re-reconciliation.
@@ -736,11 +749,8 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 			return ctl.ensureReqStatus(ctx, requestingPod, serverDat, "the desired launcher-based server-providing "+errMsg)
 		}
 		wrappedErr := fmt.Errorf("failed to create launcher-based server-providing Pod (started %s): %w", createStartStr, err)
-		innerErr, _ := ctl.ensureReqStatus(ctx, requestingPod, serverDat, fmt.Sprintf("failed to create launcher-based server-providing Pod: %s", errMsg))
-		if innerErr != nil {
-			return errors.Join(wrappedErr, innerErr), true
-		}
-		return wrappedErr, true
+		innerResult := ctl.ensureReqStatus(ctx, requestingPod, serverDat, fmt.Sprintf("failed to create launcher-based server-providing Pod: %s", errMsg))
+		return processResult{err: errors.Join(wrappedErr, innerResult.err), retry: true}
 	}
 	serverDat.Sleeping = nil
 	commitInstanceState(serverDat, desiredInstanceState)
@@ -1415,7 +1425,7 @@ func (ctl *controller) enforceSleeperBudget(ctx context.Context, serverDat *serv
 }
 
 // launcherState is non-nil iff launcher-based.
-func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requestingPod, providingPod *corev1.Pod, launcherState *vllmInstanceState, skipWake bool) (error, bool) {
+func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requestingPod, providingPod *corev1.Pod, launcherState *vllmInstanceState, skipWake bool) processResult {
 	logger := klog.FromContext(ctx)
 	providingPod = providingPod.DeepCopy()
 	providingPod.Annotations = utils.MapSet(providingPod.Annotations, requesterAnnotationKey, string(requestingPod.UID)+" "+requestingPod.Name)
@@ -1437,7 +1447,7 @@ func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requesti
 	echo, err := ctl.coreclient.Pods(ctl.namespace).Update(ctx, providingPod, metav1.UpdateOptions{FieldManager: ControllerName})
 	updStartStr := updStart.Format(time.RFC3339Nano)
 	if err != nil {
-		return fmt.Errorf("failed to bind server-providing Pod %s (started %s): %w", providingPod.Name, updStartStr, err), true
+		return processResult{err: fmt.Errorf("failed to bind server-providing Pod %s (started %s): %w", providingPod.Name, updStartStr, err), retry: true}
 	}
 	serverDat.ProvidingPodName = providingPod.Name
 	if launcherBased {
@@ -1454,17 +1464,17 @@ func (ctl *controller) bind(ctx context.Context, serverDat *serverData, requesti
 	} else {
 		_, serverPort, err = utils.GetInferenceServerContainerIndexAndPort(providingPod)
 		if err != nil { // Impossible, because such a providingPod would never be created by this controller
-			return fmt.Errorf("unable to wake up server because port not known: %w", err), true
+			return processResult{err: fmt.Errorf("unable to wake up server because port not known: %w", err), retry: true}
 		}
 	}
 	if !skipWake {
 		// Reached only for direct providers (launcher binds skip the wake); wake
 		// and clear the sleeping label in a separate update.
 		if err = ctl.wakeUp(ctx, serverDat, requestingPod, providingPod, serverPort, "freshly-bound"); err != nil {
-			return err, true
+			return processResult{err: err, retry: true}
 		}
 		if _, err = ctl.ensureSleepingLabel(ctx, providingPod, false); err != nil {
-			return err, true
+			return processResult{err: err, retry: true}
 		}
 	}
 	return ctl.ensureReqState(ctx, requestingPod, serverDat, !slices.Contains(requestingPod.Finalizers, requesterFinalizer), false)
@@ -1571,15 +1581,15 @@ func (ctl *controller) removeProviderFinalizer(ctx context.Context, providingPod
 	return false, nil // no change
 }
 
-func (item instanceGCItem) process(ctx context.Context, ctl *controller, nodeDat *nodeData) (error, bool) {
+func (item instanceGCItem) process(ctx context.Context, ctl *controller, nodeDat *nodeData) processResult {
 	logger := klog.FromContext(ctx).WithValues("iscName", item.ISCName)
 
 	isc, err := ctl.iscLister.InferenceServerConfigs(ctl.namespace).Get(item.ISCName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, false
+			return processResult{}
 		}
-		return err, true
+		return processResult{err: err, retry: true}
 	}
 
 	for launcherPodName, launcherDat := range nodeDat.Launchers {
@@ -1647,7 +1657,7 @@ func (item instanceGCItem) process(ctx context.Context, ctl *controller, nodeDat
 			logger.V(2).Info("Deleted obsolete sleeping instance", "launcherPod", launcherPodName, "instanceID", inst.InstanceID, "currentHash", currentHash)
 		}
 	}
-	return nil, false
+	return processResult{}
 }
 
 // Unbinds the given server-providing Pod.
@@ -2004,7 +2014,7 @@ func (ctl *controller) accelMemoryIsLowEnough(ctx context.Context, requestingPod
 // on the server-providing Pod shows the given user errors.
 // The returned (err error, retry bool) is a convenient match for the signature of
 // a sync function; always `retry == (err != nil)`.
-func (ctl *controller) ensureReqStatus(ctx context.Context, requestingPod *corev1.Pod, serverDat *serverData, errors ...string) (error, bool) {
+func (ctl *controller) ensureReqStatus(ctx context.Context, requestingPod *corev1.Pod, serverDat *serverData, errors ...string) processResult {
 	return ctl.ensureReqState(ctx, requestingPod, serverDat, false, false, errors...)
 }
 
@@ -2013,12 +2023,12 @@ func (ctl *controller) ensureReqStatus(ctx context.Context, requestingPod *corev
 // 2. add or remove the controller's finalizer if stipulated.
 // The returned (err error, retry bool) is a convenient match for the signature of
 // a sync function; always `retry == (err != nil)`.
-func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1.Pod, serverDat *serverData, addFinalizer, removeFinalizer bool, errors ...string) (error, bool) {
+func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1.Pod, serverDat *serverData, addFinalizer, removeFinalizer bool, errors ...string) processResult {
 	status := api.ServerRequestingPodStatus{Errors: errors}
 	logger := klog.FromContext(ctx)
 	newStatusBytes, err := json.Marshal(status)
 	if err != nil { // impossible; handle by infinite retry
-		return fmt.Errorf("failed to marshal status (%#v): %w", status, err), true
+		return processResult{err: fmt.Errorf("failed to marshal status (%#v): %w", status, err), retry: true}
 	}
 	newStatusStr := string(newStatusBytes)
 	oldStatusStr := requestingPod.Annotations[api.StatusAnnotationName]
@@ -2036,7 +2046,7 @@ func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1
 	}
 	if oldStatusStr == newStatusStr && desiredAccelerators == currentAccelerators && len(newFinalizers) == len(requestingPod.Finalizers) && serverDat.ProvidingPodName == requestingPod.Labels[api.DualLabelName] && desiredInstanceID == requestingPod.Labels[api.InstanceLabelName] {
 		logger.V(5).Info("No need to update status, accelerators, boundName, instanceID, or finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "instanceID", desiredInstanceID, "finalizers", requestingPod.Finalizers)
-		return nil, false
+		return processResult{}
 	}
 	requestingPod = requestingPod.DeepCopy()
 	requestingPod.Annotations = utils.MapSet(requestingPod.Annotations, api.StatusAnnotationName, newStatusStr)
@@ -2059,7 +2069,7 @@ func (ctl *controller) ensureReqState(ctx context.Context, requestingPod *corev1
 	} else {
 		logger.V(2).Info("Failed to set status/finalizers", "serverRequestingPod", requestingPod.Name, "status", status, "accelerators", desiredAccelerators, "boundName", serverDat.ProvidingPodName, "instanceID", desiredInstanceID, "finalizers", requestingPod.Finalizers, "resourceVersion", requestingPod.ResourceVersion, "k8sCallStartTime", updStartStr, "err", err.Error())
 	}
-	return err, err != nil
+	return processResult{err: err, retry: err != nil}
 }
 
 var coreScheme *k8sruntime.Scheme


### PR DESCRIPTION
- Add per-item retry scheduling with exponential backoff to the node-local work queue
- Replace the yank-all-and-retry model with a time-aware local queue (`takeReadyItems` / `addAfter` / `earliestPending`) that supports per-item exponential backoff via a rate limiter and fixed-delay retries via `retryAfter`. Items that aren't ready yet stay in the queue rather than being re-processed immediately. 
- The process return type is unified into a processOutput struct carrying err, retry, and retryAfter.
