### PR TITLE
Add CLAUDE.md pointing agents to AGENTS.md and .agents/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Instructions for coding agents
+
+This repository keeps its agent instructions in `AGENTS.md` and under
+`.agents/**` (including `SKILL.md` files in `.agents/skills/`). Read them
+before any substantive work in this repo — planning, editing, reviewing a PR,
+answering repo-specific questions, running workflows.


### PR DESCRIPTION
## Motivation

The Claude Code harness has been observed not to read this repo's `AGENTS.md` or the skill definitions under `.agents/`. As a result, an agent can begin substantive work — reviewing a PR, committing, etc. — without ever reading the repo's documented workflow instructions.

## Change

Add a minimal project-root `CLAUDE.md` that points agents at `AGENTS.md` and `.agents/**` (including the `SKILL.md` files) and directs them to read those before doing substantive work in the repo. It is intentionally a pointer only — no workflow content is duplicated, so `AGENTS.md`/`.agents/**` remain the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)