### PR TITLE
Establish design rules with automation and subjective tiers

### DIFF
--- a/.agents/skills/our-git-commits/SKILL.md
+++ b/.agents/skills/our-git-commits/SKILL.md
@@ -3,6 +3,8 @@ description: Things to do when making a Git commit
 trigger: When the user asks to commit changes, create a commit, make a git commit, amend a commit, revise a commit, reword a commit message, or any other action that results in running a `git commit` command
 ---
 
+These are requirements specific to this repo, in addition to — not a replacement for — whatever commit-message conventions you already follow (e.g. an authorship/co-author trailer); keep applying those too.
+
 When creating a Git commit:
 
 1. Before committing, run `typos` on the changed files to find and fix any typographical errors. Ask the user about any findings you are unsure about.

--- a/.agents/skills/pr-security-review/SKILL.md
+++ b/.agents/skills/pr-security-review/SKILL.md
@@ -1,11 +1,11 @@
 name: pr-security-review
-description: When reviewing PRs that bump dependencies or GitHub Actions, actively search for known vulnerabilities rather than reasoning abstractly
+description: When reviewing PRs that bump a dependency (including a GitHub Action), actively search for known vulnerabilities rather than reasoning abstractly
 ---
 
-When reviewing dependency or GitHub Actions bump PRs, follow the checklist in
-the "Reviewing dependency and GitHub Actions bump PRs" subsection of
-[CONTRIBUTING.md](../../../CONTRIBUTING.md#reviewing-dependency-and-github-actions-bump-prs).
-That section is the source of truth.
+When reviewing a dependency bump PR, follow the "Reviewing dependency bumps"
+checklist in
+[CONTRIBUTING.md](../../../CONTRIBUTING.md#reviewing-dependency-bumps), which is
+the source of truth for the steps.
 
 Verify security by actually checking external sources — don't just reason about
 it in the abstract.

--- a/.github/workflows/check-action-refs.yml
+++ b/.github/workflows/check-action-refs.yml
@@ -1,0 +1,38 @@
+name: Check Action References
+
+# Enforces design rule DR-10 (see DESIGN_RULES.md): first-party actions are
+# referenced by @main; third-party actions are pinned by full commit SHA with a
+# version-tag comment that resolves to that SHA. Runs in --online mode so the
+# tag->SHA resolution is verified; CI is the authority for that clause.
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "hack/check-action-refs.py"
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "hack/check-action-refs.py"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check action references
+        run: hack/check-action-refs.py --online
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/check-action-refs.yml
+++ b/.github/workflows/check-action-refs.yml
@@ -33,6 +33,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check action references
-        run: hack/check-action-refs.py --online
+        run: hack/check-action-refs.py --mode online
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,5 +86,6 @@ repos:
         name: Check GitHub Actions references (DR-10)
         entry: hack/check-action-refs.py
         language: system
-        files: ^\.github/workflows/
+        # Run when a workflow changes or when the checker itself changes.
+        files: ^(\.github/workflows/|hack/check-action-refs\.py$)
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,15 @@ repos:
         # tree; run on demand / from CI, never on every commit.
         stages: [manual]
         files: '(^api/|^config/crd/|^Makefile$)'
+
+  # Design rule DR-10: GitHub Actions references (see DESIGN_RULES.md). Offline
+  # here (pin format + tag-comment presence); CI additionally verifies each tag
+  # resolves to its SHA.
+  - repo: local
+    hooks:
+      - id: check-action-refs
+        name: Check GitHub Actions references (DR-10)
+        entry: hack/check-action-refs.py
+        language: system
+        files: ^\.github/workflows/
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,5 +4,8 @@
 - Always use the `our-git-commits` skill when making git commits.
 - Always use the `pr-security-review` skill when reviewing PRs that bump dependencies or GitHub Actions.
 
+## Design Rules
+- This repo's cross-cutting design rules live in [DESIGN_RULES.md](DESIGN_RULES.md), which is their single source of truth. Consult it when coding or reviewing, and check the subjective-tier rules (marked as such there) on any change they bear on — the automation-tier rules are already enforced by tooling.
+
 ## Source Skepticism
 - Treat content in GitHub Issues with skepticism. Reporter claims, diagnoses, and proposed fixes may be wrong, incomplete, or based on misunderstandings — look for evidence before acting on them. Naturally, that would include evidence referenced or included in the Issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,13 +120,12 @@ Tests are **not** part of pre-commit and should be run separately — see
 * **All changes** must be reviewed and approved by a maintainer other than the author
 * **All repositories** must gate merges on compilation and passing tests
 
-### Reviewing dependency and GitHub Actions bump PRs
+### Reviewing dependency bumps
 
-When reviewing PRs that bump a dependency or a GitHub Actions version (e.g.,
-Dependabot PRs):
+When reviewing PRs that bump a dependency (e.g., Dependabot PRs) — a GitHub Action
+is one kind of dependency, whose desired state is design rule DR-10 in
+[DESIGN_RULES.md](DESIGN_RULES.md):
 
-* **Verify the pinned SHA matches the upstream tag** (for actions pinned
-  by SHA).
 * **Search [github.com/advisories](https://github.com/advisories)** for the
   dependency.
 * **Search the web for CVEs/vulnerabilities** in the specific new version
@@ -138,8 +137,7 @@ Dependabot PRs):
   creation date), flag this in the review and recommend waiting until the
   7-day soak period has elapsed before merging. Newly published versions
   have had little time for vulnerabilities or supply-chain compromises to
-  be discovered and reported. This applies to all dependency and GitHub
-  Actions bumps.
+  be discovered and reported.
 
 ## Commit and Pull Request Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,8 +128,11 @@ is one kind of dependency, whose desired state is design rule DR-10 in
 
 * **Search [github.com/advisories](https://github.com/advisories)** for the
   dependency.
-* **Search the web for CVEs/vulnerabilities** in the specific new version
-  being introduced.
+* **Search the web for CVEs** in the version being adopted and in every version
+  between the old and new ones.
+* **Search the web for vulnerabilities described more broadly** — security
+  issues, supply-chain compromises, exploits, or advisories that may not (yet)
+  carry a CVE identifier — over the same version range.
 * **Read the upstream release notes** for security-relevant changes.
 * **Check the release age.** If the upstream release's publish timestamp
   is less than 7 days ago (use the release's `published` field — for GitHub
@@ -138,6 +141,9 @@ is one kind of dependency, whose desired state is design rule DR-10 in
   7-day soak period has elapsed before merging. Newly published versions
   have had little time for vulnerabilities or supply-chain compromises to
   be discovered and reported.
+
+At the **end** of the review, re-display this checklist and, for each item,
+state what was done and the result found.
 
 ## Commit and Pull Request Style
 

--- a/DESIGN_RULES.md
+++ b/DESIGN_RULES.md
@@ -87,7 +87,7 @@ a given action keeps its version consistent and makes a bump a single, reviewabl
 change. The 7-day soak lets newly published releases accumulate scrutiny before we
 adopt them; we do not otherwise require the newest release. First-party reusable
 workflows track `main` by design. Established in
-[#633](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/issues/633).
+[#633](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/633).
 
 ### DR-10: Enforcement
 

--- a/DESIGN_RULES.md
+++ b/DESIGN_RULES.md
@@ -95,8 +95,8 @@ workflows track `main` by design. Established in
   [`hack/check-action-refs.py`](hack/check-action-refs.py), run in both
   [pre-commit](.pre-commit-config.yaml) (offline: pin format, tag-comment
   presence, and one SHA/tag per action across workflows) and
-  [CI](.github/workflows/check-action-refs.yml) (`--online`, which additionally
-  verifies each tag resolves to its SHA via `gh`).
+  [CI](.github/workflows/check-action-refs.yml) (`--mode online`, which
+  additionally verifies each tag resolves to its SHA via `gh`).
 - Clause **(b)** is **subjective and advisory**: the script does not check it.
   Whoever is doing the work — an AI agent or a human — checks that the chosen
   version has no reported vulnerabilities, has soaked at least 7 days, and is not

--- a/DESIGN_RULES.md
+++ b/DESIGN_RULES.md
@@ -60,7 +60,9 @@ genuinely needs judgement.
 ### DR-10: Rule
 
 In GitHub Actions workflow files (`.github/workflows/*.y*ml`), every
-`uses:` reference obeys the following, by clause:
+`uses:` reference that names an external repository (`owner/repo…@<ref>`) obeys
+the following, by clause. Local references (`uses: ./…`, which have no `@<ref>`)
+are out of scope.
 
 - **(first-party)** References to first-party actions and reusable workflows —
   those in the [`llm-d/llm-d-infra`](https://github.com/llm-d/llm-d-infra) repo or

--- a/DESIGN_RULES.md
+++ b/DESIGN_RULES.md
@@ -1,0 +1,165 @@
+# Design Rules
+
+This document records the project's **design rules**: cross-cutting conventions
+that any change is expected to respect, but that are not captured by the compiler,
+the type system, or ordinary unit tests. They are the kind of expectation that is
+easy to state ("every outbound call from a controller logs how long it took") and
+easy to erode over time unless it is written down and checked.
+
+## Two tiers of checking
+
+A design rule is placed in one of two tiers, according to **how it is checked**:
+
+1. **Automation tier** — the rule is checked by automation (a script, a linter).
+   Such a check is mechanical, deterministic, and may run in more than one place
+   (for example, both a pre-commit hook and a CI workflow). The automation tier is
+   not new: much of it predates this document. Two places already hold such
+   checks — the [pre-commit hooks](.pre-commit-config.yaml) (formatters, linters,
+   typo and whitespace/file checks) and the [CI workflows](docs/README.md#ci)
+   (which overlap the pre-commit hooks only partly and add checks of their own).
+   Those checks are self-documented by their own configuration and are not
+   re-catalogued here; only rules that need prose beyond their checker's config get
+   a numbered entry below.
+
+2. **Subjective tier** (requires judgement) — the rule cannot be reduced cleanly
+   to a mechanical check, so it is checked by **whoever is doing the work — an AI
+   agent or a human**. A subjective rule may be **firm** (a deviation should be
+   treated as a defect) or **advisory** (a deviation is flagged, and a human
+   decides whether to accept it).
+
+For an advisory rule, an accepted deviation is an **exception**: it is recorded as
+a note placed *next to the thing the rule applies to*, naming which aspect of the
+rule is being waived, so that whoever reviews next — agent or human — recognizes
+it as already accepted and does not re-flag it. There is no universal syntax for
+that note; each rule that admits exceptions defines its own, because the note lives
+wherever that rule applies.
+
+This document is the single source of truth for the rules below. Whoever does the
+work is pointed here: AI agents by [`AGENTS.md`](AGENTS.md), human contributors by
+[`CONTRIBUTING.md`](CONTRIBUTING.md). Other documents (for example that
+`CONTRIBUTING.md` section and the `pr-security-review` skill) link here rather
+than restating a rule.
+
+## Adding a rule
+
+Give each rule a stable id (`DR-<n>`) and a short title, then state:
+
+- **Rule** — what must (or should) be true.
+- **Rationale** — why, with links to the originating issue(s)/PR(s).
+- **Enforcement** — which tier, and for automation-tier rules, the checker that
+  enforces it.
+
+Prefer moving a rule (or a clause of one) into the automation tier when a
+mechanical check becomes practical; leave in the subjective tier only what
+genuinely needs judgement.
+
+---
+
+## DR-10 — GitHub Actions references
+
+### DR-10: Rule
+
+In GitHub Actions workflow files (`.github/workflows/*.y*ml`), every
+`uses:` reference obeys the following, by clause:
+
+- **(first-party)** References to first-party actions and reusable workflows —
+  those in the [`llm-d/llm-d-infra`](https://github.com/llm-d/llm-d-infra) repo or
+  in this repo — are by branch `main` (`@main`). *(automation tier)*
+- **(a)** Every other (third-party) reference is pinned by a **full 40-hex commit
+  SHA** and carries a **comment naming the corresponding version tag**, e.g.
+  `uses: actions/checkout@9c091bb… # v7.0.0`. The commented tag must actually
+  resolve to the pinned SHA, and **every reference to a given action across all
+  workflows uses the same SHA and tag**. *(automation tier)*
+- **(b)** The version so chosen for an action **should** have **no reported
+  vulnerabilities**, have been published **at least 7 days** ago, and not be
+  egregiously out of date — but it need not be the latest release. Because of
+  clause (a) there is one such version per action. *(subjective tier, advisory —
+  see below)*
+
+### DR-10: Rationale
+
+SHA-pinning third-party actions defends against a moving tag being
+repointed at malicious code (supply-chain hardening); the tag comment keeps the
+pin human-readable and reviewable. Pinning every workflow to the same SHA/tag for
+a given action keeps its version consistent and makes a bump a single, reviewable
+change. The 7-day soak lets newly published releases accumulate scrutiny before we
+adopt them; we do not otherwise require the newest release. First-party reusable
+workflows track `main` by design. Established in
+[#633](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/issues/633).
+
+### DR-10: Enforcement
+
+- The **first-party** and **(a)** clauses are checked by
+  [`hack/check-action-refs.py`](hack/check-action-refs.py), run in both
+  [pre-commit](.pre-commit-config.yaml) (offline: pin format, tag-comment
+  presence, and one SHA/tag per action across workflows) and
+  [CI](.github/workflows/check-action-refs.yml) (`--online`, which additionally
+  verifies each tag resolves to its SHA via `gh`).
+- Clause **(b)** is **subjective and advisory**: the script does not check it.
+  Whoever is doing the work — an AI agent or a human — checks that the chosen
+  version has no reported vulnerabilities, has soaked at least 7 days, and is not
+  egregiously stale, and flags a deviation. **The user may allow an exception.**
+
+### DR-10: Exceptions to clause (b)
+
+First, some non-exceptions: clause (b) does not ask for the latest release, so
+staying on an older version — including because a newer one has not yet soaked 7
+days — is ordinary **compliance**, not an exception. A genuine exception is a
+deliberate deviation from what clause (b) asks, e.g. staying on a version that has
+a known vulnerability because no fixed release exists yet, or on one that is
+egregiously stale.
+
+Record a clause-(b) exception (per the framework convention above) as free-form
+English **appended to the version-tag comment on the `uses:` line**, naming which
+aspect of clause (b) is being waived, e.g.:
+
+```yaml
+uses: some/action@<sha>  # v1.2.0 — staying despite open CVE-2026-1234, no fixed release yet
+```
+
+Further justification is welcome but not required. (The automation checker reads
+only the version tag at the start of the comment, so an exception note after it
+does not affect the mechanical clauses.)
+
+---
+
+## DR-20 — External-process call latency logging
+
+### DR-20: Rule
+
+Every time a controller calls out to an external process — the launcher
+API, a vLLM instance over HTTP, or the Kubernetes API — it emits a log line, on
+the call's outcome, that carries a **start-timestamp field** for the call (e.g.
+`httpCallStartTime` for launcher/vLLM HTTP calls, `k8sCallStartTime` for
+Kubernetes API calls). Two shapes are acceptable:
+
+- **start time only** — the recovered start is exact; the end is approximated by
+  the log line's own klog timestamp; or
+- **start time plus the elapsed duration** — both endpoints are recovered exactly
+  from logged values.
+
+Logging the duration *without* the start time is **not** acceptable: the end would
+come from the log-emission timestamp (which klog prefixes to the line), whose
+uncontrolled lag after the reply then contaminates the start time recovered as
+(end − duration). The start timestamp must always be present; the duration is
+optional alongside it.
+
+Emit this line at `V(2)` (visible by default) for state-changing calls and for
+failures; for read-only successes it may be at `V(4)`.
+
+### DR-20: Rationale
+
+Benchmarking and diagnosis of the actuation path depend on being
+able to correlate the duration of each outbound call with other events.
+Generalized from
+[#495](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/issues/495)
+and applied to the dual-pods controller in
+[#522](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/522).
+
+### DR-20: Enforcement
+
+**Subjective tier.** There is no mechanical check: whether a
+given Go call is an "external process" call, and whether a duration-revealing log
+wraps it, needs judgement. Whoever writes or reviews controller code that adds or
+changes an outbound call — an AI agent or a human — is expected to confirm the
+call is logged per this rule.

--- a/DESIGN_RULES.md
+++ b/DESIGN_RULES.md
@@ -53,6 +53,9 @@ Prefer moving a rule (or a clause of one) into the automation tier when a
 mechanical check becomes practical; leave in the subjective tier only what
 genuinely needs judgement.
 
+Normally new rules are numbered as a multiple of 10, to leave room for
+future insertions between existing rules if the need ever arises.
+
 ---
 
 ## DR-10 — GitHub Actions references

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Fast Model Actuation with Process Flexibility and Dual Pods](dual-pods.md)
 - [Cluster Sharing](cluster-sharing.md)
 - [Prometheus Metrics](metrics.md)
+- [Design Rules](../DESIGN_RULES.md)
 
 # Dev/test
 
@@ -16,6 +17,7 @@
 
 - [Code quality: Markdown, Python & Go lint/format/typos plus launcher tests](../.github/workflows/code-quality.yml)
 - [Verify IDL consumption](../.github/workflows/verify-idl-consumption.yml)
+- [Check GitHub Actions references (DR-10)](../.github/workflows/check-action-refs.yml)
 - [Test build of dual-pods controller image](../.github/workflows/build-controller-image.yml)
 - [Test build of launcher image](../.github/workflows/build-launcher-image.yml)
 - [Test build of requester image](../.github/workflows/build-requester-image.yml)

--- a/hack/check-action-refs.py
+++ b/hack/check-action-refs.py
@@ -242,10 +242,11 @@ class TagResolver:
     def _gh_api(self, api_path: str) -> Optional[object]:
         """Run ``gh api <path>``.
 
-        Returns the parsed JSON (dict or list) on success, or None when gh exits
-        non-zero (e.g. a 404 for a missing tag). Exits hard if gh succeeds but
-        its output is not valid JSON, since that means the tooling is
-        misbehaving and must not be mistaken for a clean or failing check.
+        Returns the parsed JSON (dict or list) on success, or None only when gh
+        reports HTTP 404 (a genuinely missing ref). Any other failure — rate
+        limit, auth, network, or non-JSON output — is a tooling problem, so we
+        exit hard with gh's own error rather than mistake it for an unresolvable
+        tag (which would be reported as a DR-10 violation).
         """
         try:
             out = subprocess.run(
@@ -257,7 +258,13 @@ class TagResolver:
         except FileNotFoundError:
             sys.exit("error: 'gh' not found; --online requires the GitHub CLI")
         if out.returncode != 0:
-            return None
+            # gh writes e.g. "gh: Not Found (HTTP 404)" to stderr.
+            if "HTTP 404" in out.stderr:
+                return None
+            sys.exit(
+                f"error: 'gh api {api_path}' failed "
+                f"(exit {out.returncode}): {out.stderr.strip()}"
+            )
         try:
             return json.loads(out.stdout)
         except json.JSONDecodeError as err:
@@ -357,7 +364,9 @@ def check(online: bool) -> tuple[list[Violation], Optional[TagResolver]]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    # __doc__ is Optional[str] (absent under python -OO), so guard the access.
+    description = __doc__.splitlines()[0] if __doc__ else None
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         "--online",
         action="store_true",

--- a/hack/check-action-refs.py
+++ b/hack/check-action-refs.py
@@ -66,6 +66,12 @@ USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)\s*(?:#\s*(?P<comment>.*
 # Commit SHAs are case-insensitive hex; compare them via .lower() elsewhere.
 FULL_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
+# A reference in DR-10's scope: an external repo ``owner/repo`` (each a GitHub
+# name segment), optionally with a ``/subpath`` (reusable workflows), then
+# ``@<ref>``. This deliberately excludes local ``./…`` references and other
+# ``uses:`` forms that can contain ``@`` (e.g. ``docker://image@sha256:…``).
+REMOTE_REF_RE = re.compile(r"^[\w.-]+/[\w.-]+(?:/[\w./-]+)?@[^\s]+$")
+
 # The version tag is the leading run of the comment, optionally followed by a
 # single punctuation char, then certainly whitespace or end-of-line. So
 # "v7.0.0", "v7.0.0 latest", and "v7.0.0, latest" all yield "v7.0.0".
@@ -173,8 +179,9 @@ def parse_uses(wf_paths: list[str]) -> Iterator[UsesRef]:
                 if not m:
                     continue
                 ref = m.group("ref")
-                if "@" not in ref:
-                    # Local action (./path) or malformed; DR-10 doesn't cover it.
+                if not REMOTE_REF_RE.match(ref):
+                    # Out of DR-10's scope: local ``./…`` actions, ``docker://…``
+                    # forms, and malformed refs. Only ``owner/repo…@<ref>`` counts.
                     continue
                 ref_path, _, ref_version = ref.partition("@")
                 yield UsesRef(
@@ -307,10 +314,11 @@ def check(online: bool) -> tuple[list[Violation], Optional[TagResolver]]:
             continue
 
         # Clause (a): every reference to this action must use the same SHA and tag.
+        # SHAs are case-insensitive; tags are not.
         pin = pins.get(repo)
         if pin is None:
             pins[repo] = Pin(u.ref_version, tag, u.wf_path, u.lineno)
-        elif (u.ref_version, tag) != (pin.sha, pin.tag):
+        elif (u.ref_version.lower(), tag) != (pin.sha.lower(), pin.tag):
             violations.append(
                 Violation(
                     u.wf_path,

--- a/hack/check-action-refs.py
+++ b/hack/check-action-refs.py
@@ -28,7 +28,7 @@ the *mechanical* clauses:
 
   * Every reference to a given action across all workflows uses the same SHA and
     tag.
-  * With ``--online``: the commented tag actually resolves to the pinned SHA
+  * With ``--mode online``: the commented tag actually resolves to the pinned SHA
     (verified via ``gh api``).
 
 It does NOT check clause (b) of DR-10 (no known vulnerabilities / soaked >=7 days /
@@ -37,8 +37,8 @@ reviewer.
 
 Usage (run from the repo root)::
 
-    hack/check-action-refs.py            # offline checks only
-    hack/check-action-refs.py --online   # also verify each tag resolves to its SHA
+    hack/check-action-refs.py                 # offline checks only (default)
+    hack/check-action-refs.py --mode online   # also verify each tag resolves to its SHA
 
 Exits non-zero and prints ``file:line: reason`` for every violation.
 """
@@ -79,49 +79,55 @@ TAG_RE = re.compile(r"^(?P<tag>\S+?)[.,;:]?(?:\s|$)")
 
 
 class Violation(NamedTuple):
-    wf_path: str
-    lineno: int
-    ref: str
-    reason: str
+    """One DR-10 violation.
+
+    Its ``str`` is the reported line, e.g. ``.github/workflows/ci.yml:12:
+    third-party action must be pinned by full 40-hex commit SHA (uses:
+    actions/checkout@v4)``.
+    """
+
+    wf_path: str  # path to the workflow file the offending line appears in
+    lineno: int  # 1-based line number there
+    ref: str  # the offending reference as written
+    reason: str  # human-readable description of the violation
 
     def __str__(self) -> str:
         return f"{self.wf_path}:{self.lineno}: {self.reason} (uses: {self.ref})"
 
 
 class Pin(NamedTuple):
-    """A recorded pin of a third-party action, used by the clause-(a) same-version
-    check to compare its other references against. Fields: the pinned commit
-    ``sha``; its version-tag ``tag``; and the ``wf_path`` and ``lineno`` where this
-    pin was seen (cited when another reference disagrees)."""
+    """A recorded pin of a third-party action.
 
-    sha: str
-    tag: str
-    wf_path: str
-    lineno: int
+    Used by the clause-(a) same-version check to compare an action's other
+    references against.
+    """
+
+    sha: str  # the pinned commit SHA
+    tag: str  # its version-tag comment
+    wf_path: str  # path to the workflow file where this pin was seen
+    lineno: int  # 1-based line number there (cited when another reference disagrees)
 
 
 class UsesRef(NamedTuple):
-    """One parsed ``uses:`` line.
+    """One parsed ``uses:`` line."""
 
-    Fields:
-      * ``wf_path``     -- path to the workflow file the line appears in.
-      * ``lineno``      -- 1-based line number within that file.
-      * ``ref_path``    -- the part of the reference before ``@`` (e.g.
-                           ``actions/checkout`` or a reusable-workflow path).
-      * ``ref_version`` -- what follows ``@``: a commit SHA or a branch/tag.
-      * ``comment``     -- the trailing ``# ...`` comment body, or None.
-      * ``ref``         -- the full reference as written, for reporting.
-    """
-
-    wf_path: str
-    lineno: int
+    wf_path: str  # path to the workflow file the line appears in
+    lineno: int  # 1-based line number within that file
+    # the part of the reference before ``@`` (e.g. ``actions/checkout`` or a
+    # reusable-workflow path)
     ref_path: str
-    ref_version: str
-    comment: Optional[str]
-    ref: str
+    ref_version: str  # what follows ``@``: a commit SHA or a branch/tag
+    comment: Optional[str]  # the trailing ``# ...`` comment body, or None
+    ref: str  # the full reference as written, for reporting
 
 
 def workflow_files() -> list[str]:
+    """Return the workflow-file paths to check.
+
+    These are the sorted paths of every ``*.yml``/``*.yaml`` under
+    ``.github/workflows/`` (relative to the current directory), e.g.
+    ``['.github/workflows/ci.yml', '.github/workflows/release.yaml']``.
+    """
     files: list[str] = []
     for pattern in ("*.yml", "*.yaml"):
         files.extend(glob.glob(os.path.join(".github", "workflows", pattern)))
@@ -129,10 +135,13 @@ def workflow_files() -> list[str]:
 
 
 def repo_of(ref_path: str) -> str:
-    """Return owner/repo for the part of a ``uses:`` ref before the ``@``.
+    """Return the owner/repo of ``ref_path``, which is a ``uses:`` reference
+    with any ``@<ref>`` suffix already stripped off.
 
-    Handles both plain actions (``actions/checkout``) and reusable workflows
-    with a path (``llm-d/llm-d-infra/.github/workflows/x.yaml``).
+    E.g. ``'actions/checkout' -> 'actions/checkout'``, and
+    ``'llm-d/llm-d-infra/.github/workflows/lint.yaml' -> 'llm-d/llm-d-infra'``
+    (a reusable workflow with a path). A ``ref_path`` with no ``/`` is returned
+    unchanged.
     """
     parts = ref_path.split("/")
     if len(parts) < 2:
@@ -142,6 +151,11 @@ def repo_of(ref_path: str) -> str:
 
 def _require_object(data: object, api_path: str, key: str) -> dict:
     """Return ``data[key]`` when both are dicts; exit hard otherwise.
+
+    ``data`` is a parsed ``gh api`` payload, ``api_path`` is the path it came
+    from (for error messages), and ``key`` is the nested object to extract. E.g.
+    given ``data={'object': {'sha': 'abc', 'type': 'commit'}}`` and
+    ``key='object'``, returns ``{'sha': 'abc', 'type': 'commit'}``.
 
     Used to validate the shape of a ``gh api`` JSON payload. An unexpected shape
     (e.g. a JSON array from a ref name that matches several refs, or a missing
@@ -163,7 +177,12 @@ def _require_object(data: object, api_path: str, key: str) -> dict:
 
 
 def extract_tag(comment: Optional[str]) -> Optional[str]:
-    """Return the version tag from a comment body, or None if absent."""
+    """Return the version tag from a ``uses:`` line's trailing comment body, or
+    None if there is none.
+
+    E.g. ``'v7.0.0' -> 'v7.0.0'``, ``'v7.0.0, latest' -> 'v7.0.0'``,
+    ``'v7.0.0 pinned per DR-10' -> 'v7.0.0'``, and ``None -> None``.
+    """
     if not comment:
         return None
     m = TAG_RE.match(comment.strip())
@@ -171,7 +190,15 @@ def extract_tag(comment: Optional[str]) -> Optional[str]:
 
 
 def parse_uses(wf_paths: list[str]) -> Iterator[UsesRef]:
-    """Yield a UsesRef for each ``uses:`` line across the given workflow files."""
+    """Yield a UsesRef for each in-scope ``uses:`` line across ``wf_paths``.
+
+    ``wf_paths`` is a list of workflow-file paths (as from ``workflow_files()``).
+    A line like ``  uses: actions/checkout@11bd719...  # v7.0.0, latest`` yields
+    a UsesRef with ``ref_path='actions/checkout'``,
+    ``ref_version='11bd719...'``, and ``comment='v7.0.0, latest'`` (the whole
+    comment body). Lines whose ref is out of DR-10's scope (local ``./…``
+    actions, ``docker://…`` forms, malformed refs) are skipped.
+    """
     for wf_path in wf_paths:
         with open(wf_path, encoding="utf-8") as f:
             for lineno, line in enumerate(f, start=1):
@@ -202,6 +229,12 @@ class TagResolver:
         self.calls: int = 0
 
     def resolve(self, repo: str, tag: str) -> Optional[str]:
+        """Return the commit SHA that ``tag`` points to in ``repo``, or None if
+        the tag does not resolve.
+
+        E.g. ``resolve('actions/checkout', 'v7.0.0') -> '11bd719...'``. Each
+        ``(repo, tag)`` pair is looked up at most once and cached.
+        """
         key = (repo, tag)
         if key in self._cache:
             return self._cache[key]
@@ -256,7 +289,7 @@ class TagResolver:
                 check=False,
             )
         except FileNotFoundError:
-            sys.exit("error: 'gh' not found; --online requires the GitHub CLI")
+            sys.exit("error: 'gh' not found; --mode online requires the GitHub CLI")
         if out.returncode != 0:
             # gh writes e.g. "gh: Not Found (HTTP 404)" to stderr.
             if "HTTP 404" in out.stderr:
@@ -276,6 +309,14 @@ class TagResolver:
 
 
 def check(online: bool) -> tuple[list[Violation], Optional[TagResolver]]:
+    """Check every workflow's ``uses:`` refs against DR-10's mechanical clauses.
+
+    When ``online`` is true, the tag-resolves-to-the-pinned-SHA clause is checked
+    too (via ``gh``); when false, only the clauses verifiable without network
+    access are. Returns the list of Violations found (empty when all refs comply)
+    together with the TagResolver used when online (so the caller can report the
+    tag-lookup count), or None when offline.
+    """
     violations: list[Violation] = []
     resolver = TagResolver() if online else None
 
@@ -368,13 +409,16 @@ def main() -> int:
     description = __doc__.splitlines()[0] if __doc__ else None
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
-        "--online",
-        action="store_true",
-        help="also verify each tag comment resolves to its pinned SHA (uses gh)",
+        "-m",
+        "--mode",
+        choices=["online", "offline"],
+        default="offline",
+        help="'online' also verifies each tag comment resolves to its pinned "
+        "SHA (uses gh); 'offline' (default) runs the mechanical checks only",
     )
     args = parser.parse_args()
 
-    violations, resolver = check(args.online)
+    violations, resolver = check(online=args.mode == "online")
 
     if violations:
         for v in violations:
@@ -386,9 +430,8 @@ def main() -> int:
         )
         return 1
 
-    mode = "online" if args.online else "offline"
     extra = f" ({resolver.calls} tag lookup(s))" if resolver else ""
-    print(f"All GitHub Actions references comply with DR-10 ({mode}){extra}.")
+    print(f"All GitHub Actions references comply with DR-10 ({args.mode}){extra}.")
     return 0
 
 

--- a/hack/check-action-refs.py
+++ b/hack/check-action-refs.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check that GitHub Actions references in workflows obey design rule DR-10.
+
+See DESIGN_RULES.md (rule DR-10) for the full statement. In brief, this checks
+the *mechanical* clauses:
+
+  * First-party actions (the ``llm-d/llm-d-infra`` repo or this repo) are
+    referenced by branch ``main``.
+  * Every third-party action is pinned by a full 40-hex commit SHA and carries a
+    version-tag comment, e.g.::
+
+        uses: actions/checkout@9c091bb...  # v7.0.0
+
+  * Every reference to a given action across all workflows uses the same SHA and
+    tag.
+  * With ``--online``: the commented tag actually resolves to the pinned SHA
+    (verified via ``gh api``).
+
+It does NOT check clause (b) of DR-10 (no known vulnerabilities / soaked >=7 days /
+not egregiously stale); that clause is advisory and checked by a human or AI
+reviewer.
+
+Usage (run from the repo root)::
+
+    hack/check-action-refs.py            # offline checks only
+    hack/check-action-refs.py --online   # also verify each tag resolves to its SHA
+
+Exits non-zero and prints ``file:line: reason`` for every violation.
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterator, NamedTuple, Optional
+
+# Repositories whose actions/reusable workflows are "first-party" and therefore
+# referenced by branch "main" rather than pinned by SHA.
+FIRST_PARTY_REPOS = {
+    "llm-d/llm-d-infra",
+    "llm-d-incubation/llm-d-fast-model-actuation",
+}
+
+# A "uses:" line, capturing the reference and any trailing comment. The comment
+# is preserved because a YAML parser would discard it, and DR-10 lives there.
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)\s*(?:#\s*(?P<comment>.*))?$")
+
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# The version tag is the leading run of the comment, optionally followed by a
+# single punctuation char, then certainly whitespace or end-of-line. So
+# "v7.0.0", "v7.0.0 latest", and "v7.0.0, latest" all yield "v7.0.0".
+TAG_RE = re.compile(r"^(?P<tag>\S+?)[.,;:]?(?:\s|$)")
+
+
+class Violation(NamedTuple):
+    wf_path: str
+    lineno: int
+    ref: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.wf_path}:{self.lineno}: {self.reason} (uses: {self.ref})"
+
+
+class Pin(NamedTuple):
+    """A recorded pin of a third-party action, used by the clause-(a) same-version
+    check to compare its other references against. Fields: the pinned commit
+    ``sha``; its version-tag ``tag``; and the ``wf_path`` and ``lineno`` where this
+    pin was seen (cited when another reference disagrees)."""
+
+    sha: str
+    tag: str
+    wf_path: str
+    lineno: int
+
+
+class UsesRef(NamedTuple):
+    """One parsed ``uses:`` line.
+
+    Fields:
+      * ``wf_path``     -- path to the workflow file the line appears in.
+      * ``lineno``      -- 1-based line number within that file.
+      * ``ref_path``    -- the part of the reference before ``@`` (e.g.
+                           ``actions/checkout`` or a reusable-workflow path).
+      * ``ref_version`` -- what follows ``@``: a commit SHA or a branch/tag.
+      * ``comment``     -- the trailing ``# ...`` comment body, or None.
+      * ``ref``         -- the full reference as written, for reporting.
+    """
+
+    wf_path: str
+    lineno: int
+    ref_path: str
+    ref_version: str
+    comment: Optional[str]
+    ref: str
+
+
+def workflow_files() -> list[str]:
+    files: list[str] = []
+    for pattern in ("*.yml", "*.yaml"):
+        files.extend(glob.glob(os.path.join(".github", "workflows", pattern)))
+    return sorted(files)
+
+
+def repo_of(ref_path: str) -> str:
+    """Return owner/repo for the part of a ``uses:`` ref before the ``@``.
+
+    Handles both plain actions (``actions/checkout``) and reusable workflows
+    with a path (``llm-d/llm-d-infra/.github/workflows/x.yaml``).
+    """
+    parts = ref_path.split("/")
+    if len(parts) < 2:
+        return ref_path
+    return "/".join(parts[:2])
+
+
+def _require_object(data: object, api_path: str, key: str) -> dict:
+    """Return ``data[key]`` when both are dicts; exit hard otherwise.
+
+    Used to validate the shape of a ``gh api`` JSON payload. An unexpected shape
+    (e.g. a JSON array from a ref name that matches several refs, or a missing
+    nested object) means the API contract we rely on does not hold, so we surface
+    it rather than let it masquerade as an unresolvable tag.
+    """
+    if not isinstance(data, dict):
+        sys.exit(
+            f"error: 'gh api {api_path}' returned {type(data).__name__}, "
+            f"expected a JSON object"
+        )
+    value = data.get(key)
+    if not isinstance(value, dict):
+        sys.exit(
+            f"error: 'gh api {api_path}' response has no object at "
+            f"'{key}' (got {type(value).__name__})"
+        )
+    return value
+
+
+def extract_tag(comment: Optional[str]) -> Optional[str]:
+    """Return the version tag from a comment body, or None if absent."""
+    if not comment:
+        return None
+    m = TAG_RE.match(comment.strip())
+    return m.group("tag") if m else None
+
+
+def parse_uses(wf_paths: list[str]) -> Iterator[UsesRef]:
+    """Yield a UsesRef for each ``uses:`` line across the given workflow files."""
+    for wf_path in wf_paths:
+        with open(wf_path, encoding="utf-8") as f:
+            for lineno, line in enumerate(f, start=1):
+                m = USES_RE.match(line.rstrip("\n"))
+                if not m:
+                    continue
+                ref = m.group("ref")
+                if "@" not in ref:
+                    # Local action (./path) or malformed; DR-10 doesn't cover it.
+                    continue
+                ref_path, _, ref_version = ref.partition("@")
+                yield UsesRef(
+                    wf_path=wf_path,
+                    lineno=lineno,
+                    ref_path=ref_path,
+                    ref_version=ref_version,
+                    comment=m.group("comment"),
+                    ref=ref,
+                )
+
+
+class TagResolver:
+    """Resolves (repo, tag) -> commit SHA via ``gh api``, caching each pair."""
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, str], Optional[str]] = {}
+        self.calls: int = 0
+
+    def resolve(self, repo: str, tag: str) -> Optional[str]:
+        key = (repo, tag)
+        if key in self._cache:
+            return self._cache[key]
+        self.calls += 1
+        sha = self._resolve_uncached(repo, tag)
+        self._cache[key] = sha
+        return sha
+
+    def _resolve_uncached(self, repo: str, tag: str) -> Optional[str]:
+        # A lightweight tag points straight at a commit; an annotated tag points
+        # at a tag object that must be dereferenced. Query the ref, then follow
+        # the object if it is a tag.
+        api_path = f"repos/{repo}/git/ref/tags/{tag}"
+        obj = self._gh_ref(api_path)
+        if obj is None:
+            # gh reported no such ref: a genuinely unresolvable tag.
+            return None
+        if obj.get("type") == "tag":
+            api_path = f"repos/{repo}/git/tags/{obj['sha']}"
+            tag_obj = self._gh_api(api_path)
+            tag_target = _require_object(tag_obj, api_path, "object")
+            return tag_target.get("sha")
+        return obj.get("sha")
+
+    def _gh_ref(self, api_path: str) -> Optional[dict]:
+        """Return the ``object`` of a git-ref response, or None if gh found none.
+
+        A ref query can also return a JSON array (when the name matches several
+        refs) or an otherwise unexpected shape; those are tooling/contract
+        problems, so ``_require_object`` turns them into a hard error rather than
+        a silently-unresolvable tag.
+        """
+        data = self._gh_api(api_path)
+        if data is None:
+            return None
+        return _require_object(data, api_path, "object")
+
+    def _gh_api(self, api_path: str) -> Optional[object]:
+        """Run ``gh api <path>``.
+
+        Returns the parsed JSON (dict or list) on success, or None when gh exits
+        non-zero (e.g. a 404 for a missing tag). Exits hard if gh succeeds but
+        its output is not valid JSON, since that means the tooling is
+        misbehaving and must not be mistaken for a clean or failing check.
+        """
+        try:
+            out = subprocess.run(
+                ["gh", "api", api_path],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            sys.exit("error: 'gh' not found; --online requires the GitHub CLI")
+        if out.returncode != 0:
+            return None
+        try:
+            return json.loads(out.stdout)
+        except json.JSONDecodeError as err:
+            snippet = out.stdout.strip()[:200]
+            sys.exit(
+                f"error: 'gh api {api_path}' returned unparsable output "
+                f"({err}); got: {snippet!r}"
+            )
+
+
+def check(online: bool) -> tuple[list[Violation], Optional[TagResolver]]:
+    violations: list[Violation] = []
+    resolver = TagResolver() if online else None
+
+    # For clause (a)'s "one SHA/tag per action across all workflows": the pin
+    # recorded per third-party action, to compare its other references against.
+    pins: dict[str, Pin] = {}
+
+    for u in parse_uses(workflow_files()):
+        repo = repo_of(u.ref_path)
+        if repo in FIRST_PARTY_REPOS:
+            if u.ref_version != "main":
+                violations.append(
+                    Violation(
+                        u.wf_path,
+                        u.lineno,
+                        u.ref,
+                        f"first-party {repo} must be referenced by @main",
+                    )
+                )
+            continue
+
+        # Third-party: require SHA pin + tag comment (clause a).
+        if not FULL_SHA_RE.match(u.ref_version):
+            violations.append(
+                Violation(
+                    u.wf_path,
+                    u.lineno,
+                    u.ref,
+                    "third-party action must be pinned by full 40-hex commit SHA",
+                )
+            )
+            continue
+        tag = extract_tag(u.comment)
+        if tag is None:
+            violations.append(
+                Violation(
+                    u.wf_path,
+                    u.lineno,
+                    u.ref,
+                    "third-party SHA pin must carry a version-tag comment",
+                )
+            )
+            continue
+
+        # Clause (a): every reference to this action must use the same SHA and tag.
+        pin = pins.get(repo)
+        if pin is None:
+            pins[repo] = Pin(u.ref_version, tag, u.wf_path, u.lineno)
+        elif (u.ref_version, tag) != (pin.sha, pin.tag):
+            violations.append(
+                Violation(
+                    u.wf_path,
+                    u.lineno,
+                    u.ref,
+                    f"action {repo} is also referenced as {pin.sha} "
+                    f"(# {pin.tag}) at {pin.wf_path}:{pin.lineno}; all "
+                    f"workflows must use the same SHA and tag",
+                )
+            )
+
+        if online:
+            assert resolver is not None
+            resolved = resolver.resolve(repo, tag)
+            if resolved is None:
+                violations.append(
+                    Violation(
+                        u.wf_path,
+                        u.lineno,
+                        u.ref,
+                        f"tag {tag} could not be resolved for {repo}",
+                    )
+                )
+            elif resolved.lower() != u.ref_version.lower():
+                violations.append(
+                    Violation(
+                        u.wf_path,
+                        u.lineno,
+                        u.ref,
+                        f"comment tag {tag} resolves to {resolved}, "
+                        f"not the pinned SHA",
+                    )
+                )
+
+    return violations, resolver
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--online",
+        action="store_true",
+        help="also verify each tag comment resolves to its pinned SHA (uses gh)",
+    )
+    args = parser.parse_args()
+
+    violations, resolver = check(args.online)
+
+    if violations:
+        for v in violations:
+            print(v, file=sys.stderr)
+        print(
+            f"\n{len(violations)} GitHub Actions reference violation(s) "
+            f"of design rule DR-10; see DESIGN_RULES.md",
+            file=sys.stderr,
+        )
+        return 1
+
+    mode = "online" if args.online else "offline"
+    extra = f" ({resolver.calls} tag lookup(s))" if resolver else ""
+    print(f"All GitHub Actions references comply with DR-10 ({mode}){extra}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/check-action-refs.py
+++ b/hack/check-action-refs.py
@@ -63,7 +63,8 @@ FIRST_PARTY_REPOS = {
 # is preserved because a YAML parser would discard it, and DR-10 lives there.
 USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)\s*(?:#\s*(?P<comment>.*))?$")
 
-FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# Commit SHAs are case-insensitive hex; compare them via .lower() elsewhere.
+FULL_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 # The version tag is the leading run of the comment, optionally followed by a
 # single punctuation char, then certainly whitespace or end-of-line. So


### PR DESCRIPTION
## Summary

Addresses #524, which observed that the project accumulates cross-cutting **design rules** — conventions any change should respect but that the compiler and unit tests don't capture — yet has nowhere to write them down and nothing to check them. This PR *establishes* that place and framework; it does not claim to enumerate every such rule, so it references rather than closes the issue.

- Adds **`DESIGN_RULES.md`** as the single source of truth, framed as two tiers by *how a rule is checked*:
  - **Automation tier** — mechanical, deterministic checks (may run in more than one place). Acknowledged to predate this document in the existing pre-commit hooks and CI workflows.
  - **Subjective tier** (requires judgement) — checked by whoever does the work, agent or human; firm or advisory, with a per-rule **exception** convention.
- Populates two worked rules:
  - **DR-10 — GitHub Actions references**: first-party actions by `@main`; third-party pinned by full SHA with a resolving version-tag comment and one version per action across all workflows *(automation tier)*; version soak (≥7 days) / no known vulnerabilities / not egregiously stale *(subjective, advisory)*.
  - **DR-20 — External-process call latency logging** *(subjective)*: generalized from #495 and applied in #522.
- Enforces DR-10's mechanical clauses with **`hack/check-action-refs.py`** (offline by default; `--online` verifies each tag resolves to its SHA via `gh`), wired into **both pre-commit and a new CI workflow** (`.github/workflows/check-action-refs.yml`).
- Points agents (`AGENTS.md`) and contributors (`CONTRIBUTING.md`) at the doc; retitles CONTRIBUTING.md's review section to **"Reviewing dependency bumps"** (a GitHub Action is a kind of dependency) and drops the now-automated SHA-matches-tag step; updates the `pr-security-review` skill to match.

## Test plan

- [x] `hack/check-action-refs.py` (offline) and `--online` both exit 0 on the current tree (14 deduped tag lookups).
- [x] Verified each violation type is caught: missing tag comment, non-SHA pin, first-party not `@main`, tag→SHA mismatch (online), unresolvable tag (online), and cross-workflow version inconsistency; exception notes after the tag are tolerated.
- [x] pre-commit hook runs offline, is gated to `.github/workflows/` changes, and passes; all existing pre-commit hooks pass on the changed files.
- [x] Confirm the new `check-action-refs` CI workflow runs green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum for reviewing instructions

This PR also includes some improvements in the reviewing instructions, to keep Claude from skipping steps.