### PR TITLE
Adds make test to Makefile

### DIFF
--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -23,4 +23,4 @@ jobs:
           go-version: "1.26"
 
       - name: Run Go unit tests
-        run: go test ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,11 @@ load-populator-local:
 build-populator:
 	KO_DOCKER_REPO=$(CONTAINER_IMG_REG) ko build -B ./cmd/launcher-populator -t ${IMAGE_TAG} --platform all
 
+.PHONY: test
+test: ## Run unit tests.
+	@echo "Running unit tests..."
+	go test $$(go list ./pkg/... | grep -Ev '/pkg/(api|generated|spi)(/|$$)') -coverprofile=cover.out
+
 .PHONY: echo-var
 echo-var:
 	@echo "$($(VAR))"


### PR DESCRIPTION
It should be easier to run unit tests and check test coverage this way.
You can check that out by running:
```bash
 ~/Desktop/omerap12/llm-d-fast-model-actuation/ [makefile-ut] make test              
set -e; if [ -z "/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen" ]; then echo "Error: Target path is empty but must not be"; exit 1; fi; package=sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0 ; echo "Downloading ${package}" ; rm -f /Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen || true ; GOBIN=/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin go install ${package} ; mv /Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen /Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen-v0.19.0
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen-v0.19.0 crd paths=./api/...
/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen-v0.19.0 object:headerFile="hack/boilerplate.go.txt" paths="./api/..."
Running unit tests...
go test $(go list ./... | grep -Ev '/(e2e|api|cmd|pkg/generated|pkg/spi|pkg/api)') -coverprofile=cover.out
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/common		coverage: 0.0% of statements
?   	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common	[no test files]
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods		coverage: 0.0% of statements
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic		coverage: 0.0% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/launcher-populator	(cached)	coverage: 9.5% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils	(cached)	coverage: 54.5% of statements
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/observability		coverage: 0.0% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination	(cached)	coverage: 48.1% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes	(cached)	coverage: 90.9% of statements
 ~/Desktop/omerap12/llm-d-fast-model-actuation/ [makefile-ut] make test-code-coverage 
/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen-v0.19.0 crd paths=./api/...
/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/controller-gen-v0.19.0 object:headerFile="hack/boilerplate.go.txt" paths="./api/..."
Running unit tests...
go test $(go list ./... | grep -Ev '/(e2e|api|cmd|pkg/generated|pkg/spi|pkg/api)') -coverprofile=cover.out
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/common		coverage: 0.0% of statements
?   	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common	[no test files]
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/dual-pods		coverage: 0.0% of statements
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic		coverage: 0.0% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/launcher-populator	(cached)	coverage: 9.5% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils	(cached)	coverage: 54.5% of statements
	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/observability		coverage: 0.0% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/coordination	(cached)	coverage: 48.1% of statements
ok  	github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/server/requester/probes	(cached)	coverage: 90.9% of statements
set -e; if [ -z "/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/go-test-coverage" ]; then echo "Error: Target path is empty but must not be"; exit 1; fi; package=github.com/vladopajic/go-test-coverage/v2@v2.14.2 ; echo "Downloading ${package}" ; rm -f /Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/go-test-coverage || true ; GOBIN=/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin go install ${package} ; mv /Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/go-test-coverage /Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/go-test-coverage-v2.14.2
Downloading github.com/vladopajic/go-test-coverage/v2@v2.14.2
/Users/oaplaton/Desktop/omerap12/llm-d-fast-model-actuation/hack/tools/bin/go-test-coverage-v2.14.2 --config=./.github/.testcoverage.yml
Total coverage threshold (5%) satisfied:	PASS
Total test coverage:  8.8% (217/2467)
```

FYI: test coverage is super small (8.8%).