### PR TITLE
Update vllm to version 0.23.0 to match WVA/benchmarking etc

### DIFF
--- a/cmd/requester/README.md
+++ b/cmd/requester/README.md
@@ -82,7 +82,7 @@ spec:
           spec:
             containers:
             - name: inference-server
-              image: docker.io/vllm/vllm-openai:v0.20.2
+              image: docker.io/vllm/vllm-openai:v0.23.0
               imagePullPolicy: IfNotPresent
               command:
               - vllm
@@ -156,7 +156,7 @@ spec:
           spec:
             containers:
             - name: inference-server
-              image: docker.io/vllm/vllm-openai:v0.20.2
+              image: docker.io/vllm/vllm-openai:v0.23.0
               imagePullPolicy: IfNotPresent
               command:
               - vllm
@@ -258,7 +258,7 @@ command:
 env:
   - name: CUDA_VISIBLE_DEVICES
     value: "0"
-image: docker.io/vllm/vllm-openai:v0.20.2
+image: docker.io/vllm/vllm-openai:v0.23.0
 imagePullPolicy: IfNotPresent
 name: inference-server
 ports:

--- a/config/examples/inject-launcher/replicaset.yaml
+++ b/config/examples/inject-launcher/replicaset.yaml
@@ -33,7 +33,7 @@ spec:
             name: launcher-code
       containers:
         - name: inference-server
-          image: vllm/vllm-openai:v0.20.2
+          image: docker.io/vllm/vllm-openai:v0.23.0
           ports:
             - containerPort: 8001
           # Install dependencies and run the app

--- a/dockerfiles/Dockerfile.launcher.benchmark
+++ b/dockerfiles/Dockerfile.launcher.benchmark
@@ -1,7 +1,17 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.20.2
+ARG BASE_IMAGE=docker.io/vllm/vllm-openai:v0.23.0
 FROM ${BASE_IMAGE}
 
 WORKDIR /app
+
+# vLLM 0.22+ (torch 2.x) computes a per-user inductor cache dir at import via
+# torch's default_cache_dir() -> getpass.getuser() -> pwd.getpwuid(). Under
+# OpenShift's restricted-v2 SCC the arbitrary UID has no /etc/passwd entry, so
+# this raises KeyError. No cache-dir env var avoids it: codecache.py calls
+# default_cache_dir() directly for a deliberately-global header cache (bypassing
+# TORCHINDUCTOR_CACHE_DIR), and default_cache_dir() has no env override. Seeding
+# USER makes getpass.getuser() read the env instead of /etc/passwd.
+# See https://github.com/vllm-project/vllm/issues/44548
+ENV USER=vllm
 
 COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslator.py inference_server/launcher/launcher_pod_notifier.py /app/
 

--- a/dockerfiles/Dockerfile.launcher.cpu
+++ b/dockerfiles/Dockerfile.launcher.cpu
@@ -2,7 +2,7 @@
 # Supports both arm64 and amd64 architectures
 
 ARG TARGETARCH
-ARG VLLM_VERSION=v0.20.2
+ARG VLLM_VERSION=v0.23.0
 
 # Define base images for each architecture
 FROM public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:${VLLM_VERSION} AS base-arm64
@@ -13,6 +13,16 @@ FROM public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:${VLLM_VERSION} AS base-amd64
 FROM base-${TARGETARCH} AS final
 
 WORKDIR /app
+
+# vLLM 0.22+ (torch 2.x) computes a per-user inductor cache dir at import via
+# torch's default_cache_dir() -> getpass.getuser() -> pwd.getpwuid(). Under
+# OpenShift's restricted-v2 SCC the arbitrary UID has no /etc/passwd entry, so
+# this raises KeyError. No cache-dir env var avoids it: codecache.py calls
+# default_cache_dir() directly for a deliberately-global header cache (bypassing
+# TORCHINDUCTOR_CACHE_DIR), and default_cache_dir() has no env override. Seeding
+# USER makes getpass.getuser() read the env instead of /etc/passwd.
+# See https://github.com/vllm-project/vllm/issues/44548
+ENV USER=vllm
 
 COPY inference_server/launcher/launcher.py inference_server/launcher/gputranslator.py inference_server/launcher/launcher_pod_notifier.py /app/
 RUN chmod a+x /app/launcher.py

--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -174,7 +174,7 @@ metadata:
       spec:
         containers:
         - name: inference-server
-          image: docker.io/vllm/vllm-openai:v0.20.2
+          image: docker.io/vllm/vllm-openai:v0.23.0
           command:
           - vllm
           - serve
@@ -290,7 +290,7 @@ spec:
   nodeSelector: { "kubernetes.io/hostname": "somenode" }
   containers:
   - name: inference-server
-    image: docker.io/vllm/vllm-openai:v0.20.2
+    image: docker.io/vllm/vllm-openai:v0.23.0
     command:
     - vllm
     - serve

--- a/docs/e2e-recipe.md
+++ b/docs/e2e-recipe.md
@@ -153,7 +153,7 @@ spec:
           spec:
             containers:
             - name: inference-server
-              image: docker.io/vllm/vllm-openai:v0.20.2
+              image: docker.io/vllm/vllm-openai:v0.23.0
               command:
               - vllm
               - serve
@@ -250,7 +250,7 @@ spec:
           spec:
             containers:
             - name: inference-server
-              image: docker.io/vllm/vllm-openai:v0.20.2
+              image: docker.io/vllm/vllm-openai:v0.23.0
               command:
               - vllm
               - serve

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -12,6 +12,6 @@
 | **k8s.io/apimachinery** | `v0.34.9` | tag | `go.mod` line 9 | [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery) |
 | **k8s.io/client-go** | `v0.34.9` | tag | `go.mod` line 10 | [kubernetes/client-go](https://github.com/kubernetes/client-go) |
 | **sigs.k8s.io/controller-runtime** | `v0.22.5` | tag | `go.mod` line 14 | [kubernetes-sigs/controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) |
-| **vllm/vllm-openai** | `v0.20.2` | tag | `cmd/requester/README.md` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
-| **vllm (CPU build)** | `v0.20.2` | tag | `dockerfiles/Dockerfile.launcher.cpu` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
+| **vllm/vllm-openai** | `v0.23.0` | tag | `cmd/requester/README.md` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
+| **vllm (CPU build)** | `v0.23.0` | tag | `dockerfiles/Dockerfile.launcher.cpu` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
 | **nvidia/cuda** | `12.8.0-base-ubuntu22.04` | tag | `dockerfiles/Dockerfile.requester` | [NVIDIA CUDA](https://hub.docker.com/r/nvidia/cuda) |

--- a/inference_server/benchmark/deploy/server-request-caching-pvc.yaml
+++ b/inference_server/benchmark/deploy/server-request-caching-pvc.yaml
@@ -24,7 +24,7 @@ spec:
           spec:
             containers:
             - name: inference-server
-              image: docker.io/vllm/vllm-openai:v0.20.2
+              image: docker.io/vllm/vllm-openai:v0.23.0
               command:
               - vllm
               - serve

--- a/inference_server/benchmark/deploy/server-request-generic-model.yaml
+++ b/inference_server/benchmark/deploy/server-request-generic-model.yaml
@@ -22,7 +22,7 @@ spec:
           spec:
             containers:
             - name: inference-server
-              image: docker.io/vllm/vllm-openai:v0.20.2
+              image: docker.io/vllm/vllm-openai:v0.23.0
               command:
               - vllm
               - serve

--- a/inference_server/benchmark/deploy/server-request-minimal.yaml
+++ b/inference_server/benchmark/deploy/server-request-minimal.yaml
@@ -24,7 +24,7 @@ spec:
           spec:
             containers:
             - name: inference-server
-              image: docker.io/vllm/vllm-openai:v0.20.2
+              image: docker.io/vllm/vllm-openai:v0.23.0
               command:
               - vllm
               - serve

--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -38,7 +38,7 @@ from gputranslator import GpuTranslator
 from pydantic import BaseModel
 from vllm.entrypoints.openai.api_server import run_server
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
-from vllm.entrypoints.utils import cli_env_setup
+from vllm.entrypoints.serve.utils.api_utils import cli_env_setup
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 MAX_LOG_RESPONSE_BYTES = 1 * 1024 * 1024  # 1 MB default for API response
@@ -186,8 +186,8 @@ class VllmInstance:
                 config.env_vars = {}
             config.env_vars["CUDA_VISIBLE_DEVICES"] = ",".join(cuda_indices)
             logger.info(
-                f"Set CUDA_VISIBLE_DEVICES to \
-                    {config.env_vars['CUDA_VISIBLE_DEVICES']} based on UUIDs."
+                "Set CUDA_VISIBLE_DEVICES to %s based on UUIDs.",
+                config.env_vars["CUDA_VISIBLE_DEVICES"],
             )
 
         # Initialize instance variables

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -34,7 +34,7 @@ sys.modules["vllm.utils"] = MagicMock()
 sys.modules["vllm.utils.argparse_utils"] = MagicMock()
 sys.modules["vllm.entrypoints.openai.api_server"] = MagicMock()
 sys.modules["vllm.entrypoints.openai.cli_args"] = MagicMock()
-sys.modules["vllm.entrypoints.utils"] = MagicMock()
+sys.modules["vllm.entrypoints.serve.utils.api_utils"] = MagicMock()
 
 # Import the application and classes
 from launcher import (  # noqa: E402


### PR DESCRIPTION
The bump also requires an OpenShift compatibility fix in the launcher image (below) — without it the OpenShift E2E fails. Also, vLLM 0.23.0 moved `cli_env_setup` out of the (now-deleted) v`llm.entrypoints.utils` module.

**Symptom**

On v0.23.0 the OpenShift E2E Run E2E tests step fails (exit 99): launcher inference-server containers `CrashLoopBackOff` (1/2, only the sidecar up) and never reach Ready.

```
launcher-…  1/2  CrashLoopBackOff  6 (…)  12m
Did not become true …: [ … Ready … -ge 2 ]
##[error]Process completed with exit code 99
```

**Root cause**

`launcher.py` imports vLLM in-process. On import, the torch 2.x bundled with 0.23.0 builds a per-user inductor cache dir via `getpass.getuser()`, which falls through to `pwd.getpwuid(os.getuid())`. Under OpenShift's restricted-v2 SCC the pod runs as an arbitrary UID with no /`etc/passwd` entry, so it raises `KeyError` at import — before any vLLM arg parsing:

```
torch/_inductor/runtime/cache_dir_utils.py:23  default_cache_dir()
 → getpass.getuser() → pwd.getpwuid(os.getuid())
KeyError: 'getpwuid(): uid not found: 1003520000'
```

**Fix**

Add to both launcher Dockerfiles (Dockerfile.launcher.benchmark, Dockerfile.launcher.cpu):

```
ENV USER=vllm \
    HOME=/tmp
```

- getpass.getuser() checks $LOGNAME/$USER/$LNAME/$USERNAME before getpwuid(), so USER short-circuits the failing lookup.
- HOME=/tmp covers the sibling os.path.expanduser("~") → getpwuid path and points home at a dir writable under restricted-v2.

This is the canonical llm-d remediation — `deploy-llm-d` troubleshooting doc, "vLLM crashes on OpenShift with KeyError / getpwuid (vLLM v0.22+)": 
https://github.com/llm-d-incubation/llm-d-skills/blob/main/skills/deploy-llm-d/references/troubleshooting.md (prescribes USER=vllm). 
Upstream context: https://github.com/vllm-project/vllm/issues/44548.
