### PR TITLE
Add Prometheus metrics fma_launcher_pod_count to launcher-populator

### DIFF
--- a/charts/fma-controllers/templates/launcher-populator/deployment.yaml
+++ b/charts/fma-controllers/templates/launcher-populator/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: fma-controllers
         app.kubernetes.io/component: launcher-populator
         app.kubernetes.io/instance: {{ .Release.Name }}
+        scrape: "true"
     spec:
       serviceAccountName: {{ .Release.Name }}-fma-controllers
       containers:
@@ -30,7 +31,7 @@ spec:
             - /ko-app/launcher-populator
             - --namespace={{ .Release.Namespace }}
           ports:
-            - containerPort: 8080
+            - containerPort: 8002
               name: metrics
               protocol: TCP
           resources:

--- a/cmd/launcher-populator/main.go
+++ b/cmd/launcher-populator/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/common"
 	launcherpopulator "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/launcher-populator"
+	fmaobs "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/observability"
 	"github.com/spf13/pflag"
 
 	kubeinformers "k8s.io/client-go/informers"
@@ -42,11 +43,18 @@ func main() {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	overrides := &clientcmd.ConfigOverrides{}
 
+	obsOpts := fmaobs.DefaultOptions()
+
 	klog.InitFlags(flag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	common.AddKubernetesClientFlags(*pflag.CommandLine, loadingRules, overrides)
 	expectationTimeout := pflag.Duration("expectation-timeout", launcherpopulator.DefaultExpectationTimeout,
 		"How long to wait for the informer cache to reflect pending Pod mutations before falling back to a direct apiserver query")
+	stuckThreshold := pflag.Duration("stuck-threshold", launcherpopulator.DefaultStuckThreshold,
+		"Minimum age (since scheduling) after which a not-yet-Ready launcher is reported in the \"stuck\" phase of fma_launcher_count")
+	metricsResyncPeriod := pflag.Duration("metrics-resync-period", launcherpopulator.DefaultMetricsResyncPeriod,
+		"How often to recompute the fma_launcher_count gauge from the informer cache")
+	obsOpts.AddToFlagSet(pflag.CommandLine)
 	pflag.Parse()
 
 	// Create a context with cancellation signal
@@ -96,6 +104,8 @@ func main() {
 		kubePreInformers.Core().V1(),
 		fmaPreInformers,
 		*expectationTimeout,
+		*stuckThreshold,
+		*metricsResyncPeriod,
 	)
 	if err != nil {
 		klog.Fatal(err)
@@ -104,6 +114,9 @@ func main() {
 	// Start informers
 	kubePreInformers.Start(ctx.Done())
 	fmaPreInformers.Start(ctx.Done())
+
+	// Serve Prometheus /metrics and Go /debug/pprof.
+	obsOpts.Start(ctx)
 
 	// Start the controller in a goroutine
 	go func() {

--- a/cmd/launcher-populator/main.go
+++ b/cmd/launcher-populator/main.go
@@ -50,10 +50,10 @@ func main() {
 	common.AddKubernetesClientFlags(*pflag.CommandLine, loadingRules, overrides)
 	expectationTimeout := pflag.Duration("expectation-timeout", launcherpopulator.DefaultExpectationTimeout,
 		"How long to wait for the informer cache to reflect pending Pod mutations before falling back to a direct apiserver query")
-	pendingThreshold := pflag.Duration("pending-threshold", launcherpopulator.DefaultPendingThreshold,
-		"Minimum age (since creation) after which an unscheduled, not-yet-Ready launcher is reported in the \"pending\" phase of fma_launcher_pod_count")
-	stuckThreshold := pflag.Duration("stuck-threshold", launcherpopulator.DefaultStuckThreshold,
-		"Minimum age (since scheduling) after which a scheduled, not-yet-Ready launcher is reported in the \"stuck\" phase of fma_launcher_pod_count")
+	stuckSchedulingThreshold := pflag.Duration("stuck-scheduling-threshold", launcherpopulator.DefaultStuckSchedulingThreshold,
+		"Minimum age (since creation) after which an unscheduled launcher is reported in the \"stuck_scheduling\" phase of fma_launcher_pod_count")
+	stuckStartingThreshold := pflag.Duration("stuck-starting-threshold", launcherpopulator.DefaultStuckStartingThreshold,
+		"Minimum age (since scheduling) after which a scheduled, not-yet-Ready launcher is reported in the \"stuck_starting\" phase of fma_launcher_pod_count")
 	obsOpts.AddToFlagSet(pflag.CommandLine)
 	pflag.Parse()
 
@@ -104,8 +104,8 @@ func main() {
 		kubePreInformers.Core().V1(),
 		fmaPreInformers,
 		*expectationTimeout,
-		*pendingThreshold,
-		*stuckThreshold,
+		*stuckSchedulingThreshold,
+		*stuckStartingThreshold,
 	)
 	if err != nil {
 		klog.Fatal(err)

--- a/cmd/launcher-populator/main.go
+++ b/cmd/launcher-populator/main.go
@@ -51,9 +51,7 @@ func main() {
 	expectationTimeout := pflag.Duration("expectation-timeout", launcherpopulator.DefaultExpectationTimeout,
 		"How long to wait for the informer cache to reflect pending Pod mutations before falling back to a direct apiserver query")
 	stuckThreshold := pflag.Duration("stuck-threshold", launcherpopulator.DefaultStuckThreshold,
-		"Minimum age (since scheduling) after which a not-yet-Ready launcher is reported in the \"stuck\" phase of fma_launcher_count")
-	metricsResyncPeriod := pflag.Duration("metrics-resync-period", launcherpopulator.DefaultMetricsResyncPeriod,
-		"How often to recompute the fma_launcher_count gauge from the informer cache")
+		"Minimum age (since scheduling, or since creation when not scheduled) after which a not-yet-Ready launcher is reported in the \"stuck\" phase of fma_launcher_pod_count")
 	obsOpts.AddToFlagSet(pflag.CommandLine)
 	pflag.Parse()
 
@@ -105,7 +103,6 @@ func main() {
 		fmaPreInformers,
 		*expectationTimeout,
 		*stuckThreshold,
-		*metricsResyncPeriod,
 	)
 	if err != nil {
 		klog.Fatal(err)

--- a/cmd/launcher-populator/main.go
+++ b/cmd/launcher-populator/main.go
@@ -50,8 +50,10 @@ func main() {
 	common.AddKubernetesClientFlags(*pflag.CommandLine, loadingRules, overrides)
 	expectationTimeout := pflag.Duration("expectation-timeout", launcherpopulator.DefaultExpectationTimeout,
 		"How long to wait for the informer cache to reflect pending Pod mutations before falling back to a direct apiserver query")
+	pendingThreshold := pflag.Duration("pending-threshold", launcherpopulator.DefaultPendingThreshold,
+		"Minimum age (since creation) after which an unscheduled, not-yet-Ready launcher is reported in the \"pending\" phase of fma_launcher_pod_count")
 	stuckThreshold := pflag.Duration("stuck-threshold", launcherpopulator.DefaultStuckThreshold,
-		"Minimum age (since scheduling, or since creation when not scheduled) after which a not-yet-Ready launcher is reported in the \"stuck\" phase of fma_launcher_pod_count")
+		"Minimum age (since scheduling) after which a scheduled, not-yet-Ready launcher is reported in the \"stuck\" phase of fma_launcher_pod_count")
 	obsOpts.AddToFlagSet(pflag.CommandLine)
 	pflag.Parse()
 
@@ -102,6 +104,7 @@ func main() {
 		kubePreInformers.Core().V1(),
 		fmaPreInformers,
 		*expectationTimeout,
+		*pendingThreshold,
 		*stuckThreshold,
 	)
 	if err != nil {

--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -61,6 +61,9 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 		}
 		logger.Info("LC deleted, requeuing referencing LPPs", "config", name)
 		delete(ctl.policy.lcs, name)
+		// Drop this LC's fma_launcher_pod_count series once no launcher keeps it
+		// alive (see metricsState).
+		ctl.metrics.setLCExists(name, false)
 	} else { // LC exists: digest it
 		nodeIndep, templateHash, err = utils.BuildNodeIndependentLauncherTemplate(lc)
 		if err != nil {
@@ -78,6 +81,9 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 			templateHash:    templateHash,
 			nodeIndependent: nodeIndep,
 		}
+		// The LauncherConfig object exists, so its fma_launcher_pod_count series
+		// must exist (as explicit zeros until launchers arrive).
+		ctl.metrics.setLCExists(name, true)
 	}
 
 	if prevGood != good || good && (prevTemplateHash != templateHash) {

--- a/pkg/controller/launcher-populator/helpers.go
+++ b/pkg/controller/launcher-populator/helpers.go
@@ -59,7 +59,7 @@ func (ctl *controller) getMatchingNodeNames(ctx context.Context, labelSelector l
 }
 
 // isLauncherBoundToServerRequestingPod checks if the launcher pod is bound to any server-requesting pod
-func (ctl *controller) isLauncherBoundToServerRequestingPod(launcherPod *corev1.Pod) (bool, string) {
+func isLauncherBoundToServerRequestingPod(launcherPod *corev1.Pod) (bool, string) {
 	// Check if the launcher pod has annotations indicating assignment to a server-requesting pod
 	requesterAnnotationValue, exists := launcherPod.Annotations[common.RequesterAnnotationKey]
 	if !exists {

--- a/pkg/controller/launcher-populator/metrics.go
+++ b/pkg/controller/launcher-populator/metrics.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcherpopulator
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kubemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
+)
+
+// DefaultStuckThreshold is the default minimum age (measured from the time a
+// launcher Pod was scheduled) after which a not-yet-Ready launcher is reported
+// as "stuck". 7.5 minutes leaves room for slow image pulls while remaining
+// operationally relevant.
+const DefaultStuckThreshold = 7*time.Minute + 30*time.Second
+
+// DefaultMetricsResyncPeriod is how often the launcher-count gauge is recomputed
+// from the Pod informer cache. The "stuck" phase is a function of elapsed time,
+// so it must be recomputed on a timer rather than only on Pod events.
+const DefaultMetricsResyncPeriod = 30 * time.Second
+
+// launcherPhase is the value of the "phase" label on fma_launcher_count.
+type launcherPhase string
+
+const (
+	// phaseBound: the launcher is assigned to a server-requesting Pod.
+	phaseBound launcherPhase = "bound"
+	// phaseUnbound: the launcher uses the current template, is unbound, and is
+	// either Ready or still within the stuck threshold.
+	phaseUnbound launcherPhase = "unbound"
+	// phaseStuck: the launcher uses the current template, is unbound, has been
+	// scheduled longer than the stuck threshold, and is not Ready.
+	phaseStuck launcherPhase = "stuck"
+	// phaseStale: the launcher was built from a superseded template.
+	phaseStale launcherPhase = "stale"
+)
+
+// allLauncherPhases lists every phase value so the gauge can emit an explicit
+// zero for phases with no members. This keeps series from disappearing (which
+// would otherwise make count-based alerts flap between "0" and "no data").
+var allLauncherPhases = []launcherPhase{phaseBound, phaseUnbound, phaseStuck, phaseStale}
+
+const lcfgNameLabel = "lcfg_name"
+const phaseLabel = "phase"
+
+var (
+	metricsOnce sync.Once
+
+	// launcherCountGauge is a GaugeVec of the number of launcher Pods, labeled
+	// by LauncherConfig name and phase. It deliberately carries no Node label:
+	// a Node label would make cardinality grow with cluster size.
+	launcherCountGauge *kubemetrics.GaugeVec
+)
+
+// registerMetrics registers the launcher-populator metrics with the k8s legacy
+// registry exactly once. Safe to call from multiple NewController invocations.
+func registerMetrics() {
+	metricsOnce.Do(func() {
+		launcherCountGauge = kubemetrics.NewGaugeVec(&kubemetrics.GaugeOpts{
+			Namespace:      "fma",
+			Name:           "launcher_pod_count",
+			Help:           "Number of launcher Pods by LauncherConfig and phase (bound, unbound, stuck, stale)",
+			StabilityLevel: kubemetrics.ALPHA,
+		}, []string{lcfgNameLabel, phaseLabel})
+		legacyregistry.MustRegister(launcherCountGauge)
+	})
+}
+
+// launcherPhaseOf classifies a single (non-terminating) launcher Pod into a
+// phase. It is a pure function of the arguments so it can be unit-tested in
+// isolation. currentTemplateHash is the template hash the digest currently
+// wants for this Pod's (node, LC) key; an empty value (LC gone / not yet
+// digested) makes any templated Pod classify as stale.
+func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, stuckThreshold time.Duration, now time.Time) launcherPhase {
+	if bound, _ := ctl.isLauncherBoundToServerRequestingPod(pod); bound {
+		return phaseBound
+	}
+	if pod.Annotations[common.LauncherTemplateHashAnnotationKey] != currentTemplateHash {
+		return phaseStale
+	}
+	if !utils.IsPodReady(pod) && now.Sub(stuckReferenceTime(pod)) > stuckThreshold {
+		return phaseStuck
+	}
+	return phaseUnbound
+}
+
+// stuckReferenceTime returns the instant from which a launcher's "stuck" age is
+// measured: the time it was scheduled, when known, else its creation time.
+// Measuring from scheduling (rather than creation) avoids blaming a launcher
+// for time spent waiting in the scheduler.
+func stuckReferenceTime(pod *corev1.Pod) time.Time {
+	if cond := utils.GetPodCondition(pod, corev1.PodScheduled); cond != nil && cond.Status == corev1.ConditionTrue {
+		return cond.LastTransitionTime.Time
+	}
+	return pod.CreationTimestamp.Time
+}
+
+// runMetricsLoop recomputes the launcher-count gauge every metricsResyncPeriod
+// until ctx is cancelled. It runs one computation immediately so metrics are
+// populated without waiting a full period.
+func (ctl *controller) runMetricsLoop(ctx context.Context) {
+	logger := klog.FromContext(ctx).WithName("metrics")
+	ticker := time.NewTicker(ctl.metricsResyncPeriod)
+	defer ticker.Stop()
+	for {
+		ctl.updateLauncherCounts(logger)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// updateLauncherCounts sweeps the launcher Pods in the informer cache, tallies
+// them per (LauncherConfig, phase), and republishes launcherCountGauge.
+func (ctl *controller) updateLauncherCounts(logger klog.Logger) {
+	selector := labels.SelectorFromSet(labels.Set{
+		common.ComponentLabelKey: common.LauncherComponentLabelValue,
+	})
+	pods, err := ctl.podLister.List(selector)
+	if err != nil {
+		logger.Error(err, "Failed to list launcher Pods for metrics")
+		return
+	}
+
+	now := time.Now()
+	// counts[lcName][phase] = number of launcher Pods.
+	counts := map[string]map[launcherPhase]int{}
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		lcName := pod.Labels[common.LauncherConfigNameLabelKey]
+		if lcName == "" {
+			continue
+		}
+		key := NodeLauncherKey{
+			NodeName:           pod.Labels[common.NodeNameLabelKey],
+			LauncherConfigName: lcName,
+		}
+		currentTemplateHash := ctl.policy.snapshotForKey(key).templateHash
+		phase := ctl.launcherPhaseOf(pod, currentTemplateHash, ctl.stuckThreshold, now)
+		if counts[lcName] == nil {
+			counts[lcName] = map[launcherPhase]int{}
+		}
+		counts[lcName][phase]++
+	}
+
+	// Reset drops series for LauncherConfigs that no longer have any launcher
+	// Pods. Re-emit every phase (including zero) for each LC still present so
+	// count-based alerts see an explicit 0 rather than missing data.
+	launcherCountGauge.Reset()
+	for lcName, phases := range counts {
+		for _, phase := range allLauncherPhases {
+			launcherCountGauge.WithLabelValues(lcName, string(phase)).Set(float64(phases[phase]))
+		}
+	}
+}

--- a/pkg/controller/launcher-populator/metrics.go
+++ b/pkg/controller/launcher-populator/metrics.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubemetrics "k8s.io/component-base/metrics"
@@ -64,12 +63,6 @@ const (
 	phaseStale launcherPhase = "stale"
 )
 
-// allLauncherPhases lists every phase value so that, for every LauncherConfig
-// whose object exists or that has launcher Pods, the gauge always carries an
-// explicit value (including zero) for each phase. This keeps count-based alerts
-// from having to distinguish "0" from "no data".
-var allLauncherPhases = []launcherPhase{phaseBound, phaseUnbound, phaseStuckScheduling, phaseStuckStarting, phaseStale}
-
 const lcfgNameLabel = "lcfg_name"
 const phaseLabel = "phase"
 
@@ -96,18 +89,56 @@ func registerMetrics() {
 	})
 }
 
-// phaseCounts tallies launcher Pods by phase.
-type phaseCounts map[launcherPhase]int
+// phaseCounts tallies launcher Pods by phase. Keeping each phase as a field
+// makes unsupported phases unrepresentable in metricsState.
+type phaseCounts struct {
+	bound           int
+	unbound         int
+	stuckScheduling int
+	stuckStarting   int
+	stale           int
+}
 
 // phaseCountsByNode stores phase tallies indexed by Node name.
 type phaseCountsByNode map[string]phaseCounts
 
 func (pc phaseCounts) total() int {
-	sum := 0
-	for _, n := range pc {
-		sum += n
+	return pc.bound + pc.unbound + pc.stuckScheduling + pc.stuckStarting + pc.stale
+}
+
+func (pc *phaseCounts) addDelta(counts, oldCounts phaseCounts) {
+	pc.bound += counts.bound - oldCounts.bound
+	pc.unbound += counts.unbound - oldCounts.unbound
+	pc.stuckScheduling += counts.stuckScheduling - oldCounts.stuckScheduling
+	pc.stuckStarting += counts.stuckStarting - oldCounts.stuckStarting
+	pc.stale += counts.stale - oldCounts.stale
+}
+
+func (pc *phaseCounts) increment(phase launcherPhase) {
+	switch phase {
+	case phaseBound:
+		pc.bound++
+	case phaseUnbound:
+		pc.unbound++
+	case phaseStuckScheduling:
+		pc.stuckScheduling++
+	case phaseStuckStarting:
+		pc.stuckStarting++
+	case phaseStale:
+		pc.stale++
+	default:
+		panic("unsupported launcher phase: " + string(phase))
 	}
-	return sum
+}
+
+// forEach calls yield once for every supported metric phase, including phases
+// whose count is zero.
+func (pc phaseCounts) forEach(yield func(launcherPhase, int)) {
+	yield(phaseBound, pc.bound)
+	yield(phaseUnbound, pc.unbound)
+	yield(phaseStuckScheduling, pc.stuckScheduling)
+	yield(phaseStuckStarting, pc.stuckStarting)
+	yield(phaseStale, pc.stale)
 }
 
 // metricsState is the source of truth backing launcherPodCountGauge: it holds
@@ -145,13 +176,8 @@ func (ms *metricsState) publish(key NodeLauncherKey, counts phaseCounts) {
 	// Fold the change into the running aggregate by its delta.
 	if counts.total() != 0 || oldCounts.total() != 0 {
 		agg := ms.agg[lcfg]
-		if agg == nil {
-			agg = phaseCounts{}
-			ms.agg[lcfg] = agg
-		}
-		for _, phase := range allLauncherPhases {
-			agg[phase] += counts[phase] - oldCounts[phase]
-		}
+		agg.addDelta(counts, oldCounts)
+		ms.agg[lcfg] = agg
 	}
 
 	// Update the per-Node store, dropping empty Nodes (and the empty LC map).
@@ -190,13 +216,15 @@ func (ms *metricsState) setLCExists(lcfg string, exists bool) {
 func (ms *metricsState) republishLocked(lcfg string) {
 	if !ms.lcExists.Has(lcfg) && len(ms.perLCFG[lcfg]) == 0 {
 		delete(ms.agg, lcfg)
-		launcherPodCountGauge.DeletePartialMatch(prometheus.Labels{lcfgNameLabel: lcfg})
+		phaseCounts{}.forEach(func(phase launcherPhase, _ int) {
+			launcherPodCountGauge.DeleteLabelValues(lcfg, string(phase))
+		})
 		return
 	}
-	agg := ms.agg[lcfg] // nil when the LC exists but has no launchers -> all zeros
-	for _, phase := range allLauncherPhases {
-		launcherPodCountGauge.WithLabelValues(lcfg, string(phase)).Set(float64(agg[phase]))
-	}
+	agg := ms.agg[lcfg] // zero value when the LC exists but has no launchers
+	agg.forEach(func(phase launcherPhase, count int) {
+		launcherPodCountGauge.WithLabelValues(lcfg, string(phase)).Set(float64(count))
+	})
 }
 
 // launcherPhaseOf classifies a launcher Pod into a phase (see the launcherPhase
@@ -207,8 +235,8 @@ func (ms *metricsState) republishLocked(lcfg string) {
 // currentTemplateHash is the node-independent template hash the digest wants for
 // this Pod's LauncherConfig; an empty value (LC gone / not yet digested) makes
 // any templated Pod stale.
-func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, stuckSchedulingThreshold, stuckStartingThreshold time.Duration, now time.Time) (launcherPhase, time.Time) {
-	if bound, _ := ctl.isLauncherBoundToServerRequestingPod(pod); bound {
+func launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, stuckSchedulingThreshold, stuckStartingThreshold time.Duration, now time.Time) (launcherPhase, time.Time) {
+	if bound, _ := isLauncherBoundToServerRequestingPod(pod); bound {
 		return phaseBound, time.Time{}
 	}
 	if pod.Annotations[common.LauncherTemplateHashAnnotationKey] != currentTemplateHash {
@@ -247,8 +275,8 @@ func (ctl *controller) computeKeyPhases(pods []*corev1.Pod, templateHash string,
 	counts := phaseCounts{}
 	var earliestTransition time.Time
 	for _, pod := range pods {
-		phase, becomesOverdueAt := ctl.launcherPhaseOf(pod, templateHash, ctl.stuckSchedulingThreshold, ctl.stuckStartingThreshold, now)
-		counts[phase]++
+		phase, becomesOverdueAt := launcherPhaseOf(pod, templateHash, ctl.stuckSchedulingThreshold, ctl.stuckStartingThreshold, now)
+		counts.increment(phase)
 		if pod.DeletionTimestamp == nil && becomesOverdueAt.After(now) &&
 			(earliestTransition.IsZero() || becomesOverdueAt.Before(earliestTransition)) {
 			earliestTransition = becomesOverdueAt

--- a/pkg/controller/launcher-populator/metrics.go
+++ b/pkg/controller/launcher-populator/metrics.go
@@ -20,7 +20,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 
@@ -28,17 +30,18 @@ import (
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
 )
 
-// DefaultStuckThreshold is the default minimum age since scheduling after which
-// a scheduled-but-not-yet-Ready launcher is reported in the "stuck" phase. 7.5
-// minutes leaves room for slow image pulls while remaining operationally
-// relevant.
-const DefaultStuckThreshold = 7*time.Minute + 30*time.Second
+// DefaultStuckStartingThreshold is the default minimum age since scheduling
+// after which a scheduled-but-not-yet-Ready launcher is reported in the
+// "stuck_starting" phase. 7.5 minutes leaves room for slow image pulls while
+// remaining operationally relevant.
+const DefaultStuckStartingThreshold = 7*time.Minute + 30*time.Second
 
-// DefaultPendingThreshold is the default minimum age since creation after which
-// an unscheduled launcher is reported in the "pending" phase. Scheduling does
-// not involve a big image pull, so this is much shorter than the stuck
-// threshold; 2 minutes still leaves room for autoscaling / node warm-up.
-const DefaultPendingThreshold = 2 * time.Minute
+// DefaultStuckSchedulingThreshold is the default minimum age since creation
+// after which an unscheduled launcher is reported in the "stuck_scheduling"
+// phase. Scheduling does not involve a big image pull, so this is much shorter
+// than the stuck-starting threshold; 2 minutes still leaves room for
+// autoscaling / node warm-up.
+const DefaultStuckSchedulingThreshold = 2 * time.Minute
 
 // launcherPhase is the value of the "phase" label on fma_launcher_pod_count.
 type launcherPhase string
@@ -47,17 +50,16 @@ const (
 	// phaseBound: the launcher is assigned to a server-requesting Pod.
 	phaseBound launcherPhase = "bound"
 	// phaseUnbound: the launcher uses the current template, is unbound, and is
-	// either Ready or has not yet existed past its pending (unscheduled) or stuck
-	// (scheduled) threshold.
+	// either Ready or has not yet reached its stuck-scheduling (unscheduled) or
+	// stuck-starting (scheduled) threshold.
 	phaseUnbound launcherPhase = "unbound"
-	// phasePending: the launcher uses the current template, is unbound, is not
-	// Ready, has not been scheduled, and has existed (since creation) past the
-	// pending threshold. It is stuck getting scheduled.
-	phasePending launcherPhase = "pending"
-	// phaseStuck: the launcher uses the current template, is unbound, is not
-	// Ready, has been scheduled, and has existed (since scheduling) past the
-	// stuck threshold. It is stuck starting up (e.g. a slow image pull).
-	phaseStuck launcherPhase = "stuck"
+	// phaseStuckScheduling: the launcher uses the current template, is unbound,
+	// has not been scheduled, and has reached its stuck-scheduling threshold.
+	phaseStuckScheduling launcherPhase = "stuck_scheduling"
+	// phaseStuckStarting: the launcher uses the current template, is unbound, is
+	// not Ready, has been scheduled, and has reached its stuck-starting threshold
+	// (e.g. due to a slow image pull).
+	phaseStuckStarting launcherPhase = "stuck_starting"
 	// phaseStale: the launcher was built from a superseded template.
 	phaseStale launcherPhase = "stale"
 )
@@ -66,7 +68,7 @@ const (
 // whose object exists or that has launcher Pods, the gauge always carries an
 // explicit value (including zero) for each phase. This keeps count-based alerts
 // from having to distinguish "0" from "no data".
-var allLauncherPhases = []launcherPhase{phaseBound, phaseUnbound, phasePending, phaseStuck, phaseStale}
+var allLauncherPhases = []launcherPhase{phaseBound, phaseUnbound, phaseStuckScheduling, phaseStuckStarting, phaseStale}
 
 const lcfgNameLabel = "lcfg_name"
 const phaseLabel = "phase"
@@ -87,7 +89,7 @@ func registerMetrics() {
 		launcherPodCountGauge = kubemetrics.NewGaugeVec(&kubemetrics.GaugeOpts{
 			Namespace:      "fma",
 			Name:           "launcher_pod_count",
-			Help:           "Number of launcher Pods by LauncherConfig and phase (bound, unbound, pending, stuck, stale)",
+			Help:           "Number of launcher Pods by LauncherConfig and phase (bound, unbound, stuck_scheduling, stuck_starting, stale)",
 			StabilityLevel: kubemetrics.ALPHA,
 		}, []string{lcfgNameLabel, phaseLabel})
 		legacyregistry.MustRegister(launcherPodCountGauge)
@@ -96,6 +98,9 @@ func registerMetrics() {
 
 // phaseCounts tallies launcher Pods by phase.
 type phaseCounts map[launcherPhase]int
+
+// phaseCountsByNode stores phase tallies indexed by Node name.
+type phaseCountsByNode map[string]phaseCounts
 
 func (pc phaseCounts) total() int {
 	sum := 0
@@ -110,20 +115,20 @@ func (pc phaseCounts) total() int {
 // change.
 type metricsState struct {
 	mu sync.Mutex
-	// perNode is the phase tally of each Node with launchers, per LauncherConfig.
-	perNode map[string]map[string]phaseCounts
-	// agg is the per-LauncherConfig sum of perNode across Nodes, kept in sync
-	// incrementally so publish need not re-sum every Node.
+	// perLCFG is indexed first by LauncherConfig name, then by Node name.
+	perLCFG map[string]phaseCountsByNode
+	// agg is the per-LauncherConfig sum across Nodes, kept in sync incrementally
+	// so publish need not re-sum every Node.
 	agg map[string]phaseCounts
 	// lcExists is the set of LauncherConfig names whose object currently exists.
-	lcExists map[string]bool
+	lcExists sets.Set[string]
 }
 
 func newMetricsState() *metricsState {
 	return &metricsState{
-		perNode:  map[string]map[string]phaseCounts{},
+		perLCFG:  map[string]phaseCountsByNode{},
 		agg:      map[string]phaseCounts{},
-		lcExists: map[string]bool{},
+		lcExists: sets.New[string](),
 	}
 }
 
@@ -134,33 +139,33 @@ func (ms *metricsState) publish(key NodeLauncherKey, counts phaseCounts) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
-	nodes := ms.perNode[lcfg]
-	old := nodes[node]
+	countsByNode := ms.perLCFG[lcfg]
+	oldCounts := countsByNode[node]
 
 	// Fold the change into the running aggregate by its delta.
-	if counts.total() != 0 || old.total() != 0 {
+	if counts.total() != 0 || oldCounts.total() != 0 {
 		agg := ms.agg[lcfg]
 		if agg == nil {
 			agg = phaseCounts{}
 			ms.agg[lcfg] = agg
 		}
 		for _, phase := range allLauncherPhases {
-			agg[phase] += counts[phase] - old[phase]
+			agg[phase] += counts[phase] - oldCounts[phase]
 		}
 	}
 
 	// Update the per-Node store, dropping empty Nodes (and the empty LC map).
 	if counts.total() == 0 {
-		delete(nodes, node)
-		if len(nodes) == 0 {
-			delete(ms.perNode, lcfg)
+		delete(countsByNode, node)
+		if len(countsByNode) == 0 {
+			delete(ms.perLCFG, lcfg)
 		}
 	} else {
-		if nodes == nil {
-			nodes = map[string]phaseCounts{}
-			ms.perNode[lcfg] = nodes
+		if countsByNode == nil {
+			countsByNode = phaseCountsByNode{}
+			ms.perLCFG[lcfg] = countsByNode
 		}
-		nodes[node] = counts
+		countsByNode[node] = counts
 	}
 
 	ms.republishLocked(lcfg)
@@ -172,9 +177,9 @@ func (ms *metricsState) setLCExists(lcfg string, exists bool) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 	if exists {
-		ms.lcExists[lcfg] = true
+		ms.lcExists.Insert(lcfg)
 	} else {
-		delete(ms.lcExists, lcfg)
+		ms.lcExists.Delete(lcfg)
 	}
 	ms.republishLocked(lcfg)
 }
@@ -183,11 +188,9 @@ func (ms *metricsState) setLCExists(lcfg string, exists bool) {
 // aggregate, or deletes them once neither its object nor any launcher remains.
 // Callers must hold ms.mu.
 func (ms *metricsState) republishLocked(lcfg string) {
-	if !ms.lcExists[lcfg] && len(ms.perNode[lcfg]) == 0 {
+	if !ms.lcExists.Has(lcfg) && len(ms.perLCFG[lcfg]) == 0 {
 		delete(ms.agg, lcfg)
-		for _, phase := range allLauncherPhases {
-			launcherPodCountGauge.Delete(map[string]string{lcfgNameLabel: lcfg, phaseLabel: string(phase)})
-		}
+		launcherPodCountGauge.DeletePartialMatch(prometheus.Labels{lcfgNameLabel: lcfg})
 		return
 	}
 	agg := ms.agg[lcfg] // nil when the LC exists but has no launchers -> all zeros
@@ -197,13 +200,14 @@ func (ms *metricsState) republishLocked(lcfg string) {
 }
 
 // launcherPhaseOf classifies a launcher Pod into a phase (see the launcherPhase
-// constants) and, for one still counting down toward pending or stuck, also
-// returns the instant at which it would cross that threshold (zero Time if none).
+// constants) and, for one still counting down toward stuck-scheduling or
+// stuck-starting, also returns the instant at which it will reach that threshold
+// (zero Time if none).
 //
 // currentTemplateHash is the node-independent template hash the digest wants for
 // this Pod's LauncherConfig; an empty value (LC gone / not yet digested) makes
 // any templated Pod stale.
-func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, pendingThreshold, stuckThreshold time.Duration, now time.Time) (launcherPhase, time.Time) {
+func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, stuckSchedulingThreshold, stuckStartingThreshold time.Duration, now time.Time) (launcherPhase, time.Time) {
 	if bound, _ := ctl.isLauncherBoundToServerRequestingPod(pod); bound {
 		return phaseBound, time.Time{}
 	}
@@ -215,33 +219,35 @@ func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash stri
 	}
 	// Measure the age from scheduling (so time waiting in the scheduler is not
 	// blamed), or from creation when never scheduled (so an unschedulable
-	// launcher still surfaces, as pending).
+	// launcher still surfaces as stuck-scheduling).
 	if cond := utils.GetPodCondition(pod, corev1.PodScheduled); cond != nil && cond.Status == corev1.ConditionTrue {
-		return phaseByAge(cond.LastTransitionTime.Time, stuckThreshold, phaseStuck, now)
+		return phaseByAge(cond.LastTransitionTime.Time, stuckStartingThreshold, phaseStuckStarting, now)
 	}
-	return phaseByAge(pod.CreationTimestamp.Time, pendingThreshold, phasePending, now)
+	return phaseByAge(pod.CreationTimestamp.Time, stuckSchedulingThreshold, phaseStuckScheduling, now)
 }
 
-// phaseByAge returns overduePhase when the launcher has been not-yet-Ready past
-// threshold (measured from ref); otherwise it returns phaseUnbound plus the
-// future instant ref+threshold at which it would become overdue.
+// phaseByAge returns overduePhase when the launcher has been not-yet-Ready for
+// at least threshold (measured from ref); otherwise it returns phaseUnbound plus
+// the future instant ref+threshold at which it will become overdue.
 func phaseByAge(ref time.Time, threshold time.Duration, overduePhase launcherPhase, now time.Time) (launcherPhase, time.Time) {
-	if now.Sub(ref) > threshold {
+	overdueAt := ref.Add(threshold)
+	if !now.Before(overdueAt) {
 		return overduePhase, time.Time{}
 	}
-	return phaseUnbound, ref.Add(threshold)
+	return phaseUnbound, overdueAt
 }
 
 // computeKeyPhases classifies every launcher Pod of one (node, LC) key and
 // returns the per-phase tally plus the earliest future instant at which some
-// unbound, not-yet-Ready launcher on the current template would cross into
-// pending or stuck (zero Time if none). Pods being deleted are counted (the
-// metric counts Pod objects that exist) but never schedule a future transition.
+// unbound, not-yet-Ready launcher on the current template will reach its
+// stuck-scheduling or stuck-starting threshold (zero Time if none). Pods being
+// deleted are counted (the metric counts Pod objects that exist) but never
+// schedule a future transition.
 func (ctl *controller) computeKeyPhases(pods []*corev1.Pod, templateHash string, now time.Time) (phaseCounts, time.Time) {
 	counts := phaseCounts{}
 	var earliestTransition time.Time
 	for _, pod := range pods {
-		phase, becomesOverdueAt := ctl.launcherPhaseOf(pod, templateHash, ctl.pendingThreshold, ctl.stuckThreshold, now)
+		phase, becomesOverdueAt := ctl.launcherPhaseOf(pod, templateHash, ctl.stuckSchedulingThreshold, ctl.stuckStartingThreshold, now)
 		counts[phase]++
 		if pod.DeletionTimestamp == nil && becomesOverdueAt.After(now) &&
 			(earliestTransition.IsZero() || becomesOverdueAt.Before(earliestTransition)) {
@@ -252,9 +258,9 @@ func (ctl *controller) computeKeyPhases(pods []*corev1.Pod, templateHash string,
 }
 
 // recordLauncherPhases publishes the phase tally for one (node, LC) key and,
-// when some launcher will become pending or stuck in the future, schedules a
-// re-reconcile of the key at that instant via AddAfter, so the gauge flips
-// without a periodic sweep of all launchers.
+// when some launcher will become stuck-scheduling or stuck-starting in the
+// future, schedules a re-reconcile of the key at that instant via AddAfter, so
+// the gauge flips without a periodic sweep of all launchers.
 //
 // It is called for every key reconcile (from processKey), independent of the
 // key's desired state or whether its Node still exists, so a LauncherConfig's

--- a/pkg/controller/launcher-populator/metrics.go
+++ b/pkg/controller/launcher-populator/metrics.go
@@ -28,12 +28,17 @@ import (
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
 )
 
-// DefaultStuckThreshold is the default minimum age after which a not-yet-Ready
-// launcher is reported in the "stuck" phase. Age is measured from the time the
-// launcher was scheduled, or from its creation when it has not been scheduled.
-// 7.5 minutes leaves room for slow image pulls while remaining operationally
+// DefaultStuckThreshold is the default minimum age since scheduling after which
+// a scheduled-but-not-yet-Ready launcher is reported in the "stuck" phase. 7.5
+// minutes leaves room for slow image pulls while remaining operationally
 // relevant.
 const DefaultStuckThreshold = 7*time.Minute + 30*time.Second
+
+// DefaultPendingThreshold is the default minimum age since creation after which
+// an unscheduled launcher is reported in the "pending" phase. Scheduling does
+// not involve a big image pull, so this is much shorter than the stuck
+// threshold; 2 minutes still leaves room for autoscaling / node warm-up.
+const DefaultPendingThreshold = 2 * time.Minute
 
 // launcherPhase is the value of the "phase" label on fma_launcher_pod_count.
 type launcherPhase string
@@ -42,21 +47,26 @@ const (
 	// phaseBound: the launcher is assigned to a server-requesting Pod.
 	phaseBound launcherPhase = "bound"
 	// phaseUnbound: the launcher uses the current template, is unbound, and is
-	// either Ready or has not yet existed past the stuck threshold.
+	// either Ready or has not yet existed past its pending (unscheduled) or stuck
+	// (scheduled) threshold.
 	phaseUnbound launcherPhase = "unbound"
+	// phasePending: the launcher uses the current template, is unbound, is not
+	// Ready, has not been scheduled, and has existed (since creation) past the
+	// pending threshold. It is stuck getting scheduled.
+	phasePending launcherPhase = "pending"
 	// phaseStuck: the launcher uses the current template, is unbound, is not
-	// Ready, and has existed past the stuck threshold (measured from when it was
-	// scheduled, or from creation when it has not been scheduled).
+	// Ready, has been scheduled, and has existed (since scheduling) past the
+	// stuck threshold. It is stuck starting up (e.g. a slow image pull).
 	phaseStuck launcherPhase = "stuck"
 	// phaseStale: the launcher was built from a superseded template.
 	phaseStale launcherPhase = "stale"
 )
 
 // allLauncherPhases lists every phase value so that, for every LauncherConfig
-// that has launcher Pods, the gauge always carries an explicit value (including
-// zero) for each phase. This keeps count-based alerts from having to
-// distinguish "0" from "no data".
-var allLauncherPhases = []launcherPhase{phaseBound, phaseUnbound, phaseStuck, phaseStale}
+// whose object exists or that has launcher Pods, the gauge always carries an
+// explicit value (including zero) for each phase. This keeps count-based alerts
+// from having to distinguish "0" from "no data".
+var allLauncherPhases = []launcherPhase{phaseBound, phaseUnbound, phasePending, phaseStuck, phaseStale}
 
 const lcfgNameLabel = "lcfg_name"
 const phaseLabel = "phase"
@@ -77,7 +87,7 @@ func registerMetrics() {
 		launcherPodCountGauge = kubemetrics.NewGaugeVec(&kubemetrics.GaugeOpts{
 			Namespace:      "fma",
 			Name:           "launcher_pod_count",
-			Help:           "Number of launcher Pods by LauncherConfig and phase (bound, unbound, stuck, stale)",
+			Help:           "Number of launcher Pods by LauncherConfig and phase (bound, unbound, pending, stuck, stale)",
 			StabilityLevel: kubemetrics.ALPHA,
 		}, []string{lcfgNameLabel, phaseLabel})
 		legacyregistry.MustRegister(launcherPodCountGauge)
@@ -95,124 +105,166 @@ func (pc phaseCounts) total() int {
 	return sum
 }
 
-// metricsState is the source of truth backing launcherPodCountGauge. It holds,
-// per LauncherConfig, the per-(node, LC) key phase tallies. The gauge is
-// aggregated across nodes from this map. Keeping our own state (rather than
-// GaugeVec.Reset every period) avoids the scrape-timing splinter that Reset
-// creates and lets us delete a LauncherConfig's series only when it truly has
-// no launcher Pods left.
+// metricsState is the source of truth backing launcherPodCountGauge: it holds
+// the per-LauncherConfig launcher tallies and republishes the gauge as they
+// change.
 type metricsState struct {
-	mu      sync.Mutex
-	perLcfg map[string]map[NodeLauncherKey]phaseCounts
+	mu sync.Mutex
+	// perNode is the phase tally of each Node with launchers, per LauncherConfig.
+	perNode map[string]map[string]phaseCounts
+	// agg is the per-LauncherConfig sum of perNode across Nodes, kept in sync
+	// incrementally so publish need not re-sum every Node.
+	agg map[string]phaseCounts
+	// lcExists is the set of LauncherConfig names whose object currently exists.
+	lcExists map[string]bool
 }
 
 func newMetricsState() *metricsState {
-	return &metricsState{perLcfg: map[string]map[NodeLauncherKey]phaseCounts{}}
+	return &metricsState{
+		perNode:  map[string]map[string]phaseCounts{},
+		agg:      map[string]phaseCounts{},
+		lcExists: map[string]bool{},
+	}
 }
 
 // publish records the phase tally for one (node, LC) key and republishes the
-// affected LauncherConfig's gauge series. When a LauncherConfig has no launcher
-// Pods on any node, its series are deleted so a removed LauncherConfig does not
-// leave stale zero series behind.
+// affected LauncherConfig's gauge series.
 func (ms *metricsState) publish(key NodeLauncherKey, counts phaseCounts) {
-	lcfg := key.LauncherConfigName
+	lcfg, node := key.LauncherConfigName, key.NodeName
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
-	inner := ms.perLcfg[lcfg]
-	if counts.total() == 0 {
-		delete(inner, key)
-	} else {
-		if inner == nil {
-			inner = map[NodeLauncherKey]phaseCounts{}
-			ms.perLcfg[lcfg] = inner
+	nodes := ms.perNode[lcfg]
+	old := nodes[node]
+
+	// Fold the change into the running aggregate by its delta.
+	if counts.total() != 0 || old.total() != 0 {
+		agg := ms.agg[lcfg]
+		if agg == nil {
+			agg = phaseCounts{}
+			ms.agg[lcfg] = agg
 		}
-		inner[key] = counts
+		for _, phase := range allLauncherPhases {
+			agg[phase] += counts[phase] - old[phase]
+		}
 	}
 
-	if len(ms.perLcfg[lcfg]) == 0 {
-		delete(ms.perLcfg, lcfg)
+	// Update the per-Node store, dropping empty Nodes (and the empty LC map).
+	if counts.total() == 0 {
+		delete(nodes, node)
+		if len(nodes) == 0 {
+			delete(ms.perNode, lcfg)
+		}
+	} else {
+		if nodes == nil {
+			nodes = map[string]phaseCounts{}
+			ms.perNode[lcfg] = nodes
+		}
+		nodes[node] = counts
+	}
+
+	ms.republishLocked(lcfg)
+}
+
+// setLCExists records whether a LauncherConfig object currently exists and
+// republishes its series accordingly.
+func (ms *metricsState) setLCExists(lcfg string, exists bool) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if exists {
+		ms.lcExists[lcfg] = true
+	} else {
+		delete(ms.lcExists, lcfg)
+	}
+	ms.republishLocked(lcfg)
+}
+
+// republishLocked rewrites one LauncherConfig's gauge series from the current
+// aggregate, or deletes them once neither its object nor any launcher remains.
+// Callers must hold ms.mu.
+func (ms *metricsState) republishLocked(lcfg string) {
+	if !ms.lcExists[lcfg] && len(ms.perNode[lcfg]) == 0 {
+		delete(ms.agg, lcfg)
 		for _, phase := range allLauncherPhases {
 			launcherPodCountGauge.Delete(map[string]string{lcfgNameLabel: lcfg, phaseLabel: string(phase)})
 		}
 		return
 	}
-
-	agg := phaseCounts{}
-	for _, kc := range ms.perLcfg[lcfg] {
-		for phase, n := range kc {
-			agg[phase] += n
-		}
-	}
+	agg := ms.agg[lcfg] // nil when the LC exists but has no launchers -> all zeros
 	for _, phase := range allLauncherPhases {
 		launcherPodCountGauge.WithLabelValues(lcfg, string(phase)).Set(float64(agg[phase]))
 	}
 }
 
-// launcherPhaseOf classifies a single launcher Pod into a phase.
-// currentTemplateHash is the template hash the digest currently wants for this
-// Pod's (node, LC) key; an empty value (LC gone / not yet digested) makes any
-// templated Pod classify as stale.
-func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, stuckThreshold time.Duration, now time.Time) launcherPhase {
+// launcherPhaseOf classifies a launcher Pod into a phase (see the launcherPhase
+// constants) and, for one still counting down toward pending or stuck, also
+// returns the instant at which it would cross that threshold (zero Time if none).
+//
+// currentTemplateHash is the node-independent template hash the digest wants for
+// this Pod's LauncherConfig; an empty value (LC gone / not yet digested) makes
+// any templated Pod stale.
+func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, pendingThreshold, stuckThreshold time.Duration, now time.Time) (launcherPhase, time.Time) {
 	if bound, _ := ctl.isLauncherBoundToServerRequestingPod(pod); bound {
-		return phaseBound
+		return phaseBound, time.Time{}
 	}
 	if pod.Annotations[common.LauncherTemplateHashAnnotationKey] != currentTemplateHash {
-		return phaseStale
+		return phaseStale, time.Time{}
 	}
-	if !utils.IsPodReady(pod) && now.Sub(stuckReferenceTime(pod)) > stuckThreshold {
-		return phaseStuck
+	if utils.IsPodReady(pod) {
+		return phaseUnbound, time.Time{}
 	}
-	return phaseUnbound
+	// Measure the age from scheduling (so time waiting in the scheduler is not
+	// blamed), or from creation when never scheduled (so an unschedulable
+	// launcher still surfaces, as pending).
+	if cond := utils.GetPodCondition(pod, corev1.PodScheduled); cond != nil && cond.Status == corev1.ConditionTrue {
+		return phaseByAge(cond.LastTransitionTime.Time, stuckThreshold, phaseStuck, now)
+	}
+	return phaseByAge(pod.CreationTimestamp.Time, pendingThreshold, phasePending, now)
 }
 
-// stuckReferenceTime returns the instant from which a launcher's "stuck" age is
-// measured: the time it was scheduled, when known, else its creation time.
-// Measuring from scheduling (rather than creation) avoids blaming a launcher
-// for time spent waiting in the scheduler; a launcher that has not been
-// scheduled at all is still measured from creation, so a launcher that cannot
-// be scheduled is eventually reported as stuck.
-func stuckReferenceTime(pod *corev1.Pod) time.Time {
-	if cond := utils.GetPodCondition(pod, corev1.PodScheduled); cond != nil && cond.Status == corev1.ConditionTrue {
-		return cond.LastTransitionTime.Time
+// phaseByAge returns overduePhase when the launcher has been not-yet-Ready past
+// threshold (measured from ref); otherwise it returns phaseUnbound plus the
+// future instant ref+threshold at which it would become overdue.
+func phaseByAge(ref time.Time, threshold time.Duration, overduePhase launcherPhase, now time.Time) (launcherPhase, time.Time) {
+	if now.Sub(ref) > threshold {
+		return overduePhase, time.Time{}
 	}
-	return pod.CreationTimestamp.Time
+	return phaseUnbound, ref.Add(threshold)
 }
 
 // computeKeyPhases classifies every launcher Pod of one (node, LC) key and
 // returns the per-phase tally plus the earliest future instant at which some
-// unbound, not-yet-Ready launcher on the current template would cross the stuck
-// threshold (zero Time if none). Pods being deleted are counted (the metric
-// counts Pod objects that exist) but never schedule a future transition.
+// unbound, not-yet-Ready launcher on the current template would cross into
+// pending or stuck (zero Time if none). Pods being deleted are counted (the
+// metric counts Pod objects that exist) but never schedule a future transition.
 func (ctl *controller) computeKeyPhases(pods []*corev1.Pod, templateHash string, now time.Time) (phaseCounts, time.Time) {
 	counts := phaseCounts{}
-	var earliestStuck time.Time
+	var earliestTransition time.Time
 	for _, pod := range pods {
-		phase := ctl.launcherPhaseOf(pod, templateHash, ctl.stuckThreshold, now)
+		phase, becomesOverdueAt := ctl.launcherPhaseOf(pod, templateHash, ctl.pendingThreshold, ctl.stuckThreshold, now)
 		counts[phase]++
-		if pod.DeletionTimestamp == nil && phase == phaseUnbound && !utils.IsPodReady(pod) {
-			becomesStuckAt := stuckReferenceTime(pod).Add(ctl.stuckThreshold)
-			if becomesStuckAt.After(now) && (earliestStuck.IsZero() || becomesStuckAt.Before(earliestStuck)) {
-				earliestStuck = becomesStuckAt
-			}
+		if pod.DeletionTimestamp == nil && becomesOverdueAt.After(now) &&
+			(earliestTransition.IsZero() || becomesOverdueAt.Before(earliestTransition)) {
+			earliestTransition = becomesOverdueAt
 		}
 	}
-	return counts, earliestStuck
+	return counts, earliestTransition
 }
 
 // recordLauncherPhases publishes the phase tally for one (node, LC) key and,
-// when some launcher will become "stuck" in the future, schedules a
-// re-reconcile of the key at that instant via AddAfter, so the gauge flips to
-// "stuck" without a periodic sweep of all launchers.
+// when some launcher will become pending or stuck in the future, schedules a
+// re-reconcile of the key at that instant via AddAfter, so the gauge flips
+// without a periodic sweep of all launchers.
 //
 // It is called for every key reconcile (from processKey), independent of the
 // key's desired state or whether its Node still exists, so a LauncherConfig's
-// series are always kept current and are deleted once it has no launcher Pods.
+// series are always kept current and are deleted once it has neither launcher
+// Pods nor an existing LauncherConfig object.
 func (ctl *controller) recordLauncherPhases(key NodeLauncherKey, pods []*corev1.Pod, templateHash string) {
-	now := time.Now()
-	counts, earliestStuck := ctl.computeKeyPhases(pods, templateHash, now)
+	now := ctl.clock.Now()
+	counts, earliestTransition := ctl.computeKeyPhases(pods, templateHash, now)
 	ctl.metrics.publish(key, counts)
-	if !earliestStuck.IsZero() {
-		ctl.keyQueue.Queue.AddAfter(keyItem{NodeLauncherKey: key}, earliestStuck.Sub(now))
+	if !earliestTransition.IsZero() {
+		ctl.keyQueue.Queue.AddAfter(keyItem{NodeLauncherKey: key}, earliestTransition.Sub(now))
 	}
 }

--- a/pkg/controller/launcher-populator/metrics.go
+++ b/pkg/controller/launcher-populator/metrics.go
@@ -17,50 +17,45 @@ limitations under the License.
 package launcherpopulator
 
 import (
-	"context"
 	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	kubemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog/v2"
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/utils"
 )
 
-// DefaultStuckThreshold is the default minimum age (measured from the time a
-// launcher Pod was scheduled) after which a not-yet-Ready launcher is reported
-// as "stuck". 7.5 minutes leaves room for slow image pulls while remaining
-// operationally relevant.
+// DefaultStuckThreshold is the default minimum age after which a not-yet-Ready
+// launcher is reported in the "stuck" phase. Age is measured from the time the
+// launcher was scheduled, or from its creation when it has not been scheduled.
+// 7.5 minutes leaves room for slow image pulls while remaining operationally
+// relevant.
 const DefaultStuckThreshold = 7*time.Minute + 30*time.Second
 
-// DefaultMetricsResyncPeriod is how often the launcher-count gauge is recomputed
-// from the Pod informer cache. The "stuck" phase is a function of elapsed time,
-// so it must be recomputed on a timer rather than only on Pod events.
-const DefaultMetricsResyncPeriod = 30 * time.Second
-
-// launcherPhase is the value of the "phase" label on fma_launcher_count.
+// launcherPhase is the value of the "phase" label on fma_launcher_pod_count.
 type launcherPhase string
 
 const (
 	// phaseBound: the launcher is assigned to a server-requesting Pod.
 	phaseBound launcherPhase = "bound"
 	// phaseUnbound: the launcher uses the current template, is unbound, and is
-	// either Ready or still within the stuck threshold.
+	// either Ready or has not yet existed past the stuck threshold.
 	phaseUnbound launcherPhase = "unbound"
-	// phaseStuck: the launcher uses the current template, is unbound, has been
-	// scheduled longer than the stuck threshold, and is not Ready.
+	// phaseStuck: the launcher uses the current template, is unbound, is not
+	// Ready, and has existed past the stuck threshold (measured from when it was
+	// scheduled, or from creation when it has not been scheduled).
 	phaseStuck launcherPhase = "stuck"
 	// phaseStale: the launcher was built from a superseded template.
 	phaseStale launcherPhase = "stale"
 )
 
-// allLauncherPhases lists every phase value so the gauge can emit an explicit
-// zero for phases with no members. This keeps series from disappearing (which
-// would otherwise make count-based alerts flap between "0" and "no data").
+// allLauncherPhases lists every phase value so that, for every LauncherConfig
+// that has launcher Pods, the gauge always carries an explicit value (including
+// zero) for each phase. This keeps count-based alerts from having to
+// distinguish "0" from "no data".
 var allLauncherPhases = []launcherPhase{phaseBound, phaseUnbound, phaseStuck, phaseStale}
 
 const lcfgNameLabel = "lcfg_name"
@@ -69,31 +64,95 @@ const phaseLabel = "phase"
 var (
 	metricsOnce sync.Once
 
-	// launcherCountGauge is a GaugeVec of the number of launcher Pods, labeled
+	// launcherPodCountGauge is a GaugeVec of the number of launcher Pods, labeled
 	// by LauncherConfig name and phase. It deliberately carries no Node label:
 	// a Node label would make cardinality grow with cluster size.
-	launcherCountGauge *kubemetrics.GaugeVec
+	launcherPodCountGauge *kubemetrics.GaugeVec
 )
 
 // registerMetrics registers the launcher-populator metrics with the k8s legacy
 // registry exactly once. Safe to call from multiple NewController invocations.
 func registerMetrics() {
 	metricsOnce.Do(func() {
-		launcherCountGauge = kubemetrics.NewGaugeVec(&kubemetrics.GaugeOpts{
+		launcherPodCountGauge = kubemetrics.NewGaugeVec(&kubemetrics.GaugeOpts{
 			Namespace:      "fma",
 			Name:           "launcher_pod_count",
 			Help:           "Number of launcher Pods by LauncherConfig and phase (bound, unbound, stuck, stale)",
 			StabilityLevel: kubemetrics.ALPHA,
 		}, []string{lcfgNameLabel, phaseLabel})
-		legacyregistry.MustRegister(launcherCountGauge)
+		legacyregistry.MustRegister(launcherPodCountGauge)
 	})
 }
 
-// launcherPhaseOf classifies a single (non-terminating) launcher Pod into a
-// phase. It is a pure function of the arguments so it can be unit-tested in
-// isolation. currentTemplateHash is the template hash the digest currently
-// wants for this Pod's (node, LC) key; an empty value (LC gone / not yet
-// digested) makes any templated Pod classify as stale.
+// phaseCounts tallies launcher Pods by phase.
+type phaseCounts map[launcherPhase]int
+
+func (pc phaseCounts) total() int {
+	sum := 0
+	for _, n := range pc {
+		sum += n
+	}
+	return sum
+}
+
+// metricsState is the source of truth backing launcherPodCountGauge. It holds,
+// per LauncherConfig, the per-(node, LC) key phase tallies. The gauge is
+// aggregated across nodes from this map. Keeping our own state (rather than
+// GaugeVec.Reset every period) avoids the scrape-timing splinter that Reset
+// creates and lets us delete a LauncherConfig's series only when it truly has
+// no launcher Pods left.
+type metricsState struct {
+	mu      sync.Mutex
+	perLcfg map[string]map[NodeLauncherKey]phaseCounts
+}
+
+func newMetricsState() *metricsState {
+	return &metricsState{perLcfg: map[string]map[NodeLauncherKey]phaseCounts{}}
+}
+
+// publish records the phase tally for one (node, LC) key and republishes the
+// affected LauncherConfig's gauge series. When a LauncherConfig has no launcher
+// Pods on any node, its series are deleted so a removed LauncherConfig does not
+// leave stale zero series behind.
+func (ms *metricsState) publish(key NodeLauncherKey, counts phaseCounts) {
+	lcfg := key.LauncherConfigName
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	inner := ms.perLcfg[lcfg]
+	if counts.total() == 0 {
+		delete(inner, key)
+	} else {
+		if inner == nil {
+			inner = map[NodeLauncherKey]phaseCounts{}
+			ms.perLcfg[lcfg] = inner
+		}
+		inner[key] = counts
+	}
+
+	if len(ms.perLcfg[lcfg]) == 0 {
+		delete(ms.perLcfg, lcfg)
+		for _, phase := range allLauncherPhases {
+			launcherPodCountGauge.Delete(map[string]string{lcfgNameLabel: lcfg, phaseLabel: string(phase)})
+		}
+		return
+	}
+
+	agg := phaseCounts{}
+	for _, kc := range ms.perLcfg[lcfg] {
+		for phase, n := range kc {
+			agg[phase] += n
+		}
+	}
+	for _, phase := range allLauncherPhases {
+		launcherPodCountGauge.WithLabelValues(lcfg, string(phase)).Set(float64(agg[phase]))
+	}
+}
+
+// launcherPhaseOf classifies a single launcher Pod into a phase.
+// currentTemplateHash is the template hash the digest currently wants for this
+// Pod's (node, LC) key; an empty value (LC gone / not yet digested) makes any
+// templated Pod classify as stale.
 func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash string, stuckThreshold time.Duration, now time.Time) launcherPhase {
 	if bound, _ := ctl.isLauncherBoundToServerRequestingPod(pod); bound {
 		return phaseBound
@@ -110,7 +169,9 @@ func (ctl *controller) launcherPhaseOf(pod *corev1.Pod, currentTemplateHash stri
 // stuckReferenceTime returns the instant from which a launcher's "stuck" age is
 // measured: the time it was scheduled, when known, else its creation time.
 // Measuring from scheduling (rather than creation) avoids blaming a launcher
-// for time spent waiting in the scheduler.
+// for time spent waiting in the scheduler; a launcher that has not been
+// scheduled at all is still measured from creation, so a launcher that cannot
+// be scheduled is eventually reported as stuck.
 func stuckReferenceTime(pod *corev1.Pod) time.Time {
 	if cond := utils.GetPodCondition(pod, corev1.PodScheduled); cond != nil && cond.Status == corev1.ConditionTrue {
 		return cond.LastTransitionTime.Time
@@ -118,65 +179,40 @@ func stuckReferenceTime(pod *corev1.Pod) time.Time {
 	return pod.CreationTimestamp.Time
 }
 
-// runMetricsLoop recomputes the launcher-count gauge every metricsResyncPeriod
-// until ctx is cancelled. It runs one computation immediately so metrics are
-// populated without waiting a full period.
-func (ctl *controller) runMetricsLoop(ctx context.Context) {
-	logger := klog.FromContext(ctx).WithName("metrics")
-	ticker := time.NewTicker(ctl.metricsResyncPeriod)
-	defer ticker.Stop()
-	for {
-		ctl.updateLauncherCounts(logger)
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
+// computeKeyPhases classifies every launcher Pod of one (node, LC) key and
+// returns the per-phase tally plus the earliest future instant at which some
+// unbound, not-yet-Ready launcher on the current template would cross the stuck
+// threshold (zero Time if none). Pods being deleted are counted (the metric
+// counts Pod objects that exist) but never schedule a future transition.
+func (ctl *controller) computeKeyPhases(pods []*corev1.Pod, templateHash string, now time.Time) (phaseCounts, time.Time) {
+	counts := phaseCounts{}
+	var earliestStuck time.Time
+	for _, pod := range pods {
+		phase := ctl.launcherPhaseOf(pod, templateHash, ctl.stuckThreshold, now)
+		counts[phase]++
+		if pod.DeletionTimestamp == nil && phase == phaseUnbound && !utils.IsPodReady(pod) {
+			becomesStuckAt := stuckReferenceTime(pod).Add(ctl.stuckThreshold)
+			if becomesStuckAt.After(now) && (earliestStuck.IsZero() || becomesStuckAt.Before(earliestStuck)) {
+				earliestStuck = becomesStuckAt
+			}
 		}
 	}
+	return counts, earliestStuck
 }
 
-// updateLauncherCounts sweeps the launcher Pods in the informer cache, tallies
-// them per (LauncherConfig, phase), and republishes launcherCountGauge.
-func (ctl *controller) updateLauncherCounts(logger klog.Logger) {
-	selector := labels.SelectorFromSet(labels.Set{
-		common.ComponentLabelKey: common.LauncherComponentLabelValue,
-	})
-	pods, err := ctl.podLister.List(selector)
-	if err != nil {
-		logger.Error(err, "Failed to list launcher Pods for metrics")
-		return
-	}
-
+// recordLauncherPhases publishes the phase tally for one (node, LC) key and,
+// when some launcher will become "stuck" in the future, schedules a
+// re-reconcile of the key at that instant via AddAfter, so the gauge flips to
+// "stuck" without a periodic sweep of all launchers.
+//
+// It is called for every key reconcile (from processKey), independent of the
+// key's desired state or whether its Node still exists, so a LauncherConfig's
+// series are always kept current and are deleted once it has no launcher Pods.
+func (ctl *controller) recordLauncherPhases(key NodeLauncherKey, pods []*corev1.Pod, templateHash string) {
 	now := time.Now()
-	// counts[lcName][phase] = number of launcher Pods.
-	counts := map[string]map[launcherPhase]int{}
-	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil {
-			continue
-		}
-		lcName := pod.Labels[common.LauncherConfigNameLabelKey]
-		if lcName == "" {
-			continue
-		}
-		key := NodeLauncherKey{
-			NodeName:           pod.Labels[common.NodeNameLabelKey],
-			LauncherConfigName: lcName,
-		}
-		currentTemplateHash := ctl.policy.snapshotForKey(key).templateHash
-		phase := ctl.launcherPhaseOf(pod, currentTemplateHash, ctl.stuckThreshold, now)
-		if counts[lcName] == nil {
-			counts[lcName] = map[launcherPhase]int{}
-		}
-		counts[lcName][phase]++
-	}
-
-	// Reset drops series for LauncherConfigs that no longer have any launcher
-	// Pods. Re-emit every phase (including zero) for each LC still present so
-	// count-based alerts see an explicit 0 rather than missing data.
-	launcherCountGauge.Reset()
-	for lcName, phases := range counts {
-		for _, phase := range allLauncherPhases {
-			launcherCountGauge.WithLabelValues(lcName, string(phase)).Set(float64(phases[phase]))
-		}
+	counts, earliestStuck := ctl.computeKeyPhases(pods, templateHash, now)
+	ctl.metrics.publish(key, counts)
+	if !earliestStuck.IsZero() {
+		ctl.keyQueue.Queue.AddAfter(keyItem{NodeLauncherKey: key}, earliestStuck.Sub(now))
 	}
 }

--- a/pkg/controller/launcher-populator/metrics_test.go
+++ b/pkg/controller/launcher-populator/metrics_test.go
@@ -17,18 +17,25 @@ limitations under the License.
 package launcherpopulator
 
 import (
+	"fmt"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/component-base/metrics/legacyregistry"
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
+	genctlr "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic"
 )
 
 const testTemplateHash = "hash-current"
 
-// launcherPodBuilder builds a launcher Pod for classification tests.
+// launcherPodBuilder builds a launcher Pod for classification tests. All
+// timestamps are supplied by tests so classification is deterministic.
 type launcherPodBuilder struct {
 	pod corev1.Pod
 }
@@ -42,8 +49,15 @@ func newLauncherPod() *launcherPodBuilder {
 	}}
 }
 
+// hash overrides the template-hash annotation (to model a superseded template).
 func (b *launcherPodBuilder) hash(h string) *launcherPodBuilder {
 	b.pod.Annotations[common.LauncherTemplateHashAnnotationKey] = h
+	return b
+}
+
+// noHash removes the template-hash annotation entirely.
+func (b *launcherPodBuilder) noHash() *launcherPodBuilder {
+	delete(b.pod.Annotations, common.LauncherTemplateHashAnnotationKey)
 	return b
 }
 
@@ -74,69 +88,128 @@ func (b *launcherPodBuilder) createdAt(t time.Time) *launcherPodBuilder {
 	return b
 }
 
+// deleting marks the Pod as terminating (DeletionTimestamp set).
+func (b *launcherPodBuilder) deleting() *launcherPodBuilder {
+	dt := metav1.NewTime(time.Date(2026, 6, 21, 11, 0, 0, 0, time.UTC))
+	b.pod.DeletionTimestamp = &dt
+	return b
+}
+
 func (b *launcherPodBuilder) build() *corev1.Pod { return &b.pod }
 
+// Classification input dimensions, enumerated exhaustively by
+// TestLauncherPhaseOf.
+type hashKind int
+
+const (
+	hashMatches hashKind = iota // annotation equals the current template hash
+	hashDiffers                 // annotation present but superseded
+	hashAbsent                  // annotation missing
+)
+
+type ageKind int
+
+const (
+	ageYoung                ageKind = iota // younger than the stuck threshold
+	ageOldUnscheduled                      // older than threshold, never scheduled
+	ageOldScheduledLongAgo                 // older than threshold, scheduled long ago
+	ageOldScheduledRecently                // created long ago but scheduled recently
+)
+
+var (
+	hashKindNames = map[hashKind]string{hashMatches: "hashMatches", hashDiffers: "hashDiffers", hashAbsent: "hashAbsent"}
+	ageKindNames  = map[ageKind]string{ageYoung: "young", ageOldUnscheduled: "oldUnscheduled", ageOldScheduledLongAgo: "oldSchedLongAgo", ageOldScheduledRecently: "oldSchedRecently"}
+	allHashKinds  = []hashKind{hashMatches, hashDiffers, hashAbsent}
+	allAgeKinds   = []ageKind{ageYoung, ageOldUnscheduled, ageOldScheduledLongAgo, ageOldScheduledRecently}
+)
+
+// buildClassifyPod constructs a launcher Pod for the given input dimensions.
+// It only wires inputs; it does not encode the expected classification.
+func buildClassifyPod(now time.Time, bound bool, hk hashKind, ready bool, age ageKind) *corev1.Pod {
+	old := now.Add(-10 * time.Minute)   // older than the 7.5m threshold
+	recent := now.Add(-1 * time.Minute) // younger than the threshold
+	b := newLauncherPod()               // defaults to the current template hash
+	switch hk {
+	case hashDiffers:
+		b.hash("superseded")
+	case hashAbsent:
+		b.noHash()
+	}
+	if bound {
+		b.bound()
+	}
+	if ready {
+		b.ready()
+	}
+	switch age {
+	case ageYoung:
+		b.createdAt(recent).scheduledAt(recent)
+	case ageOldUnscheduled:
+		b.createdAt(old) // no PodScheduled condition
+	case ageOldScheduledLongAgo:
+		b.createdAt(old).scheduledAt(old)
+	case ageOldScheduledRecently:
+		b.createdAt(old).scheduledAt(recent)
+	}
+	return b.build()
+}
+
+// TestLauncherPhaseOf exhaustively covers the cross product of the
+// classification inputs: bound/unbound x hash(matches/differs/absent) x
+// ready/not x four age buckets (2*3*2*4 = 48). Inputs are generated
+// programmatically; expected phases are hand-authored per block (constants for
+// the short-circuit blocks, an explicit map for the age-dependent block) so the
+// oracle never re-implements launcherPhaseOf.
 func TestLauncherPhaseOf(t *testing.T) {
 	ctl := &controller{}
 	const threshold = 7*time.Minute + 30*time.Second
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
-	long := now.Add(-10 * time.Minute) // older than threshold
-	short := now.Add(-1 * time.Minute) // younger than threshold
 
-	cases := []struct {
-		name string
-		pod  *corev1.Pod
-		want launcherPhase
-	}{
-		{
-			name: "bound wins over everything",
-			pod:  newLauncherPod().bound().hash("stale-hash").scheduledAt(long).build(),
-			want: phaseBound,
-		},
-		{
-			name: "stale template hash",
-			pod:  newLauncherPod().hash("stale-hash").scheduledAt(short).build(),
-			want: phaseStale,
-		},
-		{
-			name: "stuck: current hash, not ready, scheduled long ago",
-			pod:  newLauncherPod().scheduledAt(long).build(),
-			want: phaseStuck,
-		},
-		{
-			name: "unbound: current hash, ready even if old",
-			pod:  newLauncherPod().ready().scheduledAt(long).build(),
-			want: phaseUnbound,
-		},
-		{
-			name: "unbound: current hash, not ready but young",
-			pod:  newLauncherPod().scheduledAt(short).build(),
-			want: phaseUnbound,
-		},
-		{
-			name: "stuck via creation-time fallback when no PodScheduled condition",
-			pod:  newLauncherPod().createdAt(long).build(),
-			want: phaseStuck,
-		},
-		{
-			name: "unbound: created long ago but scheduled recently (measure from scheduling)",
-			pod:  newLauncherPod().createdAt(now.Add(-20 * time.Minute)).scheduledAt(short).build(),
-			want: phaseUnbound,
-		},
-		{
-			name: "stale beats stuck: superseded template never reported stuck",
-			pod:  newLauncherPod().hash("stale-hash").scheduledAt(long).build(),
-			want: phaseStale,
-		},
+	check := func(t *testing.T, bound bool, hk hashKind, ready bool, age ageKind, want launcherPhase) {
+		t.Helper()
+		pod := buildClassifyPod(now, bound, hk, ready, age)
+		if got := ctl.launcherPhaseOf(pod, testTemplateHash, threshold, now); got != want {
+			t.Errorf("bound=%v hash=%s ready=%v age=%s: got %q, want %q",
+				bound, hashKindNames[hk], ready, ageKindNames[age], got, want)
+		}
+	}
+	run := func(t *testing.T, bound bool, hk hashKind, ready bool, age ageKind, want launcherPhase) {
+		name := fmt.Sprintf("bound=%v/%s/ready=%v/%s", bound, hashKindNames[hk], ready, ageKindNames[age])
+		t.Run(name, func(t *testing.T) { check(t, bound, hk, ready, age, want) })
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := ctl.launcherPhaseOf(tc.pod, testTemplateHash, threshold, now)
-			if got != tc.want {
-				t.Errorf("launcherPhaseOf() = %q, want %q", got, tc.want)
+	// Block 1 (24): bound short-circuits every other attribute -> always bound.
+	for _, hk := range allHashKinds {
+		for _, ready := range []bool{true, false} {
+			for _, age := range allAgeKinds {
+				run(t, true, hk, ready, age, phaseBound)
 			}
-		})
+		}
+	}
+
+	// Block 2 (16): unbound + wrong/absent hash -> always stale.
+	for _, hk := range []hashKind{hashDiffers, hashAbsent} {
+		for _, ready := range []bool{true, false} {
+			for _, age := range allAgeKinds {
+				run(t, false, hk, ready, age, phaseStale)
+			}
+		}
+	}
+
+	// Block 3 (4): unbound + matching hash + Ready -> always unbound.
+	for _, age := range allAgeKinds {
+		run(t, false, hashMatches, true, age, phaseUnbound)
+	}
+
+	// Block 4 (4): unbound + matching hash + not Ready -> depends on age.
+	wantByAge := map[ageKind]launcherPhase{
+		ageYoung:                phaseUnbound,
+		ageOldUnscheduled:       phaseStuck,
+		ageOldScheduledLongAgo:  phaseStuck,
+		ageOldScheduledRecently: phaseUnbound,
+	}
+	for _, age := range allAgeKinds {
+		run(t, false, hashMatches, false, age, wantByAge[age])
 	}
 }
 
@@ -150,4 +223,397 @@ func TestLauncherPhaseOfEmptyCurrentHash(t *testing.T) {
 	if got := ctl.launcherPhaseOf(pod, "", DefaultStuckThreshold, now); got != phaseStale {
 		t.Errorf("launcherPhaseOf() with empty current hash = %q, want %q", got, phaseStale)
 	}
+}
+
+// gatheredPhases returns the fma_launcher_pod_count series currently present
+// for one LauncherConfig, as phase->value. It reads the registry directly (not
+// WithLabelValues, which would lazily create a missing series at 0), so a
+// deleted series is observably absent and an explicit zero is observably
+// present.
+func gatheredPhases(t *testing.T, lcfg string) map[string]float64 {
+	t.Helper()
+	mfs, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+	out := map[string]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != "fma_launcher_pod_count" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var name, phase string
+			for _, lp := range m.GetLabel() {
+				switch lp.GetName() {
+				case lcfgNameLabel:
+					name = lp.GetValue()
+				case phaseLabel:
+					phase = lp.GetValue()
+				}
+			}
+			if name == lcfg {
+				out[phase] = m.GetGauge().GetValue()
+			}
+		}
+	}
+	return out
+}
+
+// seriesCountForLcfg returns how many fma_launcher_pod_count series exist for
+// the given LauncherConfig.
+func seriesCountForLcfg(t *testing.T, lcfg string) int {
+	t.Helper()
+	return len(gatheredPhases(t, lcfg))
+}
+
+// assertLcfgPhases asserts the exact set of phase series (values and presence)
+// for one lcfg.
+func assertLcfgPhases(t *testing.T, lcfg string, bound, unbound, stuck, stale int) {
+	t.Helper()
+	got := gatheredPhases(t, lcfg)
+	want := map[string]float64{
+		string(phaseBound):   float64(bound),
+		string(phaseUnbound): float64(unbound),
+		string(phaseStuck):   float64(stuck),
+		string(phaseStale):   float64(stale),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("lcfg %q phases = %v, want %v", lcfg, got, want)
+	}
+}
+
+// TestMetricsStatePublish verifies cross-node aggregation, per-phase Set
+// (including explicit zeros — proven by the series count, not by a value read),
+// overwrite/re-aggregation, and true deletion of a LauncherConfig's series once
+// it has no launcher Pods on any node.
+func TestMetricsStatePublish(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset() // isolate this test's series from others
+	ms := newMetricsState()
+	const lcfg = "lc-publish-test"
+	keyA := NodeLauncherKey{NodeName: "nodeA", LauncherConfigName: lcfg}
+	keyB := NodeLauncherKey{NodeName: "nodeB", LauncherConfigName: lcfg}
+
+	// The steps below share ms/gauge state and must run in order.
+	t.Run("aggregate across nodes", func(t *testing.T) {
+		// All four phases must be present (count == 4 proves bound/stale exist as
+		// explicit zeros, not just that a value read returns 0).
+		ms.publish(keyA, phaseCounts{phaseUnbound: 2})
+		ms.publish(keyB, phaseCounts{phaseUnbound: 1, phaseStuck: 1})
+		if n := seriesCountForLcfg(t, lcfg); n != 4 {
+			t.Errorf("series count = %d, want 4 (all phases present incl. explicit zeros)", n)
+		}
+		assertLcfgPhases(t, lcfg, 0, 3, 1, 0)
+	})
+
+	t.Run("overwrite key re-aggregates", func(t *testing.T) {
+		// Overwriting an existing, still-nonzero key must recompute (not
+		// accumulate) the aggregate from the replaced counts.
+		ms.publish(keyA, phaseCounts{phaseUnbound: 5, phaseBound: 1})
+		if n := seriesCountForLcfg(t, lcfg); n != 4 {
+			t.Errorf("series count = %d, want 4 after overwrite", n)
+		}
+		assertLcfgPhases(t, lcfg, 1, 6, 1, 0)
+	})
+
+	t.Run("drop one node keeps lcfg", func(t *testing.T) {
+		ms.publish(keyA, phaseCounts{})
+		if _, ok := ms.perLcfg[lcfg][keyA]; ok {
+			t.Error("keyA should be removed from perLcfg after dropping to zero")
+		}
+		if n := seriesCountForLcfg(t, lcfg); n != 4 {
+			t.Errorf("series count = %d, want 4 while nodeB still has launchers", n)
+		}
+		assertLcfgPhases(t, lcfg, 0, 1, 1, 0)
+	})
+
+	t.Run("delete last node removes series", func(t *testing.T) {
+		// The series must be truly gone from the registry (not left as stale
+		// zeros) — the whole point of metricsState — so assert absence via the
+		// count, not a value read.
+		ms.publish(keyB, phaseCounts{})
+		if _, ok := ms.perLcfg[lcfg]; ok {
+			t.Error("lcfg should be removed from perLcfg once no node has launchers")
+		}
+		if n := seriesCountForLcfg(t, lcfg); n != 0 {
+			t.Errorf("series count = %d, want 0 (series must be deleted, not left as zeros)", n)
+		}
+	})
+}
+
+// TestMetricsStatePublishZeroForAbsentKey covers publishing a zero count for a
+// key that was never present (nil inner map): it must not panic and must leave
+// no series.
+func TestMetricsStatePublishZeroForAbsentKey(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset()
+	ms := newMetricsState()
+	ms.publish(NodeLauncherKey{NodeName: "n", LauncherConfigName: "never"}, phaseCounts{})
+	if len(ms.perLcfg) != 0 {
+		t.Errorf("perLcfg should stay empty, got %v", ms.perLcfg)
+	}
+	if n := seriesCountForLcfg(t, "never"); n != 0 {
+		t.Errorf("series count = %d, want 0", n)
+	}
+}
+
+// TestMetricsStatePublishIndependentLcfgs verifies that two LauncherConfigs do
+// not interfere: aggregation is per-lcfg and deleting one leaves the other.
+func TestMetricsStatePublishIndependentLcfgs(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset()
+	ms := newMetricsState()
+	const lcX, lcY = "lc-x", "lc-y"
+
+	t.Run("both present independently", func(t *testing.T) {
+		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{phaseUnbound: 2})
+		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcY}, phaseCounts{phaseStuck: 1})
+		if n := seriesCountForLcfg(t, lcX); n != 4 {
+			t.Errorf("lcX series count = %d, want 4", n)
+		}
+		if n := seriesCountForLcfg(t, lcY); n != 4 {
+			t.Errorf("lcY series count = %d, want 4", n)
+		}
+		assertLcfgPhases(t, lcX, 0, 2, 0, 0)
+		assertLcfgPhases(t, lcY, 0, 0, 1, 0)
+	})
+
+	t.Run("deleting one keeps the other", func(t *testing.T) {
+		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{})
+		if _, ok := ms.perLcfg[lcY]; !ok {
+			t.Error("lcY must survive deletion of lcX")
+		}
+		if n := seriesCountForLcfg(t, lcX); n != 0 {
+			t.Errorf("lcX series count = %d, want 0 after deletion", n)
+		}
+		if n := seriesCountForLcfg(t, lcY); n != 4 {
+			t.Errorf("lcY series count = %d, want 4 (untouched)", n)
+		}
+		assertLcfgPhases(t, lcY, 0, 0, 1, 0)
+	})
+}
+
+// TestMetricsStatePublishConcurrent exercises the mutex in publish. Run with
+// -race to catch unsynchronized access to perLcfg / the gauge.
+func TestMetricsStatePublishConcurrent(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset()
+	ms := newMetricsState()
+	const lcfg = "lc-concurrent"
+	const nKeys = 32
+
+	var wg sync.WaitGroup
+	for i := 0; i < nKeys; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := NodeLauncherKey{NodeName: fmt.Sprintf("node-%d", i), LauncherConfigName: lcfg}
+			ms.publish(key, phaseCounts{phaseUnbound: 1})
+		}(i)
+	}
+	wg.Wait()
+
+	if n := seriesCountForLcfg(t, lcfg); n != 4 {
+		t.Errorf("series count = %d, want 4", n)
+	}
+	assertLcfgPhases(t, lcfg, 0, nKeys, 0, 0) // every key contributed unbound:1
+}
+
+// TestComputeKeyPhases covers the two behaviors the maintainer asked for that
+// live only in the tallying path: terminating Pods are still counted (#3), and
+// the earliest future "stuck" instant is computed for AddAfter scheduling (#1).
+func TestComputeKeyPhases(t *testing.T) {
+	ctl := &controller{stuckThreshold: 7*time.Minute + 30*time.Second}
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-1 * time.Minute)
+	older := now.Add(-2 * time.Minute)
+	old := now.Add(-10 * time.Minute)
+
+	t.Run("terminating pod is counted but never scheduled", func(t *testing.T) {
+		// Unbound, not-Ready, young — would schedule AddAfter if not terminating.
+		pods := []*corev1.Pod{newLauncherPod().deleting().scheduledAt(recent).build()}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts[phaseUnbound] != 1 {
+			t.Errorf("terminating pod not counted: unbound=%d want 1", counts[phaseUnbound])
+		}
+		if !earliest.IsZero() {
+			t.Errorf("terminating pod must not schedule a future transition, got %v", earliest)
+		}
+	})
+
+	t.Run("earliest future-stuck instant across pods", func(t *testing.T) {
+		pods := []*corev1.Pod{
+			newLauncherPod().scheduledAt(recent).build(),         // stuck at recent+threshold
+			newLauncherPod().scheduledAt(older).build(),          // stuck at older+threshold (earlier)
+			newLauncherPod().ready().scheduledAt(recent).build(), // Ready: never becomes stuck
+		}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts[phaseUnbound] != 3 {
+			t.Errorf("unbound=%d want 3", counts[phaseUnbound])
+		}
+		want := older.Add(ctl.stuckThreshold)
+		if !earliest.Equal(want) {
+			t.Errorf("earliestStuck=%v want %v", earliest, want)
+		}
+	})
+
+	t.Run("already-stuck pod does not schedule", func(t *testing.T) {
+		pods := []*corev1.Pod{newLauncherPod().scheduledAt(old).build()}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts[phaseStuck] != 1 {
+			t.Errorf("stuck=%d want 1", counts[phaseStuck])
+		}
+		if !earliest.IsZero() {
+			t.Errorf("already-stuck pod must not schedule, got %v", earliest)
+		}
+	})
+
+	t.Run("empty pod slice", func(t *testing.T) {
+		counts, earliest := ctl.computeKeyPhases(nil, testTemplateHash, now)
+		if counts.total() != 0 {
+			t.Errorf("empty slice total=%d want 0", counts.total())
+		}
+		if !earliest.IsZero() {
+			t.Errorf("empty slice must not schedule, got %v", earliest)
+		}
+	})
+
+	t.Run("exact-threshold boundary is not yet stuck and not scheduled", func(t *testing.T) {
+		// age since scheduling == threshold exactly. launcherPhaseOf uses strict
+		// '>', so it is still unbound; becomesStuckAt == now, and the strict
+		// After(now) guard must not schedule (guards against an AddAfter(0) loop).
+		atThreshold := now.Add(-ctl.stuckThreshold)
+		pods := []*corev1.Pod{newLauncherPod().scheduledAt(atThreshold).build()}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts[phaseUnbound] != 1 {
+			t.Errorf("boundary pod unbound=%d want 1", counts[phaseUnbound])
+		}
+		if !earliest.IsZero() {
+			t.Errorf("boundary pod (becomesStuckAt==now) must not schedule, got %v", earliest)
+		}
+	})
+
+	t.Run("earliestStuck excludes Ready pods even when they are earliest", func(t *testing.T) {
+		// The Ready pod is scheduled earliest, so if the !Ready guard were
+		// dropped it would (wrongly) win the minimum. The true answer is the
+		// not-Ready pod's later instant.
+		earliestSched := now.Add(-3 * time.Minute)
+		laterSched := now.Add(-1 * time.Minute)
+		pods := []*corev1.Pod{
+			newLauncherPod().ready().scheduledAt(earliestSched).build(), // Ready: must be skipped
+			newLauncherPod().scheduledAt(laterSched).build(),            // not Ready: the real winner
+		}
+		_, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		want := laterSched.Add(ctl.stuckThreshold)
+		if !earliest.Equal(want) {
+			t.Errorf("earliestStuck=%v want %v (Ready pod must be excluded)", earliest, want)
+		}
+	})
+
+	t.Run("earliestStuck from unscheduled pod uses creation time", func(t *testing.T) {
+		// No PodScheduled condition -> reference is creation time.
+		pods := []*corev1.Pod{newLauncherPod().createdAt(recent).build()}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts[phaseUnbound] != 1 {
+			t.Errorf("unbound=%d want 1", counts[phaseUnbound])
+		}
+		want := recent.Add(ctl.stuckThreshold)
+		if !earliest.Equal(want) {
+			t.Errorf("earliestStuck=%v want %v (from creation time)", earliest, want)
+		}
+	})
+
+	t.Run("mixed phases: counts every pod, schedules only qualifying unbound", func(t *testing.T) {
+		pods := []*corev1.Pod{
+			newLauncherPod().bound().build(),                     // bound
+			newLauncherPod().hash("superseded").build(),          // stale
+			newLauncherPod().scheduledAt(old).build(),            // stuck (not ready, past threshold)
+			newLauncherPod().scheduledAt(recent).build(),         // unbound, counting down
+			newLauncherPod().ready().scheduledAt(recent).build(), // unbound, Ready
+		}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts.total() != len(pods) {
+			t.Errorf("total=%d want %d (every pod must be counted)", counts.total(), len(pods))
+		}
+		for phase, want := range map[launcherPhase]int{phaseBound: 1, phaseStale: 1, phaseStuck: 1, phaseUnbound: 2} {
+			if counts[phase] != want {
+				t.Errorf("counts[%s]=%d want %d", phase, counts[phase], want)
+			}
+		}
+		// Only the not-Ready, counting-down unbound pod drives earliestStuck.
+		want := recent.Add(ctl.stuckThreshold)
+		if !earliest.Equal(want) {
+			t.Errorf("earliestStuck=%v want %v", earliest, want)
+		}
+	})
+}
+
+// recordingQueue is a keyQueue stand-in that captures AddAfter calls. Embedding
+// the interface leaves all other methods nil; recordLauncherPhases only calls
+// AddAfter, so nothing else is exercised.
+type recordingQueue struct {
+	workqueue.TypedRateLimitingInterface[keyItem]
+	added []scheduledItem
+}
+
+type scheduledItem struct {
+	item  keyItem
+	delay time.Duration
+}
+
+func (q *recordingQueue) AddAfter(item keyItem, d time.Duration) {
+	q.added = append(q.added, scheduledItem{item: item, delay: d})
+}
+
+// TestRecordLauncherPhases covers the glue that publishes the tally and, only
+// when a launcher is counting down toward stuck, schedules a re-reconcile via
+// AddAfter.
+func TestRecordLauncherPhases(t *testing.T) {
+	registerMetrics()
+	const threshold = 7*time.Minute + 30*time.Second
+
+	setup := func() (*controller, *recordingQueue) {
+		launcherPodCountGauge.Reset()
+		q := &recordingQueue{}
+		ctl := &controller{
+			stuckThreshold: threshold,
+			metrics:        newMetricsState(),
+			keyQueue:       &genctlr.QueueAndWorkers[keyItem]{Queue: q},
+		}
+		return ctl, q
+	}
+
+	t.Run("publishes counts and schedules the future stuck transition", func(t *testing.T) {
+		ctl, q := setup()
+		key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: "lc-rec"}
+		// Unbound, not Ready, just scheduled -> counting down.
+		pods := []*corev1.Pod{newLauncherPod().scheduledAt(time.Now()).build()}
+
+		ctl.recordLauncherPhases(key, pods, testTemplateHash)
+
+		assertLcfgPhases(t, "lc-rec", 0, 1, 0, 0) // publish happened
+		if len(q.added) != 1 {
+			t.Fatalf("AddAfter calls = %d, want 1", len(q.added))
+		}
+		if q.added[0].item != (keyItem{NodeLauncherKey: key}) {
+			t.Errorf("scheduled item = %+v, want key %+v", q.added[0].item, key)
+		}
+		if d := q.added[0].delay; d <= 0 || d > threshold {
+			t.Errorf("scheduled delay = %v, want in (0, %v]", d, threshold)
+		}
+	})
+
+	t.Run("does not schedule when nothing is counting down", func(t *testing.T) {
+		ctl, q := setup()
+		key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: "lc-rec2"}
+		// Ready -> unbound but never becomes stuck.
+		pods := []*corev1.Pod{newLauncherPod().ready().scheduledAt(time.Now()).build()}
+
+		ctl.recordLauncherPhases(key, pods, testTemplateHash)
+
+		assertLcfgPhases(t, "lc-rec2", 0, 1, 0, 0)
+		if len(q.added) != 0 {
+			t.Errorf("AddAfter calls = %d, want 0", len(q.added))
+		}
+	})
 }

--- a/pkg/controller/launcher-populator/metrics_test.go
+++ b/pkg/controller/launcher-populator/metrics_test.go
@@ -36,6 +36,24 @@ import (
 
 const testTemplateHash = "hash-current"
 
+func TestLauncherPhaseLabelValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase launcherPhase
+		want  string
+	}{
+		{name: "stuck scheduling", phase: phaseStuckScheduling, want: "stuck_scheduling"},
+		{name: "stuck starting", phase: phaseStuckStarting, want: "stuck_starting"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(tt.phase); got != tt.want {
+				t.Errorf("phase label = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // podBuilder wraps a launcher Pod for classification tests, configured via
 // fluent setters. All timestamps are supplied by tests so classification is
 // deterministic.
@@ -114,7 +132,7 @@ const (
 type ageKind int
 
 const (
-	ageYoung                ageKind = iota // younger than the stuck threshold
+	ageYoung                ageKind = iota // younger than both stuck thresholds
 	ageOldUnscheduled                      // older than threshold, never scheduled
 	ageOldScheduledLongAgo                 // older than threshold, scheduled long ago
 	ageOldScheduledRecently                // created long ago but scheduled recently
@@ -167,14 +185,14 @@ func buildClassifyPod(now time.Time, bound bool, hk hashKind, ready bool, age ag
 // age-dependent block) so the oracle never re-implements launcherPhaseOf.
 func TestLauncherPhaseOf(t *testing.T) {
 	ctl := &controller{}
-	const pendingThreshold = 2 * time.Minute
-	const stuckThreshold = 7*time.Minute + 30*time.Second
+	const stuckSchedulingThreshold = 2 * time.Minute
+	const stuckStartingThreshold = 7*time.Minute + 30*time.Second
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 
 	check := func(t *testing.T, bound bool, hk hashKind, ready bool, age ageKind, want launcherPhase) {
 		t.Helper()
 		pod := buildClassifyPod(now, bound, hk, ready, age)
-		if got, _ := ctl.launcherPhaseOf(pod, testTemplateHash, pendingThreshold, stuckThreshold, now); got != want {
+		if got, _ := ctl.launcherPhaseOf(pod, testTemplateHash, stuckSchedulingThreshold, stuckStartingThreshold, now); got != want {
 			t.Errorf("bound=%v hash=%s ready=%v age=%s: got %q, want %q",
 				bound, hashKindNames[hk], ready, ageKindNames[age], got, want)
 		}
@@ -208,11 +226,12 @@ func TestLauncherPhaseOf(t *testing.T) {
 	}
 
 	// Block 4 (4): unbound + matching hash + not Ready -> depends on whether it
-	// has been scheduled and for how long. Unscheduled-and-old is pending;
-	// scheduled-and-old is stuck; recently scheduled (or young) is still unbound.
+	// has been scheduled and for how long. Unscheduled-and-old is
+	// stuck_scheduling; scheduled-and-old is stuck_starting; recently scheduled
+	// (or young) is still unbound.
 	run(t, false, hashMatches, false, ageYoung, phaseUnbound)
-	run(t, false, hashMatches, false, ageOldUnscheduled, phasePending)
-	run(t, false, hashMatches, false, ageOldScheduledLongAgo, phaseStuck)
+	run(t, false, hashMatches, false, ageOldUnscheduled, phaseStuckScheduling)
+	run(t, false, hashMatches, false, ageOldScheduledLongAgo, phaseStuckStarting)
 	run(t, false, hashMatches, false, ageOldScheduledRecently, phaseUnbound)
 }
 
@@ -223,7 +242,7 @@ func TestLauncherPhaseOfEmptyCurrentHash(t *testing.T) {
 	ctl := &controller{}
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	pod := newBuilder().scheduledAt(now).pod()
-	if got, _ := ctl.launcherPhaseOf(pod, "", DefaultPendingThreshold, DefaultStuckThreshold, now); got != phaseStale {
+	if got, _ := ctl.launcherPhaseOf(pod, "", DefaultStuckSchedulingThreshold, DefaultStuckStartingThreshold, now); got != phaseStale {
 		t.Errorf("launcherPhaseOf() with empty current hash = %q, want %q", got, phaseStale)
 	}
 }
@@ -245,16 +264,16 @@ func gatheredPhases(t *testing.T, lcfg string) map[string]float64 {
 			continue
 		}
 		for _, m := range mf.GetMetric() {
-			var name, phase string
+			var metricLCFGName, phase string
 			for _, lp := range m.GetLabel() {
 				switch lp.GetName() {
 				case lcfgNameLabel:
-					name = lp.GetValue()
+					metricLCFGName = lp.GetValue()
 				case phaseLabel:
 					phase = lp.GetValue()
 				}
 			}
-			if name == lcfg {
+			if metricLCFGName == lcfg {
 				out[phase] = m.GetGauge().GetValue()
 			}
 		}
@@ -273,15 +292,15 @@ func assertLcfgAbsent(t *testing.T, lcfg string) {
 
 // assertLcfgPhases asserts the exact value reported for every phase of one
 // LauncherConfig, and that all of those phases (and only them) are present.
-func assertLcfgPhases(t *testing.T, lcfg string, bound, unbound, pending, stuck, stale int) {
+func assertLcfgPhases(t *testing.T, lcfg string, bound, unbound, stuckScheduling, stuckStarting, stale int) {
 	t.Helper()
 	got := gatheredPhases(t, lcfg)
 	want := map[string]float64{
-		string(phaseBound):   float64(bound),
-		string(phaseUnbound): float64(unbound),
-		string(phasePending): float64(pending),
-		string(phaseStuck):   float64(stuck),
-		string(phaseStale):   float64(stale),
+		string(phaseBound):           float64(bound),
+		string(phaseUnbound):         float64(unbound),
+		string(phaseStuckScheduling): float64(stuckScheduling),
+		string(phaseStuckStarting):   float64(stuckStarting),
+		string(phaseStale):           float64(stale),
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("lcfg %q phases = %v, want %v", lcfg, got, want)
@@ -303,9 +322,10 @@ func TestMetricsStatePublish(t *testing.T) {
 	// The steps below share ms/gauge state and must run in order.
 	t.Run("aggregate across nodes", func(t *testing.T) {
 		ms.publish(keyA, phaseCounts{phaseUnbound: 2})
-		ms.publish(keyB, phaseCounts{phaseUnbound: 1, phaseStuck: 1})
-		// assertLcfgPhases requires every phase present, so bound/pending/stale
-		// existing as explicit zeros is part of what this asserts.
+		ms.publish(keyB, phaseCounts{phaseUnbound: 1, phaseStuckStarting: 1})
+		// assertLcfgPhases requires every phase present, so
+		// bound/stuck_scheduling/stale existing as explicit zeros is part of what
+		// this asserts.
 		assertLcfgPhases(t, lcfg, 0, 3, 0, 1, 0)
 	})
 
@@ -318,8 +338,8 @@ func TestMetricsStatePublish(t *testing.T) {
 
 	t.Run("drop one node keeps lcfg", func(t *testing.T) {
 		ms.publish(keyA, phaseCounts{})
-		if _, ok := ms.perNode[lcfg][keyA.NodeName]; ok {
-			t.Error("nodeA should be removed from perNode after dropping to zero")
+		if _, ok := ms.perLCFG[lcfg][keyA.NodeName]; ok {
+			t.Error("nodeA should be removed from perLCFG after dropping to zero")
 		}
 		assertLcfgPhases(t, lcfg, 0, 1, 0, 1, 0)
 	})
@@ -328,8 +348,8 @@ func TestMetricsStatePublish(t *testing.T) {
 		// No LauncherConfig object exists here, so once the last node drops the
 		// series must be truly gone from the registry (not left as stale zeros).
 		ms.publish(keyB, phaseCounts{})
-		if _, ok := ms.perNode[lcfg]; ok {
-			t.Error("lcfg should be removed from perNode once no node has launchers")
+		if _, ok := ms.perLCFG[lcfg]; ok {
+			t.Error("lcfg should be removed from perLCFG once no node has launchers")
 		}
 		assertLcfgAbsent(t, lcfg)
 	})
@@ -343,10 +363,26 @@ func TestMetricsStatePublishZeroForAbsentKey(t *testing.T) {
 	launcherPodCountGauge.Reset()
 	ms := newMetricsState()
 	ms.publish(NodeLauncherKey{NodeName: "n", LauncherConfigName: "never"}, phaseCounts{})
-	if len(ms.perNode) != 0 {
-		t.Errorf("perNode should stay empty, got %v", ms.perNode)
+	if len(ms.perLCFG) != 0 {
+		t.Errorf("perLCFG should stay empty, got %v", ms.perLCFG)
 	}
 	assertLcfgAbsent(t, "never")
+}
+
+// TestMetricsStateDeletesAllLCFGSeries verifies that removing a LauncherConfig
+// deletes every phase series for it, including values unknown to this version's
+// allLauncherPhases list.
+func TestMetricsStateDeletesAllLCFGSeries(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset()
+	ms := newMetricsState()
+	const lcfg = "lc-delete-all-series"
+
+	ms.setLCExists(lcfg, true)
+	launcherPodCountGauge.WithLabelValues(lcfg, "future_phase").Set(1)
+	ms.setLCExists(lcfg, false)
+
+	assertLcfgAbsent(t, lcfg)
 }
 
 // TestMetricsStatePublishIndependentLcfgs verifies that two LauncherConfigs do
@@ -359,14 +395,14 @@ func TestMetricsStatePublishIndependentLcfgs(t *testing.T) {
 
 	t.Run("both present independently", func(t *testing.T) {
 		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{phaseUnbound: 2})
-		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcY}, phaseCounts{phaseStuck: 1})
+		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcY}, phaseCounts{phaseStuckStarting: 1})
 		assertLcfgPhases(t, lcX, 0, 2, 0, 0, 0)
 		assertLcfgPhases(t, lcY, 0, 0, 0, 1, 0)
 	})
 
 	t.Run("deleting one keeps the other", func(t *testing.T) {
 		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{})
-		if _, ok := ms.perNode[lcY]; !ok {
+		if _, ok := ms.perLCFG[lcY]; !ok {
 			t.Error("lcY must survive deletion of lcX")
 		}
 		assertLcfgAbsent(t, lcX)
@@ -375,7 +411,7 @@ func TestMetricsStatePublishIndependentLcfgs(t *testing.T) {
 }
 
 // TestMetricsStatePublishConcurrent exercises the mutex in publish. Run with
-// -race to catch unsynchronized access to perNode / agg / the gauge.
+// -race to catch unsynchronized access to perLCFG / agg / the gauge.
 func TestMetricsStatePublishConcurrent(t *testing.T) {
 	registerMetrics()
 	launcherPodCountGauge.Reset()
@@ -414,7 +450,7 @@ func TestMetricsStateSetLCExists(t *testing.T) {
 	})
 
 	t.Run("launchers add on top of the existing zeros", func(t *testing.T) {
-		ms.publish(key, phaseCounts{phaseUnbound: 2, phaseStuck: 1})
+		ms.publish(key, phaseCounts{phaseUnbound: 2, phaseStuckStarting: 1})
 		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
 	})
 
@@ -424,6 +460,39 @@ func TestMetricsStateSetLCExists(t *testing.T) {
 	})
 
 	t.Run("removing the last launcher then drops the series", func(t *testing.T) {
+		ms.publish(key, phaseCounts{})
+		assertLcfgAbsent(t, lcfg)
+	})
+}
+
+// TestMetricsStateLauncherPrecedesLCObject covers the other order for series
+// creation: launcher Pods can be observed before their LauncherConfig object.
+// It also verifies that those series survive while the launchers reference a
+// LauncherConfig that no longer exists.
+func TestMetricsStateLauncherPrecedesLCObject(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset()
+	ms := newMetricsState()
+	const lcfg = "lc-launcher-first"
+	key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcfg}
+
+	// Steps share ms/gauge state and must run in order.
+	t.Run("launcher without LC object creates series", func(t *testing.T) {
+		ms.publish(key, phaseCounts{phaseUnbound: 2, phaseStuckStarting: 1})
+		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
+	})
+
+	t.Run("LC object appearance preserves launcher counts", func(t *testing.T) {
+		ms.setLCExists(lcfg, true)
+		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
+	})
+
+	t.Run("LC object deletion preserves orphan launcher counts", func(t *testing.T) {
+		ms.setLCExists(lcfg, false)
+		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
+	})
+
+	t.Run("last launcher removal deletes series", func(t *testing.T) {
 		ms.publish(key, phaseCounts{})
 		assertLcfgAbsent(t, lcfg)
 	})
@@ -454,9 +523,9 @@ func TestMetricsStateLCObjectOutlivesLaunchers(t *testing.T) {
 
 // TestComputeKeyPhases covers the two behaviors the maintainer asked for that
 // live only in the tallying path: terminating Pods are still counted (#3), and
-// the earliest future "stuck" instant is computed for AddAfter scheduling (#1).
+// the earliest future stuck transition is computed for AddAfter scheduling (#1).
 func TestComputeKeyPhases(t *testing.T) {
-	ctl := &controller{pendingThreshold: 2 * time.Minute, stuckThreshold: 7*time.Minute + 30*time.Second}
+	ctl := &controller{stuckSchedulingThreshold: 2 * time.Minute, stuckStartingThreshold: 7*time.Minute + 30*time.Second}
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	recent := now.Add(-30 * time.Second)
 	earlier := now.Add(-1 * time.Minute)
@@ -474,30 +543,30 @@ func TestComputeKeyPhases(t *testing.T) {
 		}
 	})
 
-	t.Run("earliest future-stuck instant across pods", func(t *testing.T) {
+	t.Run("earliest future stuck-starting instant across pods", func(t *testing.T) {
 		pods := []*corev1.Pod{
-			newBuilder().scheduledAt(recent).pod(),         // stuck at recent+threshold
-			newBuilder().scheduledAt(earlier).pod(),        // stuck at earlier+threshold (the winner)
-			newBuilder().ready().scheduledAt(recent).pod(), // Ready: never becomes stuck
+			newBuilder().scheduledAt(recent).pod(),         // stuck_starting at recent+threshold
+			newBuilder().scheduledAt(earlier).pod(),        // stuck_starting at earlier+threshold (the winner)
+			newBuilder().ready().scheduledAt(recent).pod(), // Ready: never becomes stuck_starting
 		}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts[phaseUnbound] != 3 {
 			t.Errorf("unbound=%d want 3", counts[phaseUnbound])
 		}
-		want := earlier.Add(ctl.stuckThreshold)
+		want := earlier.Add(ctl.stuckStartingThreshold)
 		if !earliest.Equal(want) {
-			t.Errorf("earliestStuck=%v want %v", earliest, want)
+			t.Errorf("earliestTransition=%v want %v", earliest, want)
 		}
 	})
 
-	t.Run("already-stuck pod does not schedule", func(t *testing.T) {
+	t.Run("already stuck-starting pod does not schedule", func(t *testing.T) {
 		pods := []*corev1.Pod{newBuilder().scheduledAt(old).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseStuck] != 1 {
-			t.Errorf("stuck=%d want 1", counts[phaseStuck])
+		if counts[phaseStuckStarting] != 1 {
+			t.Errorf("stuck_starting=%d want 1", counts[phaseStuckStarting])
 		}
 		if !earliest.IsZero() {
-			t.Errorf("already-stuck pod must not schedule, got %v", earliest)
+			t.Errorf("already stuck-starting pod must not schedule, got %v", earliest)
 		}
 	})
 
@@ -511,38 +580,37 @@ func TestComputeKeyPhases(t *testing.T) {
 		}
 	})
 
-	t.Run("exact-threshold boundary is not yet stuck and not scheduled", func(t *testing.T) {
-		// age since scheduling == stuckThreshold exactly. launcherPhaseOf uses
-		// strict '>', so it is still unbound; the transition instant == now, and
-		// the strict After(now) guard must not schedule (guards against an
-		// AddAfter(0) loop).
-		atThreshold := now.Add(-ctl.stuckThreshold)
+	t.Run("exact stuck-starting threshold is stuck-starting and not scheduled", func(t *testing.T) {
+		// age since scheduling == stuckStartingThreshold exactly. The threshold is the
+		// minimum stuck-starting age, so the Pod is already stuck_starting and needs no future
+		// transition to be scheduled.
+		atThreshold := now.Add(-ctl.stuckStartingThreshold)
 		pods := []*corev1.Pod{newBuilder().scheduledAt(atThreshold).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseUnbound] != 1 {
-			t.Errorf("boundary pod unbound=%d want 1", counts[phaseUnbound])
+		if counts[phaseStuckStarting] != 1 {
+			t.Errorf("boundary pod stuck_starting=%d want 1", counts[phaseStuckStarting])
 		}
 		if !earliest.IsZero() {
-			t.Errorf("boundary pod (transition instant == now) must not schedule, got %v", earliest)
+			t.Errorf("boundary pod is already stuck_starting and must not schedule, got %v", earliest)
 		}
 	})
 
-	t.Run("exact-pending-threshold boundary is not yet pending and not scheduled", func(t *testing.T) {
-		// Symmetric with the stuck boundary, on the pending track: age since
-		// creation == pendingThreshold exactly (never scheduled). Strict '>' keeps
-		// it unbound, and the transition instant == now must not schedule.
-		atThreshold := now.Add(-ctl.pendingThreshold)
+	t.Run("exact stuck-scheduling threshold is stuck-scheduling and not scheduled", func(t *testing.T) {
+		// Symmetric with the stuck-starting boundary, on the stuck-scheduling
+		// track: an unscheduled Pod at the threshold is already stuck_scheduling
+		// and needs no future transition to be scheduled.
+		atThreshold := now.Add(-ctl.stuckSchedulingThreshold)
 		pods := []*corev1.Pod{newBuilder().createdAt(atThreshold).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseUnbound] != 1 {
-			t.Errorf("boundary pod unbound=%d want 1", counts[phaseUnbound])
+		if counts[phaseStuckScheduling] != 1 {
+			t.Errorf("boundary pod stuck_scheduling=%d want 1", counts[phaseStuckScheduling])
 		}
 		if !earliest.IsZero() {
-			t.Errorf("boundary pod (transition instant == now) must not schedule, got %v", earliest)
+			t.Errorf("boundary pod is already stuck_scheduling and must not schedule, got %v", earliest)
 		}
 	})
 
-	t.Run("earliestStuck excludes Ready pods even when they are earliest", func(t *testing.T) {
+	t.Run("earliest transition excludes Ready pods even when they are earliest", func(t *testing.T) {
 		// The Ready pod is scheduled earliest, so if the !Ready guard were
 		// dropped it would (wrongly) win the minimum. The true answer is the
 		// not-Ready pod's later instant.
@@ -553,35 +621,37 @@ func TestComputeKeyPhases(t *testing.T) {
 			newBuilder().scheduledAt(laterSched).pod(),            // not Ready: the real winner
 		}
 		_, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		want := laterSched.Add(ctl.stuckThreshold)
+		want := laterSched.Add(ctl.stuckStartingThreshold)
 		if !earliest.Equal(want) {
-			t.Errorf("earliestStuck=%v want %v (Ready pod must be excluded)", earliest, want)
+			t.Errorf("earliestTransition=%v want %v (Ready pod must be excluded)", earliest, want)
 		}
 	})
 
-	t.Run("earliestStuck from unscheduled pod uses creation time and pending threshold", func(t *testing.T) {
-		// No PodScheduled condition -> pending track, measured from creation.
+	t.Run("earliest transition from unscheduled pod uses creation time and stuck-scheduling threshold", func(t *testing.T) {
+		// No PodScheduled condition -> stuck-scheduling track, measured from
+		// creation.
 		pods := []*corev1.Pod{newBuilder().createdAt(recent).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts[phaseUnbound] != 1 {
 			t.Errorf("unbound=%d want 1", counts[phaseUnbound])
 		}
-		want := recent.Add(ctl.pendingThreshold)
+		want := recent.Add(ctl.stuckSchedulingThreshold)
 		if !earliest.Equal(want) {
-			t.Errorf("earliestStuck=%v want %v (creation time + pending threshold)", earliest, want)
+			t.Errorf("earliestTransition=%v want %v (creation time + stuck-scheduling threshold)", earliest, want)
 		}
 	})
 
-	t.Run("unscheduled past pending threshold counts pending and does not schedule", func(t *testing.T) {
-		// Never scheduled and older than the pending threshold -> pending, and
-		// already past its transition so it schedules nothing.
+	t.Run("unscheduled past stuck-scheduling threshold counts stuck-scheduling and does not schedule", func(t *testing.T) {
+		// Never scheduled and older than the stuck-scheduling threshold ->
+		// stuck_scheduling, and already past its transition so it schedules
+		// nothing.
 		pods := []*corev1.Pod{newBuilder().createdAt(old).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phasePending] != 1 {
-			t.Errorf("pending=%d want 1", counts[phasePending])
+		if counts[phaseStuckScheduling] != 1 {
+			t.Errorf("stuck_scheduling=%d want 1", counts[phaseStuckScheduling])
 		}
 		if !earliest.IsZero() {
-			t.Errorf("already-pending pod must not schedule, got %v", earliest)
+			t.Errorf("already stuck-scheduling pod must not schedule, got %v", earliest)
 		}
 	})
 
@@ -589,7 +659,7 @@ func TestComputeKeyPhases(t *testing.T) {
 		pods := []*corev1.Pod{
 			newBuilder().bound().pod(),                     // bound
 			newBuilder().hash("superseded").pod(),          // stale
-			newBuilder().scheduledAt(old).pod(),            // stuck (not ready, past threshold)
+			newBuilder().scheduledAt(old).pod(),            // stuck_starting (not ready, past threshold)
 			newBuilder().scheduledAt(recent).pod(),         // unbound, counting down
 			newBuilder().ready().scheduledAt(recent).pod(), // unbound, Ready
 		}
@@ -597,22 +667,23 @@ func TestComputeKeyPhases(t *testing.T) {
 		if counts.total() != len(pods) {
 			t.Errorf("total=%d want %d (every pod must be counted)", counts.total(), len(pods))
 		}
-		for phase, want := range map[launcherPhase]int{phaseBound: 1, phaseStale: 1, phaseStuck: 1, phaseUnbound: 2} {
+		for phase, want := range map[launcherPhase]int{phaseBound: 1, phaseStale: 1, phaseStuckStarting: 1, phaseUnbound: 2} {
 			if counts[phase] != want {
 				t.Errorf("counts[%s]=%d want %d", phase, counts[phase], want)
 			}
 		}
-		// Only the not-Ready, counting-down unbound pod drives earliestStuck.
-		want := recent.Add(ctl.stuckThreshold)
+		// Only the not-Ready, counting-down unbound pod drives earliestTransition.
+		want := recent.Add(ctl.stuckStartingThreshold)
 		if !earliest.Equal(want) {
-			t.Errorf("earliestStuck=%v want %v", earliest, want)
+			t.Errorf("earliestTransition=%v want %v", earliest, want)
 		}
 	})
 }
 
-// recordingQueue is a keyQueue stand-in that captures AddAfter calls. Embedding
-// the interface leaves all other methods nil; recordLauncherPhases only calls
-// AddAfter, so nothing else is exercised.
+// recordingQueue records AddAfter calls for TestRecordLauncherPhases. Embedding
+// TypedRateLimitingInterface supplies the rest of the interface's method set.
+// Tests leave the embedded interface nil, which is safe because
+// recordLauncherPhases only calls the explicitly defined AddAfter method.
 type recordingQueue struct {
 	workqueue.TypedRateLimitingInterface[keyItem]
 	added []scheduledItem
@@ -628,12 +699,12 @@ func (q *recordingQueue) AddAfter(item keyItem, d time.Duration) {
 }
 
 // TestRecordLauncherPhases covers the glue that publishes the tally and, only
-// when a launcher is counting down toward stuck, schedules a re-reconcile via
-// AddAfter.
+// when a launcher is counting down toward stuck_scheduling or stuck_starting,
+// schedules a re-reconcile via AddAfter.
 func TestRecordLauncherPhases(t *testing.T) {
 	registerMetrics()
-	const pendingThreshold = 2 * time.Minute
-	const stuckThreshold = 7*time.Minute + 30*time.Second
+	const stuckSchedulingThreshold = 2 * time.Minute
+	const stuckStartingThreshold = 7*time.Minute + 30*time.Second
 	// A fixed fake clock lets us assert the AddAfter delay exactly.
 	base := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 
@@ -641,20 +712,20 @@ func TestRecordLauncherPhases(t *testing.T) {
 		launcherPodCountGauge.Reset()
 		q := &recordingQueue{}
 		ctl := &controller{
-			pendingThreshold: pendingThreshold,
-			stuckThreshold:   stuckThreshold,
-			clock:            testingclock.NewFakeClock(base),
-			metrics:          newMetricsState(),
-			keyQueue:         &genctlr.QueueAndWorkers[keyItem]{Queue: q},
+			stuckSchedulingThreshold: stuckSchedulingThreshold,
+			stuckStartingThreshold:   stuckStartingThreshold,
+			clock:                    testingclock.NewFakeClock(base),
+			metrics:                  newMetricsState(),
+			keyQueue:                 &genctlr.QueueAndWorkers[keyItem]{Queue: q},
 		}
 		return ctl, q
 	}
 
-	t.Run("publishes counts and schedules the future stuck transition", func(t *testing.T) {
+	t.Run("publishes counts and schedules the future stuck-starting transition", func(t *testing.T) {
 		ctl, q := setup()
 		key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: "lc-rec"}
 		// Unbound, not Ready, scheduled exactly at (fake) now -> counts down and
-		// becomes stuck exactly stuckThreshold later.
+		// becomes stuck_starting exactly stuckStartingThreshold later.
 		pods := []*corev1.Pod{newBuilder().scheduledAt(base).pod()}
 
 		ctl.recordLauncherPhases(key, pods, testTemplateHash)
@@ -666,15 +737,15 @@ func TestRecordLauncherPhases(t *testing.T) {
 		if q.added[0].item != (keyItem{NodeLauncherKey: key}) {
 			t.Errorf("scheduled item = %+v, want key %+v", q.added[0].item, key)
 		}
-		if d := q.added[0].delay; d != stuckThreshold {
-			t.Errorf("scheduled delay = %v, want %v", d, stuckThreshold)
+		if d := q.added[0].delay; d != stuckStartingThreshold {
+			t.Errorf("scheduled delay = %v, want %v", d, stuckStartingThreshold)
 		}
 	})
 
 	t.Run("does not schedule when nothing is counting down", func(t *testing.T) {
 		ctl, q := setup()
 		key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: "lc-rec2"}
-		// Ready -> unbound but never becomes stuck.
+		// Ready -> unbound but never becomes stuck_starting.
 		pods := []*corev1.Pod{newBuilder().ready().scheduledAt(base).pod()}
 
 		ctl.recordLauncherPhases(key, pods, testTemplateHash)

--- a/pkg/controller/launcher-populator/metrics_test.go
+++ b/pkg/controller/launcher-populator/metrics_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcherpopulator
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
+)
+
+const testTemplateHash = "hash-current"
+
+// launcherPodBuilder builds a launcher Pod for classification tests.
+type launcherPodBuilder struct {
+	pod corev1.Pod
+}
+
+func newLauncherPod() *launcherPodBuilder {
+	return &launcherPodBuilder{pod: corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "launcher-test",
+			Annotations: map[string]string{common.LauncherTemplateHashAnnotationKey: testTemplateHash},
+		},
+	}}
+}
+
+func (b *launcherPodBuilder) hash(h string) *launcherPodBuilder {
+	b.pod.Annotations[common.LauncherTemplateHashAnnotationKey] = h
+	return b
+}
+
+func (b *launcherPodBuilder) bound() *launcherPodBuilder {
+	b.pod.Annotations[common.RequesterAnnotationKey] = "some-uid requester-name"
+	return b
+}
+
+func (b *launcherPodBuilder) ready() *launcherPodBuilder {
+	b.pod.Status.Conditions = append(b.pod.Status.Conditions, corev1.PodCondition{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	})
+	return b
+}
+
+func (b *launcherPodBuilder) scheduledAt(t time.Time) *launcherPodBuilder {
+	b.pod.Status.Conditions = append(b.pod.Status.Conditions, corev1.PodCondition{
+		Type:               corev1.PodScheduled,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(t),
+	})
+	return b
+}
+
+func (b *launcherPodBuilder) createdAt(t time.Time) *launcherPodBuilder {
+	b.pod.CreationTimestamp = metav1.NewTime(t)
+	return b
+}
+
+func (b *launcherPodBuilder) build() *corev1.Pod { return &b.pod }
+
+func TestLauncherPhaseOf(t *testing.T) {
+	ctl := &controller{}
+	const threshold = 7*time.Minute + 30*time.Second
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	long := now.Add(-10 * time.Minute) // older than threshold
+	short := now.Add(-1 * time.Minute) // younger than threshold
+
+	cases := []struct {
+		name string
+		pod  *corev1.Pod
+		want launcherPhase
+	}{
+		{
+			name: "bound wins over everything",
+			pod:  newLauncherPod().bound().hash("stale-hash").scheduledAt(long).build(),
+			want: phaseBound,
+		},
+		{
+			name: "stale template hash",
+			pod:  newLauncherPod().hash("stale-hash").scheduledAt(short).build(),
+			want: phaseStale,
+		},
+		{
+			name: "stuck: current hash, not ready, scheduled long ago",
+			pod:  newLauncherPod().scheduledAt(long).build(),
+			want: phaseStuck,
+		},
+		{
+			name: "unbound: current hash, ready even if old",
+			pod:  newLauncherPod().ready().scheduledAt(long).build(),
+			want: phaseUnbound,
+		},
+		{
+			name: "unbound: current hash, not ready but young",
+			pod:  newLauncherPod().scheduledAt(short).build(),
+			want: phaseUnbound,
+		},
+		{
+			name: "stuck via creation-time fallback when no PodScheduled condition",
+			pod:  newLauncherPod().createdAt(long).build(),
+			want: phaseStuck,
+		},
+		{
+			name: "unbound: created long ago but scheduled recently (measure from scheduling)",
+			pod:  newLauncherPod().createdAt(now.Add(-20 * time.Minute)).scheduledAt(short).build(),
+			want: phaseUnbound,
+		},
+		{
+			name: "stale beats stuck: superseded template never reported stuck",
+			pod:  newLauncherPod().hash("stale-hash").scheduledAt(long).build(),
+			want: phaseStale,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ctl.launcherPhaseOf(tc.pod, testTemplateHash, threshold, now)
+			if got != tc.want {
+				t.Errorf("launcherPhaseOf() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLauncherPhaseOfEmptyCurrentHash verifies that when the digest has no
+// template hash for a Pod's key (LC gone / not yet digested), a templated Pod
+// classifies as stale.
+func TestLauncherPhaseOfEmptyCurrentHash(t *testing.T) {
+	ctl := &controller{}
+	now := time.Now()
+	pod := newLauncherPod().scheduledAt(now).build()
+	if got := ctl.launcherPhaseOf(pod, "", DefaultStuckThreshold, now); got != phaseStale {
+		t.Errorf("launcherPhaseOf() with empty current hash = %q, want %q", got, phaseStale)
+	}
+}

--- a/pkg/controller/launcher-populator/metrics_test.go
+++ b/pkg/controller/launcher-populator/metrics_test.go
@@ -36,24 +36,6 @@ import (
 
 const testTemplateHash = "hash-current"
 
-func TestLauncherPhaseLabelValues(t *testing.T) {
-	tests := []struct {
-		name  string
-		phase launcherPhase
-		want  string
-	}{
-		{name: "stuck scheduling", phase: phaseStuckScheduling, want: "stuck_scheduling"},
-		{name: "stuck starting", phase: phaseStuckStarting, want: "stuck_starting"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := string(tt.phase); got != tt.want {
-				t.Errorf("phase label = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 // podBuilder wraps a launcher Pod for classification tests, configured via
 // fluent setters. All timestamps are supplied by tests so classification is
 // deterministic.
@@ -184,7 +166,6 @@ func buildClassifyPod(now time.Time, bound bool, hk hashKind, ready bool, age ag
 // the short-circuit blocks, one explicit case per age bucket for the
 // age-dependent block) so the oracle never re-implements launcherPhaseOf.
 func TestLauncherPhaseOf(t *testing.T) {
-	ctl := &controller{}
 	const stuckSchedulingThreshold = 2 * time.Minute
 	const stuckStartingThreshold = 7*time.Minute + 30*time.Second
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
@@ -192,7 +173,7 @@ func TestLauncherPhaseOf(t *testing.T) {
 	check := func(t *testing.T, bound bool, hk hashKind, ready bool, age ageKind, want launcherPhase) {
 		t.Helper()
 		pod := buildClassifyPod(now, bound, hk, ready, age)
-		if got, _ := ctl.launcherPhaseOf(pod, testTemplateHash, stuckSchedulingThreshold, stuckStartingThreshold, now); got != want {
+		if got, _ := launcherPhaseOf(pod, testTemplateHash, stuckSchedulingThreshold, stuckStartingThreshold, now); got != want {
 			t.Errorf("bound=%v hash=%s ready=%v age=%s: got %q, want %q",
 				bound, hashKindNames[hk], ready, ageKindNames[age], got, want)
 		}
@@ -239,10 +220,9 @@ func TestLauncherPhaseOf(t *testing.T) {
 // template hash for a Pod's key (LC gone / not yet digested), a templated Pod
 // classifies as stale.
 func TestLauncherPhaseOfEmptyCurrentHash(t *testing.T) {
-	ctl := &controller{}
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	pod := newBuilder().scheduledAt(now).pod()
-	if got, _ := ctl.launcherPhaseOf(pod, "", DefaultStuckSchedulingThreshold, DefaultStuckStartingThreshold, now); got != phaseStale {
+	if got, _ := launcherPhaseOf(pod, "", DefaultStuckSchedulingThreshold, DefaultStuckStartingThreshold, now); got != phaseStale {
 		t.Errorf("launcherPhaseOf() with empty current hash = %q, want %q", got, phaseStale)
 	}
 }
@@ -321,8 +301,8 @@ func TestMetricsStatePublish(t *testing.T) {
 
 	// The steps below share ms/gauge state and must run in order.
 	t.Run("aggregate across nodes", func(t *testing.T) {
-		ms.publish(keyA, phaseCounts{phaseUnbound: 2})
-		ms.publish(keyB, phaseCounts{phaseUnbound: 1, phaseStuckStarting: 1})
+		ms.publish(keyA, phaseCounts{unbound: 2})
+		ms.publish(keyB, phaseCounts{unbound: 1, stuckStarting: 1})
 		// assertLcfgPhases requires every phase present, so
 		// bound/stuck_scheduling/stale existing as explicit zeros is part of what
 		// this asserts.
@@ -332,7 +312,7 @@ func TestMetricsStatePublish(t *testing.T) {
 	t.Run("overwrite key re-aggregates", func(t *testing.T) {
 		// Overwriting an existing, still-nonzero key must recompute (not
 		// accumulate) the aggregate from the replaced counts.
-		ms.publish(keyA, phaseCounts{phaseUnbound: 5, phaseBound: 1})
+		ms.publish(keyA, phaseCounts{unbound: 5, bound: 1})
 		assertLcfgPhases(t, lcfg, 1, 6, 0, 1, 0)
 	})
 
@@ -369,9 +349,11 @@ func TestMetricsStatePublishZeroForAbsentKey(t *testing.T) {
 	assertLcfgAbsent(t, "never")
 }
 
-// TestMetricsStateDeletesAllLCFGSeries verifies that removing a LauncherConfig
-// deletes every phase series for it, including values unknown to this version's
-// allLauncherPhases list.
+// TestMetricsStateDeletesAllLCFGSeries verifies that deleting a launcher-free
+// LauncherConfig removes every phase series owned by metricsState. No launcher
+// counts are published here, so the LauncherConfig's existence is the only
+// reason its series are present; setLCExists(false) therefore satisfies both
+// conditions required for deletion.
 func TestMetricsStateDeletesAllLCFGSeries(t *testing.T) {
 	registerMetrics()
 	launcherPodCountGauge.Reset()
@@ -379,9 +361,9 @@ func TestMetricsStateDeletesAllLCFGSeries(t *testing.T) {
 	const lcfg = "lc-delete-all-series"
 
 	ms.setLCExists(lcfg, true)
-	launcherPodCountGauge.WithLabelValues(lcfg, "future_phase").Set(1)
-	ms.setLCExists(lcfg, false)
+	assertLcfgPhases(t, lcfg, 0, 0, 0, 0, 0)
 
+	ms.setLCExists(lcfg, false)
 	assertLcfgAbsent(t, lcfg)
 }
 
@@ -394,8 +376,8 @@ func TestMetricsStatePublishIndependentLcfgs(t *testing.T) {
 	const lcX, lcY = "lc-x", "lc-y"
 
 	t.Run("both present independently", func(t *testing.T) {
-		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{phaseUnbound: 2})
-		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcY}, phaseCounts{phaseStuckStarting: 1})
+		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{unbound: 2})
+		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcY}, phaseCounts{stuckStarting: 1})
 		assertLcfgPhases(t, lcX, 0, 2, 0, 0, 0)
 		assertLcfgPhases(t, lcY, 0, 0, 0, 1, 0)
 	})
@@ -425,7 +407,7 @@ func TestMetricsStatePublishConcurrent(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			key := NodeLauncherKey{NodeName: fmt.Sprintf("node-%d", i), LauncherConfigName: lcfg}
-			ms.publish(key, phaseCounts{phaseUnbound: 1})
+			ms.publish(key, phaseCounts{unbound: 1})
 		}(i)
 	}
 	wg.Wait()
@@ -449,8 +431,8 @@ func TestMetricsStateSetLCExists(t *testing.T) {
 		assertLcfgPhases(t, lcfg, 0, 0, 0, 0, 0)
 	})
 
-	t.Run("launchers add on top of the existing zeros", func(t *testing.T) {
-		ms.publish(key, phaseCounts{phaseUnbound: 2, phaseStuckStarting: 1})
+	t.Run("existing series reflect launcher counts", func(t *testing.T) {
+		ms.publish(key, phaseCounts{unbound: 2, stuckStarting: 1})
 		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
 	})
 
@@ -465,10 +447,10 @@ func TestMetricsStateSetLCExists(t *testing.T) {
 	})
 }
 
-// TestMetricsStateLauncherPrecedesLCObject covers the other order for series
-// creation: launcher Pods can be observed before their LauncherConfig object.
-// It also verifies that those series survive while the launchers reference a
-// LauncherConfig that no longer exists.
+// TestMetricsStateLauncherPrecedesLCObject covers a launcher-first upswing and
+// LauncherConfig-first downswing. It verifies that the series appear before the
+// LauncherConfig object and survive its deletion while launchers still refer to
+// it.
 func TestMetricsStateLauncherPrecedesLCObject(t *testing.T) {
 	registerMetrics()
 	launcherPodCountGauge.Reset()
@@ -478,7 +460,7 @@ func TestMetricsStateLauncherPrecedesLCObject(t *testing.T) {
 
 	// Steps share ms/gauge state and must run in order.
 	t.Run("launcher without LC object creates series", func(t *testing.T) {
-		ms.publish(key, phaseCounts{phaseUnbound: 2, phaseStuckStarting: 1})
+		ms.publish(key, phaseCounts{unbound: 2, stuckStarting: 1})
 		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
 	})
 
@@ -498,9 +480,9 @@ func TestMetricsStateLauncherPrecedesLCObject(t *testing.T) {
 	})
 }
 
-// TestMetricsStateLCObjectOutlivesLaunchers covers the other order: a launcher's
-// series must survive the launcher's own removal as long as the LauncherConfig
-// object still exists (reported as explicit zeros), and vanish once it too goes.
+// TestMetricsStateLCObjectOutlivesLaunchers covers a LauncherConfig-first
+// upswing and launcher-first downswing. The series survive launcher removal as
+// explicit zeros, then vanish when the LauncherConfig is deleted.
 func TestMetricsStateLCObjectOutlivesLaunchers(t *testing.T) {
 	registerMetrics()
 	launcherPodCountGauge.Reset()
@@ -509,7 +491,7 @@ func TestMetricsStateLCObjectOutlivesLaunchers(t *testing.T) {
 	key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcfg}
 
 	ms.setLCExists(lcfg, true)
-	ms.publish(key, phaseCounts{phaseUnbound: 1})
+	ms.publish(key, phaseCounts{unbound: 1})
 	assertLcfgPhases(t, lcfg, 0, 1, 0, 0, 0)
 
 	// Launcher goes away but the LC object still exists -> zeros remain.
@@ -535,8 +517,8 @@ func TestComputeKeyPhases(t *testing.T) {
 		// Unbound, not-Ready, young — would schedule AddAfter if not terminating.
 		pods := []*corev1.Pod{newBuilder().deleting().scheduledAt(recent).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseUnbound] != 1 {
-			t.Errorf("terminating pod not counted: unbound=%d want 1", counts[phaseUnbound])
+		if counts.unbound != 1 {
+			t.Errorf("terminating pod not counted: unbound=%d want 1", counts.unbound)
 		}
 		if !earliest.IsZero() {
 			t.Errorf("terminating pod must not schedule a future transition, got %v", earliest)
@@ -550,8 +532,8 @@ func TestComputeKeyPhases(t *testing.T) {
 			newBuilder().ready().scheduledAt(recent).pod(), // Ready: never becomes stuck_starting
 		}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseUnbound] != 3 {
-			t.Errorf("unbound=%d want 3", counts[phaseUnbound])
+		if counts.unbound != 3 {
+			t.Errorf("unbound=%d want 3", counts.unbound)
 		}
 		want := earlier.Add(ctl.stuckStartingThreshold)
 		if !earliest.Equal(want) {
@@ -562,8 +544,8 @@ func TestComputeKeyPhases(t *testing.T) {
 	t.Run("already stuck-starting pod does not schedule", func(t *testing.T) {
 		pods := []*corev1.Pod{newBuilder().scheduledAt(old).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseStuckStarting] != 1 {
-			t.Errorf("stuck_starting=%d want 1", counts[phaseStuckStarting])
+		if counts.stuckStarting != 1 {
+			t.Errorf("stuck_starting=%d want 1", counts.stuckStarting)
 		}
 		if !earliest.IsZero() {
 			t.Errorf("already stuck-starting pod must not schedule, got %v", earliest)
@@ -587,8 +569,8 @@ func TestComputeKeyPhases(t *testing.T) {
 		atThreshold := now.Add(-ctl.stuckStartingThreshold)
 		pods := []*corev1.Pod{newBuilder().scheduledAt(atThreshold).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseStuckStarting] != 1 {
-			t.Errorf("boundary pod stuck_starting=%d want 1", counts[phaseStuckStarting])
+		if counts.stuckStarting != 1 {
+			t.Errorf("boundary pod stuck_starting=%d want 1", counts.stuckStarting)
 		}
 		if !earliest.IsZero() {
 			t.Errorf("boundary pod is already stuck_starting and must not schedule, got %v", earliest)
@@ -602,8 +584,8 @@ func TestComputeKeyPhases(t *testing.T) {
 		atThreshold := now.Add(-ctl.stuckSchedulingThreshold)
 		pods := []*corev1.Pod{newBuilder().createdAt(atThreshold).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseStuckScheduling] != 1 {
-			t.Errorf("boundary pod stuck_scheduling=%d want 1", counts[phaseStuckScheduling])
+		if counts.stuckScheduling != 1 {
+			t.Errorf("boundary pod stuck_scheduling=%d want 1", counts.stuckScheduling)
 		}
 		if !earliest.IsZero() {
 			t.Errorf("boundary pod is already stuck_scheduling and must not schedule, got %v", earliest)
@@ -632,8 +614,8 @@ func TestComputeKeyPhases(t *testing.T) {
 		// creation.
 		pods := []*corev1.Pod{newBuilder().createdAt(recent).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseUnbound] != 1 {
-			t.Errorf("unbound=%d want 1", counts[phaseUnbound])
+		if counts.unbound != 1 {
+			t.Errorf("unbound=%d want 1", counts.unbound)
 		}
 		want := recent.Add(ctl.stuckSchedulingThreshold)
 		if !earliest.Equal(want) {
@@ -647,8 +629,8 @@ func TestComputeKeyPhases(t *testing.T) {
 		// nothing.
 		pods := []*corev1.Pod{newBuilder().createdAt(old).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
-		if counts[phaseStuckScheduling] != 1 {
-			t.Errorf("stuck_scheduling=%d want 1", counts[phaseStuckScheduling])
+		if counts.stuckScheduling != 1 {
+			t.Errorf("stuck_scheduling=%d want 1", counts.stuckScheduling)
 		}
 		if !earliest.IsZero() {
 			t.Errorf("already stuck-scheduling pod must not schedule, got %v", earliest)
@@ -657,20 +639,19 @@ func TestComputeKeyPhases(t *testing.T) {
 
 	t.Run("mixed phases: counts every pod, schedules only qualifying unbound", func(t *testing.T) {
 		pods := []*corev1.Pod{
-			newBuilder().bound().pod(),                     // bound
-			newBuilder().hash("superseded").pod(),          // stale
-			newBuilder().scheduledAt(old).pod(),            // stuck_starting (not ready, past threshold)
-			newBuilder().scheduledAt(recent).pod(),         // unbound, counting down
-			newBuilder().ready().scheduledAt(recent).pod(), // unbound, Ready
+			newBuilder().bound().pod(),                      // bound
+			newBuilder().hash("superseded").pod(),           // stale
+			newBuilder().scheduledAt(old).pod(),             // stuck_starting (not ready, past threshold)
+			newBuilder().scheduledAt(recent).pod(),          // unbound, counting down
+			newBuilder().ready().scheduledAt(earlier).pod(), // unbound, Ready; must not win despite being earlier
 		}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts.total() != len(pods) {
 			t.Errorf("total=%d want %d (every pod must be counted)", counts.total(), len(pods))
 		}
-		for phase, want := range map[launcherPhase]int{phaseBound: 1, phaseStale: 1, phaseStuckStarting: 1, phaseUnbound: 2} {
-			if counts[phase] != want {
-				t.Errorf("counts[%s]=%d want %d", phase, counts[phase], want)
-			}
+		wantCounts := phaseCounts{bound: 1, unbound: 2, stuckStarting: 1, stale: 1}
+		if !reflect.DeepEqual(counts, wantCounts) {
+			t.Errorf("counts=%+v want %+v", counts, wantCounts)
 		}
 		// Only the not-Ready, counting-down unbound pod drives earliestTransition.
 		want := recent.Add(ctl.stuckStartingThreshold)

--- a/pkg/controller/launcher-populator/metrics_test.go
+++ b/pkg/controller/launcher-populator/metrics_test.go
@@ -25,8 +25,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/metrics/legacyregistry"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
 	genctlr "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic"
@@ -34,14 +36,15 @@ import (
 
 const testTemplateHash = "hash-current"
 
-// launcherPodBuilder builds a launcher Pod for classification tests. All
-// timestamps are supplied by tests so classification is deterministic.
-type launcherPodBuilder struct {
-	pod corev1.Pod
+// podBuilder wraps a launcher Pod for classification tests, configured via
+// fluent setters. All timestamps are supplied by tests so classification is
+// deterministic.
+type podBuilder struct {
+	p corev1.Pod
 }
 
-func newLauncherPod() *launcherPodBuilder {
-	return &launcherPodBuilder{pod: corev1.Pod{
+func newBuilder() *podBuilder {
+	return &podBuilder{p: corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "launcher-test",
 			Annotations: map[string]string{common.LauncherTemplateHashAnnotationKey: testTemplateHash},
@@ -50,32 +53,32 @@ func newLauncherPod() *launcherPodBuilder {
 }
 
 // hash overrides the template-hash annotation (to model a superseded template).
-func (b *launcherPodBuilder) hash(h string) *launcherPodBuilder {
-	b.pod.Annotations[common.LauncherTemplateHashAnnotationKey] = h
+func (b *podBuilder) hash(h string) *podBuilder {
+	b.p.Annotations[common.LauncherTemplateHashAnnotationKey] = h
 	return b
 }
 
 // noHash removes the template-hash annotation entirely.
-func (b *launcherPodBuilder) noHash() *launcherPodBuilder {
-	delete(b.pod.Annotations, common.LauncherTemplateHashAnnotationKey)
+func (b *podBuilder) noHash() *podBuilder {
+	delete(b.p.Annotations, common.LauncherTemplateHashAnnotationKey)
 	return b
 }
 
-func (b *launcherPodBuilder) bound() *launcherPodBuilder {
-	b.pod.Annotations[common.RequesterAnnotationKey] = "some-uid requester-name"
+func (b *podBuilder) bound() *podBuilder {
+	b.p.Annotations[common.RequesterAnnotationKey] = "some-uid requester-name"
 	return b
 }
 
-func (b *launcherPodBuilder) ready() *launcherPodBuilder {
-	b.pod.Status.Conditions = append(b.pod.Status.Conditions, corev1.PodCondition{
+func (b *podBuilder) ready() *podBuilder {
+	b.p.Status.Conditions = append(b.p.Status.Conditions, corev1.PodCondition{
 		Type:   corev1.PodReady,
 		Status: corev1.ConditionTrue,
 	})
 	return b
 }
 
-func (b *launcherPodBuilder) scheduledAt(t time.Time) *launcherPodBuilder {
-	b.pod.Status.Conditions = append(b.pod.Status.Conditions, corev1.PodCondition{
+func (b *podBuilder) scheduledAt(t time.Time) *podBuilder {
+	b.p.Status.Conditions = append(b.p.Status.Conditions, corev1.PodCondition{
 		Type:               corev1.PodScheduled,
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.NewTime(t),
@@ -83,19 +86,20 @@ func (b *launcherPodBuilder) scheduledAt(t time.Time) *launcherPodBuilder {
 	return b
 }
 
-func (b *launcherPodBuilder) createdAt(t time.Time) *launcherPodBuilder {
-	b.pod.CreationTimestamp = metav1.NewTime(t)
+func (b *podBuilder) createdAt(t time.Time) *podBuilder {
+	b.p.CreationTimestamp = metav1.NewTime(t)
 	return b
 }
 
 // deleting marks the Pod as terminating (DeletionTimestamp set).
-func (b *launcherPodBuilder) deleting() *launcherPodBuilder {
+func (b *podBuilder) deleting() *podBuilder {
 	dt := metav1.NewTime(time.Date(2026, 6, 21, 11, 0, 0, 0, time.UTC))
-	b.pod.DeletionTimestamp = &dt
+	b.p.DeletionTimestamp = &dt
 	return b
 }
 
-func (b *launcherPodBuilder) build() *corev1.Pod { return &b.pod }
+// pod returns the wrapped Pod.
+func (b *podBuilder) pod() *corev1.Pod { return &b.p }
 
 // Classification input dimensions, enumerated exhaustively by
 // TestLauncherPhaseOf.
@@ -119,16 +123,17 @@ const (
 var (
 	hashKindNames = map[hashKind]string{hashMatches: "hashMatches", hashDiffers: "hashDiffers", hashAbsent: "hashAbsent"}
 	ageKindNames  = map[ageKind]string{ageYoung: "young", ageOldUnscheduled: "oldUnscheduled", ageOldScheduledLongAgo: "oldSchedLongAgo", ageOldScheduledRecently: "oldSchedRecently"}
-	allHashKinds  = []hashKind{hashMatches, hashDiffers, hashAbsent}
-	allAgeKinds   = []ageKind{ageYoung, ageOldUnscheduled, ageOldScheduledLongAgo, ageOldScheduledRecently}
+	// Derived from the name maps (sorted, i.e. iota order) to avoid restating them.
+	allHashKinds = sets.List(sets.KeySet(hashKindNames))
+	allAgeKinds  = sets.List(sets.KeySet(ageKindNames))
 )
 
 // buildClassifyPod constructs a launcher Pod for the given input dimensions.
 // It only wires inputs; it does not encode the expected classification.
 func buildClassifyPod(now time.Time, bound bool, hk hashKind, ready bool, age ageKind) *corev1.Pod {
-	old := now.Add(-10 * time.Minute)   // older than the 7.5m threshold
-	recent := now.Add(-1 * time.Minute) // younger than the threshold
-	b := newLauncherPod()               // defaults to the current template hash
+	old := now.Add(-10 * time.Minute)   // older than both thresholds
+	recent := now.Add(-1 * time.Minute) // younger than both thresholds
+	b := newBuilder()                   // defaults to the current template hash
 	switch hk {
 	case hashDiffers:
 		b.hash("superseded")
@@ -151,24 +156,25 @@ func buildClassifyPod(now time.Time, bound bool, hk hashKind, ready bool, age ag
 	case ageOldScheduledRecently:
 		b.createdAt(old).scheduledAt(recent)
 	}
-	return b.build()
+	return b.pod()
 }
 
 // TestLauncherPhaseOf exhaustively covers the cross product of the
 // classification inputs: bound/unbound x hash(matches/differs/absent) x
 // ready/not x four age buckets (2*3*2*4 = 48). Inputs are generated
 // programmatically; expected phases are hand-authored per block (constants for
-// the short-circuit blocks, an explicit map for the age-dependent block) so the
-// oracle never re-implements launcherPhaseOf.
+// the short-circuit blocks, one explicit case per age bucket for the
+// age-dependent block) so the oracle never re-implements launcherPhaseOf.
 func TestLauncherPhaseOf(t *testing.T) {
 	ctl := &controller{}
-	const threshold = 7*time.Minute + 30*time.Second
+	const pendingThreshold = 2 * time.Minute
+	const stuckThreshold = 7*time.Minute + 30*time.Second
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 
 	check := func(t *testing.T, bound bool, hk hashKind, ready bool, age ageKind, want launcherPhase) {
 		t.Helper()
 		pod := buildClassifyPod(now, bound, hk, ready, age)
-		if got := ctl.launcherPhaseOf(pod, testTemplateHash, threshold, now); got != want {
+		if got, _ := ctl.launcherPhaseOf(pod, testTemplateHash, pendingThreshold, stuckThreshold, now); got != want {
 			t.Errorf("bound=%v hash=%s ready=%v age=%s: got %q, want %q",
 				bound, hashKindNames[hk], ready, ageKindNames[age], got, want)
 		}
@@ -201,16 +207,13 @@ func TestLauncherPhaseOf(t *testing.T) {
 		run(t, false, hashMatches, true, age, phaseUnbound)
 	}
 
-	// Block 4 (4): unbound + matching hash + not Ready -> depends on age.
-	wantByAge := map[ageKind]launcherPhase{
-		ageYoung:                phaseUnbound,
-		ageOldUnscheduled:       phaseStuck,
-		ageOldScheduledLongAgo:  phaseStuck,
-		ageOldScheduledRecently: phaseUnbound,
-	}
-	for _, age := range allAgeKinds {
-		run(t, false, hashMatches, false, age, wantByAge[age])
-	}
+	// Block 4 (4): unbound + matching hash + not Ready -> depends on whether it
+	// has been scheduled and for how long. Unscheduled-and-old is pending;
+	// scheduled-and-old is stuck; recently scheduled (or young) is still unbound.
+	run(t, false, hashMatches, false, ageYoung, phaseUnbound)
+	run(t, false, hashMatches, false, ageOldUnscheduled, phasePending)
+	run(t, false, hashMatches, false, ageOldScheduledLongAgo, phaseStuck)
+	run(t, false, hashMatches, false, ageOldScheduledRecently, phaseUnbound)
 }
 
 // TestLauncherPhaseOfEmptyCurrentHash verifies that when the digest has no
@@ -218,18 +221,18 @@ func TestLauncherPhaseOf(t *testing.T) {
 // classifies as stale.
 func TestLauncherPhaseOfEmptyCurrentHash(t *testing.T) {
 	ctl := &controller{}
-	now := time.Now()
-	pod := newLauncherPod().scheduledAt(now).build()
-	if got := ctl.launcherPhaseOf(pod, "", DefaultStuckThreshold, now); got != phaseStale {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	pod := newBuilder().scheduledAt(now).pod()
+	if got, _ := ctl.launcherPhaseOf(pod, "", DefaultPendingThreshold, DefaultStuckThreshold, now); got != phaseStale {
 		t.Errorf("launcherPhaseOf() with empty current hash = %q, want %q", got, phaseStale)
 	}
 }
 
-// gatheredPhases returns the fma_launcher_pod_count series currently present
-// for one LauncherConfig, as phase->value. It reads the registry directly (not
-// WithLabelValues, which would lazily create a missing series at 0), so a
-// deleted series is observably absent and an explicit zero is observably
-// present.
+// gatheredPhases returns a map from phase to the value currently reported by the
+// fma_launcher_pod_count metric for the given LauncherConfig name. It reads the
+// registry directly (not WithLabelValues, which would lazily create a missing
+// series at 0), so a deleted series is observably absent and an explicit zero is
+// observably present.
 func gatheredPhases(t *testing.T, lcfg string) map[string]float64 {
 	t.Helper()
 	mfs, err := legacyregistry.DefaultGatherer.Gather()
@@ -259,21 +262,24 @@ func gatheredPhases(t *testing.T, lcfg string) map[string]float64 {
 	return out
 }
 
-// seriesCountForLcfg returns how many fma_launcher_pod_count series exist for
-// the given LauncherConfig.
-func seriesCountForLcfg(t *testing.T, lcfg string) int {
+// assertLcfgAbsent asserts that no fma_launcher_pod_count series exist for the
+// given LauncherConfig (as opposed to existing with zero values).
+func assertLcfgAbsent(t *testing.T, lcfg string) {
 	t.Helper()
-	return len(gatheredPhases(t, lcfg))
+	if got := gatheredPhases(t, lcfg); len(got) != 0 {
+		t.Errorf("lcfg %q: want no series, got %v", lcfg, got)
+	}
 }
 
-// assertLcfgPhases asserts the exact set of phase series (values and presence)
-// for one lcfg.
-func assertLcfgPhases(t *testing.T, lcfg string, bound, unbound, stuck, stale int) {
+// assertLcfgPhases asserts the exact value reported for every phase of one
+// LauncherConfig, and that all of those phases (and only them) are present.
+func assertLcfgPhases(t *testing.T, lcfg string, bound, unbound, pending, stuck, stale int) {
 	t.Helper()
 	got := gatheredPhases(t, lcfg)
 	want := map[string]float64{
 		string(phaseBound):   float64(bound),
 		string(phaseUnbound): float64(unbound),
+		string(phasePending): float64(pending),
 		string(phaseStuck):   float64(stuck),
 		string(phaseStale):   float64(stale),
 	}
@@ -283,7 +289,7 @@ func assertLcfgPhases(t *testing.T, lcfg string, bound, unbound, stuck, stale in
 }
 
 // TestMetricsStatePublish verifies cross-node aggregation, per-phase Set
-// (including explicit zeros — proven by the series count, not by a value read),
+// (including explicit zeros — assertLcfgPhases proves every phase is present),
 // overwrite/re-aggregation, and true deletion of a LauncherConfig's series once
 // it has no launcher Pods on any node.
 func TestMetricsStatePublish(t *testing.T) {
@@ -296,48 +302,36 @@ func TestMetricsStatePublish(t *testing.T) {
 
 	// The steps below share ms/gauge state and must run in order.
 	t.Run("aggregate across nodes", func(t *testing.T) {
-		// All four phases must be present (count == 4 proves bound/stale exist as
-		// explicit zeros, not just that a value read returns 0).
 		ms.publish(keyA, phaseCounts{phaseUnbound: 2})
 		ms.publish(keyB, phaseCounts{phaseUnbound: 1, phaseStuck: 1})
-		if n := seriesCountForLcfg(t, lcfg); n != 4 {
-			t.Errorf("series count = %d, want 4 (all phases present incl. explicit zeros)", n)
-		}
-		assertLcfgPhases(t, lcfg, 0, 3, 1, 0)
+		// assertLcfgPhases requires every phase present, so bound/pending/stale
+		// existing as explicit zeros is part of what this asserts.
+		assertLcfgPhases(t, lcfg, 0, 3, 0, 1, 0)
 	})
 
 	t.Run("overwrite key re-aggregates", func(t *testing.T) {
 		// Overwriting an existing, still-nonzero key must recompute (not
 		// accumulate) the aggregate from the replaced counts.
 		ms.publish(keyA, phaseCounts{phaseUnbound: 5, phaseBound: 1})
-		if n := seriesCountForLcfg(t, lcfg); n != 4 {
-			t.Errorf("series count = %d, want 4 after overwrite", n)
-		}
-		assertLcfgPhases(t, lcfg, 1, 6, 1, 0)
+		assertLcfgPhases(t, lcfg, 1, 6, 0, 1, 0)
 	})
 
 	t.Run("drop one node keeps lcfg", func(t *testing.T) {
 		ms.publish(keyA, phaseCounts{})
-		if _, ok := ms.perLcfg[lcfg][keyA]; ok {
-			t.Error("keyA should be removed from perLcfg after dropping to zero")
+		if _, ok := ms.perNode[lcfg][keyA.NodeName]; ok {
+			t.Error("nodeA should be removed from perNode after dropping to zero")
 		}
-		if n := seriesCountForLcfg(t, lcfg); n != 4 {
-			t.Errorf("series count = %d, want 4 while nodeB still has launchers", n)
-		}
-		assertLcfgPhases(t, lcfg, 0, 1, 1, 0)
+		assertLcfgPhases(t, lcfg, 0, 1, 0, 1, 0)
 	})
 
 	t.Run("delete last node removes series", func(t *testing.T) {
-		// The series must be truly gone from the registry (not left as stale
-		// zeros) — the whole point of metricsState — so assert absence via the
-		// count, not a value read.
+		// No LauncherConfig object exists here, so once the last node drops the
+		// series must be truly gone from the registry (not left as stale zeros).
 		ms.publish(keyB, phaseCounts{})
-		if _, ok := ms.perLcfg[lcfg]; ok {
-			t.Error("lcfg should be removed from perLcfg once no node has launchers")
+		if _, ok := ms.perNode[lcfg]; ok {
+			t.Error("lcfg should be removed from perNode once no node has launchers")
 		}
-		if n := seriesCountForLcfg(t, lcfg); n != 0 {
-			t.Errorf("series count = %d, want 0 (series must be deleted, not left as zeros)", n)
-		}
+		assertLcfgAbsent(t, lcfg)
 	})
 }
 
@@ -349,12 +343,10 @@ func TestMetricsStatePublishZeroForAbsentKey(t *testing.T) {
 	launcherPodCountGauge.Reset()
 	ms := newMetricsState()
 	ms.publish(NodeLauncherKey{NodeName: "n", LauncherConfigName: "never"}, phaseCounts{})
-	if len(ms.perLcfg) != 0 {
-		t.Errorf("perLcfg should stay empty, got %v", ms.perLcfg)
+	if len(ms.perNode) != 0 {
+		t.Errorf("perNode should stay empty, got %v", ms.perNode)
 	}
-	if n := seriesCountForLcfg(t, "never"); n != 0 {
-		t.Errorf("series count = %d, want 0", n)
-	}
+	assertLcfgAbsent(t, "never")
 }
 
 // TestMetricsStatePublishIndependentLcfgs verifies that two LauncherConfigs do
@@ -368,33 +360,22 @@ func TestMetricsStatePublishIndependentLcfgs(t *testing.T) {
 	t.Run("both present independently", func(t *testing.T) {
 		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{phaseUnbound: 2})
 		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcY}, phaseCounts{phaseStuck: 1})
-		if n := seriesCountForLcfg(t, lcX); n != 4 {
-			t.Errorf("lcX series count = %d, want 4", n)
-		}
-		if n := seriesCountForLcfg(t, lcY); n != 4 {
-			t.Errorf("lcY series count = %d, want 4", n)
-		}
-		assertLcfgPhases(t, lcX, 0, 2, 0, 0)
-		assertLcfgPhases(t, lcY, 0, 0, 1, 0)
+		assertLcfgPhases(t, lcX, 0, 2, 0, 0, 0)
+		assertLcfgPhases(t, lcY, 0, 0, 0, 1, 0)
 	})
 
 	t.Run("deleting one keeps the other", func(t *testing.T) {
 		ms.publish(NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcX}, phaseCounts{})
-		if _, ok := ms.perLcfg[lcY]; !ok {
+		if _, ok := ms.perNode[lcY]; !ok {
 			t.Error("lcY must survive deletion of lcX")
 		}
-		if n := seriesCountForLcfg(t, lcX); n != 0 {
-			t.Errorf("lcX series count = %d, want 0 after deletion", n)
-		}
-		if n := seriesCountForLcfg(t, lcY); n != 4 {
-			t.Errorf("lcY series count = %d, want 4 (untouched)", n)
-		}
-		assertLcfgPhases(t, lcY, 0, 0, 1, 0)
+		assertLcfgAbsent(t, lcX)
+		assertLcfgPhases(t, lcY, 0, 0, 0, 1, 0)
 	})
 }
 
 // TestMetricsStatePublishConcurrent exercises the mutex in publish. Run with
-// -race to catch unsynchronized access to perLcfg / the gauge.
+// -race to catch unsynchronized access to perNode / agg / the gauge.
 func TestMetricsStatePublishConcurrent(t *testing.T) {
 	registerMetrics()
 	launcherPodCountGauge.Reset()
@@ -413,25 +394,77 @@ func TestMetricsStatePublishConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	if n := seriesCountForLcfg(t, lcfg); n != 4 {
-		t.Errorf("series count = %d, want 4", n)
-	}
-	assertLcfgPhases(t, lcfg, 0, nKeys, 0, 0) // every key contributed unbound:1
+	assertLcfgPhases(t, lcfg, 0, nKeys, 0, 0, 0) // every key contributed unbound:1
+}
+
+// TestMetricsStateSetLCExists verifies the "series exist while the
+// LauncherConfig object exists OR a launcher references it" semantics: the
+// series appear as soon as either does and disappear only once neither holds.
+func TestMetricsStateSetLCExists(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset()
+	ms := newMetricsState()
+	const lcfg = "lc-exists"
+	key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcfg}
+
+	// Steps share ms/gauge state and must run in order.
+	t.Run("LC object with no launchers reports explicit zeros", func(t *testing.T) {
+		ms.setLCExists(lcfg, true)
+		assertLcfgPhases(t, lcfg, 0, 0, 0, 0, 0)
+	})
+
+	t.Run("launchers add on top of the existing zeros", func(t *testing.T) {
+		ms.publish(key, phaseCounts{phaseUnbound: 2, phaseStuck: 1})
+		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
+	})
+
+	t.Run("deleting the LC object keeps series while a launcher remains", func(t *testing.T) {
+		ms.setLCExists(lcfg, false)
+		assertLcfgPhases(t, lcfg, 0, 2, 0, 1, 0)
+	})
+
+	t.Run("removing the last launcher then drops the series", func(t *testing.T) {
+		ms.publish(key, phaseCounts{})
+		assertLcfgAbsent(t, lcfg)
+	})
+}
+
+// TestMetricsStateLCObjectOutlivesLaunchers covers the other order: a launcher's
+// series must survive the launcher's own removal as long as the LauncherConfig
+// object still exists (reported as explicit zeros), and vanish once it too goes.
+func TestMetricsStateLCObjectOutlivesLaunchers(t *testing.T) {
+	registerMetrics()
+	launcherPodCountGauge.Reset()
+	ms := newMetricsState()
+	const lcfg = "lc-outlive"
+	key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: lcfg}
+
+	ms.setLCExists(lcfg, true)
+	ms.publish(key, phaseCounts{phaseUnbound: 1})
+	assertLcfgPhases(t, lcfg, 0, 1, 0, 0, 0)
+
+	// Launcher goes away but the LC object still exists -> zeros remain.
+	ms.publish(key, phaseCounts{})
+	assertLcfgPhases(t, lcfg, 0, 0, 0, 0, 0)
+
+	// LC object deleted too -> series gone.
+	ms.setLCExists(lcfg, false)
+	assertLcfgAbsent(t, lcfg)
 }
 
 // TestComputeKeyPhases covers the two behaviors the maintainer asked for that
 // live only in the tallying path: terminating Pods are still counted (#3), and
 // the earliest future "stuck" instant is computed for AddAfter scheduling (#1).
 func TestComputeKeyPhases(t *testing.T) {
-	ctl := &controller{stuckThreshold: 7*time.Minute + 30*time.Second}
+	ctl := &controller{pendingThreshold: 2 * time.Minute, stuckThreshold: 7*time.Minute + 30*time.Second}
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
-	recent := now.Add(-1 * time.Minute)
-	older := now.Add(-2 * time.Minute)
+	recent := now.Add(-30 * time.Second)
+	earlier := now.Add(-1 * time.Minute)
 	old := now.Add(-10 * time.Minute)
 
 	t.Run("terminating pod is counted but never scheduled", func(t *testing.T) {
 		// Unbound, not-Ready, young — would schedule AddAfter if not terminating.
-		pods := []*corev1.Pod{newLauncherPod().deleting().scheduledAt(recent).build()}
+		pods := []*corev1.Pod{newBuilder().deleting().scheduledAt(recent).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts[phaseUnbound] != 1 {
 			t.Errorf("terminating pod not counted: unbound=%d want 1", counts[phaseUnbound])
@@ -443,22 +476,22 @@ func TestComputeKeyPhases(t *testing.T) {
 
 	t.Run("earliest future-stuck instant across pods", func(t *testing.T) {
 		pods := []*corev1.Pod{
-			newLauncherPod().scheduledAt(recent).build(),         // stuck at recent+threshold
-			newLauncherPod().scheduledAt(older).build(),          // stuck at older+threshold (earlier)
-			newLauncherPod().ready().scheduledAt(recent).build(), // Ready: never becomes stuck
+			newBuilder().scheduledAt(recent).pod(),         // stuck at recent+threshold
+			newBuilder().scheduledAt(earlier).pod(),        // stuck at earlier+threshold (the winner)
+			newBuilder().ready().scheduledAt(recent).pod(), // Ready: never becomes stuck
 		}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts[phaseUnbound] != 3 {
 			t.Errorf("unbound=%d want 3", counts[phaseUnbound])
 		}
-		want := older.Add(ctl.stuckThreshold)
+		want := earlier.Add(ctl.stuckThreshold)
 		if !earliest.Equal(want) {
 			t.Errorf("earliestStuck=%v want %v", earliest, want)
 		}
 	})
 
 	t.Run("already-stuck pod does not schedule", func(t *testing.T) {
-		pods := []*corev1.Pod{newLauncherPod().scheduledAt(old).build()}
+		pods := []*corev1.Pod{newBuilder().scheduledAt(old).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts[phaseStuck] != 1 {
 			t.Errorf("stuck=%d want 1", counts[phaseStuck])
@@ -479,17 +512,33 @@ func TestComputeKeyPhases(t *testing.T) {
 	})
 
 	t.Run("exact-threshold boundary is not yet stuck and not scheduled", func(t *testing.T) {
-		// age since scheduling == threshold exactly. launcherPhaseOf uses strict
-		// '>', so it is still unbound; becomesStuckAt == now, and the strict
-		// After(now) guard must not schedule (guards against an AddAfter(0) loop).
+		// age since scheduling == stuckThreshold exactly. launcherPhaseOf uses
+		// strict '>', so it is still unbound; the transition instant == now, and
+		// the strict After(now) guard must not schedule (guards against an
+		// AddAfter(0) loop).
 		atThreshold := now.Add(-ctl.stuckThreshold)
-		pods := []*corev1.Pod{newLauncherPod().scheduledAt(atThreshold).build()}
+		pods := []*corev1.Pod{newBuilder().scheduledAt(atThreshold).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts[phaseUnbound] != 1 {
 			t.Errorf("boundary pod unbound=%d want 1", counts[phaseUnbound])
 		}
 		if !earliest.IsZero() {
-			t.Errorf("boundary pod (becomesStuckAt==now) must not schedule, got %v", earliest)
+			t.Errorf("boundary pod (transition instant == now) must not schedule, got %v", earliest)
+		}
+	})
+
+	t.Run("exact-pending-threshold boundary is not yet pending and not scheduled", func(t *testing.T) {
+		// Symmetric with the stuck boundary, on the pending track: age since
+		// creation == pendingThreshold exactly (never scheduled). Strict '>' keeps
+		// it unbound, and the transition instant == now must not schedule.
+		atThreshold := now.Add(-ctl.pendingThreshold)
+		pods := []*corev1.Pod{newBuilder().createdAt(atThreshold).pod()}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts[phaseUnbound] != 1 {
+			t.Errorf("boundary pod unbound=%d want 1", counts[phaseUnbound])
+		}
+		if !earliest.IsZero() {
+			t.Errorf("boundary pod (transition instant == now) must not schedule, got %v", earliest)
 		}
 	})
 
@@ -500,8 +549,8 @@ func TestComputeKeyPhases(t *testing.T) {
 		earliestSched := now.Add(-3 * time.Minute)
 		laterSched := now.Add(-1 * time.Minute)
 		pods := []*corev1.Pod{
-			newLauncherPod().ready().scheduledAt(earliestSched).build(), // Ready: must be skipped
-			newLauncherPod().scheduledAt(laterSched).build(),            // not Ready: the real winner
+			newBuilder().ready().scheduledAt(earliestSched).pod(), // Ready: must be skipped
+			newBuilder().scheduledAt(laterSched).pod(),            // not Ready: the real winner
 		}
 		_, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		want := laterSched.Add(ctl.stuckThreshold)
@@ -510,26 +559,39 @@ func TestComputeKeyPhases(t *testing.T) {
 		}
 	})
 
-	t.Run("earliestStuck from unscheduled pod uses creation time", func(t *testing.T) {
-		// No PodScheduled condition -> reference is creation time.
-		pods := []*corev1.Pod{newLauncherPod().createdAt(recent).build()}
+	t.Run("earliestStuck from unscheduled pod uses creation time and pending threshold", func(t *testing.T) {
+		// No PodScheduled condition -> pending track, measured from creation.
+		pods := []*corev1.Pod{newBuilder().createdAt(recent).pod()}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts[phaseUnbound] != 1 {
 			t.Errorf("unbound=%d want 1", counts[phaseUnbound])
 		}
-		want := recent.Add(ctl.stuckThreshold)
+		want := recent.Add(ctl.pendingThreshold)
 		if !earliest.Equal(want) {
-			t.Errorf("earliestStuck=%v want %v (from creation time)", earliest, want)
+			t.Errorf("earliestStuck=%v want %v (creation time + pending threshold)", earliest, want)
+		}
+	})
+
+	t.Run("unscheduled past pending threshold counts pending and does not schedule", func(t *testing.T) {
+		// Never scheduled and older than the pending threshold -> pending, and
+		// already past its transition so it schedules nothing.
+		pods := []*corev1.Pod{newBuilder().createdAt(old).pod()}
+		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
+		if counts[phasePending] != 1 {
+			t.Errorf("pending=%d want 1", counts[phasePending])
+		}
+		if !earliest.IsZero() {
+			t.Errorf("already-pending pod must not schedule, got %v", earliest)
 		}
 	})
 
 	t.Run("mixed phases: counts every pod, schedules only qualifying unbound", func(t *testing.T) {
 		pods := []*corev1.Pod{
-			newLauncherPod().bound().build(),                     // bound
-			newLauncherPod().hash("superseded").build(),          // stale
-			newLauncherPod().scheduledAt(old).build(),            // stuck (not ready, past threshold)
-			newLauncherPod().scheduledAt(recent).build(),         // unbound, counting down
-			newLauncherPod().ready().scheduledAt(recent).build(), // unbound, Ready
+			newBuilder().bound().pod(),                     // bound
+			newBuilder().hash("superseded").pod(),          // stale
+			newBuilder().scheduledAt(old).pod(),            // stuck (not ready, past threshold)
+			newBuilder().scheduledAt(recent).pod(),         // unbound, counting down
+			newBuilder().ready().scheduledAt(recent).pod(), // unbound, Ready
 		}
 		counts, earliest := ctl.computeKeyPhases(pods, testTemplateHash, now)
 		if counts.total() != len(pods) {
@@ -570,15 +632,20 @@ func (q *recordingQueue) AddAfter(item keyItem, d time.Duration) {
 // AddAfter.
 func TestRecordLauncherPhases(t *testing.T) {
 	registerMetrics()
-	const threshold = 7*time.Minute + 30*time.Second
+	const pendingThreshold = 2 * time.Minute
+	const stuckThreshold = 7*time.Minute + 30*time.Second
+	// A fixed fake clock lets us assert the AddAfter delay exactly.
+	base := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 
 	setup := func() (*controller, *recordingQueue) {
 		launcherPodCountGauge.Reset()
 		q := &recordingQueue{}
 		ctl := &controller{
-			stuckThreshold: threshold,
-			metrics:        newMetricsState(),
-			keyQueue:       &genctlr.QueueAndWorkers[keyItem]{Queue: q},
+			pendingThreshold: pendingThreshold,
+			stuckThreshold:   stuckThreshold,
+			clock:            testingclock.NewFakeClock(base),
+			metrics:          newMetricsState(),
+			keyQueue:         &genctlr.QueueAndWorkers[keyItem]{Queue: q},
 		}
 		return ctl, q
 	}
@@ -586,20 +653,21 @@ func TestRecordLauncherPhases(t *testing.T) {
 	t.Run("publishes counts and schedules the future stuck transition", func(t *testing.T) {
 		ctl, q := setup()
 		key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: "lc-rec"}
-		// Unbound, not Ready, just scheduled -> counting down.
-		pods := []*corev1.Pod{newLauncherPod().scheduledAt(time.Now()).build()}
+		// Unbound, not Ready, scheduled exactly at (fake) now -> counts down and
+		// becomes stuck exactly stuckThreshold later.
+		pods := []*corev1.Pod{newBuilder().scheduledAt(base).pod()}
 
 		ctl.recordLauncherPhases(key, pods, testTemplateHash)
 
-		assertLcfgPhases(t, "lc-rec", 0, 1, 0, 0) // publish happened
+		assertLcfgPhases(t, "lc-rec", 0, 1, 0, 0, 0) // publish happened
 		if len(q.added) != 1 {
 			t.Fatalf("AddAfter calls = %d, want 1", len(q.added))
 		}
 		if q.added[0].item != (keyItem{NodeLauncherKey: key}) {
 			t.Errorf("scheduled item = %+v, want key %+v", q.added[0].item, key)
 		}
-		if d := q.added[0].delay; d <= 0 || d > threshold {
-			t.Errorf("scheduled delay = %v, want in (0, %v]", d, threshold)
+		if d := q.added[0].delay; d != stuckThreshold {
+			t.Errorf("scheduled delay = %v, want %v", d, stuckThreshold)
 		}
 	})
 
@@ -607,11 +675,11 @@ func TestRecordLauncherPhases(t *testing.T) {
 		ctl, q := setup()
 		key := NodeLauncherKey{NodeName: "n1", LauncherConfigName: "lc-rec2"}
 		// Ready -> unbound but never becomes stuck.
-		pods := []*corev1.Pod{newLauncherPod().ready().scheduledAt(time.Now()).build()}
+		pods := []*corev1.Pod{newBuilder().ready().scheduledAt(base).pod()}
 
 		ctl.recordLauncherPhases(key, pods, testTemplateHash)
 
-		assertLcfgPhases(t, "lc-rec2", 0, 1, 0, 0)
+		assertLcfgPhases(t, "lc-rec2", 0, 1, 0, 0, 0)
 		if len(q.added) != 0 {
 			t.Errorf("AddAfter calls = %d, want 0", len(q.added))
 		}

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -58,21 +58,26 @@ func NewController(
 	corev1PreInformers corev1preinformers.Interface,
 	fmaInformerFactory fmainformers.SharedInformerFactory,
 	expectationTimeout time.Duration,
+	stuckThreshold time.Duration,
+	metricsResyncPeriod time.Duration,
 ) (*controller, error) {
+	registerMetrics()
 	ctl := &controller{
-		enqueueLogger: logger.WithName(ControllerName),
-		coreclient:    coreClient,
-		fmaclient:     fmaClient,
-		namespace:     namespace,
-		podInformer:   corev1PreInformers.Pods().Informer(),
-		podLister:     corev1PreInformers.Pods().Lister(),
-		nodeInformer:  corev1PreInformers.Nodes().Informer(),
-		nodeLister:    corev1PreInformers.Nodes().Lister(),
-		lppInformer:   fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
-		lppLister:     fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
-		lcInformer:    fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
-		lcLister:      fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
-		expectations:  newPendingExpectations(expectationTimeout),
+		enqueueLogger:       logger.WithName(ControllerName),
+		coreclient:          coreClient,
+		fmaclient:           fmaClient,
+		namespace:           namespace,
+		podInformer:         corev1PreInformers.Pods().Informer(),
+		podLister:           corev1PreInformers.Pods().Lister(),
+		nodeInformer:        corev1PreInformers.Nodes().Informer(),
+		nodeLister:          corev1PreInformers.Nodes().Lister(),
+		lppInformer:         fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
+		lppLister:           fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
+		lcInformer:          fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
+		lcLister:            fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
+		expectations:        newPendingExpectations(expectationTimeout),
+		stuckThreshold:      stuckThreshold,
+		metricsResyncPeriod: metricsResyncPeriod,
 	}
 	ctl.policy = newDigestedPolicy()
 
@@ -151,6 +156,15 @@ type controller struct {
 	// It is the single source of truth for per-key reconciliation.
 	// Written only by the digestQueue worker; read by keyQueue workers.
 	policy *digestedPolicy
+
+	// stuckThreshold is the minimum age (from scheduling) after which a
+	// not-yet-Ready launcher is reported in the "stuck" phase of the
+	// fma_launcher_count metric. It does not change reconcile behavior.
+	stuckThreshold time.Duration
+
+	// metricsResyncPeriod is how often runMetricsLoop recomputes the
+	// launcher-count gauge from the informer cache.
+	metricsResyncPeriod time.Duration
 }
 
 var _ Controller = &controller{}
@@ -305,6 +319,10 @@ func (ctl *controller) Start(ctx context.Context) error {
 	if !cache.WaitForNamedCacheSync(ControllerName, ctx.Done(), ctl.lppInformer.HasSynced, ctl.lcInformer.HasSynced, ctl.podInformer.HasSynced, ctl.nodeInformer.HasSynced) {
 		return fmt.Errorf("caches not synced before end of Start context")
 	}
+
+	// Publish the launcher-count metric periodically. Runs independently of the
+	// work queues; the informer caches are synced by this point.
+	go ctl.runMetricsLoop(ctx)
 
 	// Start digest workers. KnowsProcessedSync appends sentinels behind the
 	// initial batch and invokes onDigestSyncProcessed when those sentinels are

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -59,25 +59,24 @@ func NewController(
 	fmaInformerFactory fmainformers.SharedInformerFactory,
 	expectationTimeout time.Duration,
 	stuckThreshold time.Duration,
-	metricsResyncPeriod time.Duration,
 ) (*controller, error) {
 	registerMetrics()
 	ctl := &controller{
-		enqueueLogger:       logger.WithName(ControllerName),
-		coreclient:          coreClient,
-		fmaclient:           fmaClient,
-		namespace:           namespace,
-		podInformer:         corev1PreInformers.Pods().Informer(),
-		podLister:           corev1PreInformers.Pods().Lister(),
-		nodeInformer:        corev1PreInformers.Nodes().Informer(),
-		nodeLister:          corev1PreInformers.Nodes().Lister(),
-		lppInformer:         fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
-		lppLister:           fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
-		lcInformer:          fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
-		lcLister:            fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
-		expectations:        newPendingExpectations(expectationTimeout),
-		stuckThreshold:      stuckThreshold,
-		metricsResyncPeriod: metricsResyncPeriod,
+		enqueueLogger:  logger.WithName(ControllerName),
+		coreclient:     coreClient,
+		fmaclient:      fmaClient,
+		namespace:      namespace,
+		podInformer:    corev1PreInformers.Pods().Informer(),
+		podLister:      corev1PreInformers.Pods().Lister(),
+		nodeInformer:   corev1PreInformers.Nodes().Informer(),
+		nodeLister:     corev1PreInformers.Nodes().Lister(),
+		lppInformer:    fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
+		lppLister:      fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
+		lcInformer:     fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
+		lcLister:       fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
+		expectations:   newPendingExpectations(expectationTimeout),
+		stuckThreshold: stuckThreshold,
+		metrics:        newMetricsState(),
 	}
 	ctl.policy = newDigestedPolicy()
 
@@ -157,14 +156,15 @@ type controller struct {
 	// Written only by the digestQueue worker; read by keyQueue workers.
 	policy *digestedPolicy
 
-	// stuckThreshold is the minimum age (from scheduling) after which a
-	// not-yet-Ready launcher is reported in the "stuck" phase of the
-	// fma_launcher_count metric. It does not change reconcile behavior.
+	// stuckThreshold is the minimum age (from scheduling, or from creation when
+	// not scheduled) after which a not-yet-Ready launcher is reported in the
+	// "stuck" phase of the fma_launcher_pod_count metric. It does not change
+	// reconcile behavior.
 	stuckThreshold time.Duration
 
-	// metricsResyncPeriod is how often runMetricsLoop recomputes the
-	// launcher-count gauge from the informer cache.
-	metricsResyncPeriod time.Duration
+	// metrics backs the fma_launcher_pod_count gauge; it is updated from
+	// reconcileKey as launcher Pods are observed.
+	metrics *metricsState
 }
 
 var _ Controller = &controller{}
@@ -320,10 +320,6 @@ func (ctl *controller) Start(ctx context.Context) error {
 		return fmt.Errorf("caches not synced before end of Start context")
 	}
 
-	// Publish the launcher-count metric periodically. Runs independently of the
-	// work queues; the informer caches are synced by this point.
-	go ctl.runMetricsLoop(ctx)
-
 	// Start digest workers. KnowsProcessedSync appends sentinels behind the
 	// initial batch and invokes onDigestSyncProcessed when those sentinels are
 	// drained, which is when keyQueue starts its workers.
@@ -383,6 +379,20 @@ func (ctl *controller) processKey(ctx context.Context, key NodeLauncherKey) (err
 	logger := klog.FromContext(ctx)
 
 	snap := ctl.policy.snapshotForKey(key)
+
+	// Update the fma_launcher_pod_count metric for this key from the observed
+	// launcher Pods (classifying all of them, including any being deleted). This
+	// runs for every key reconcile — before the desired-state and node-existence
+	// branches below — so a LauncherConfig's series never go stale when a Node is
+	// deleted or the key becomes handsOff, and are dropped once no launcher Pods
+	// remain.
+	if pods, err := ctl.listPodsFromCache(key); err != nil {
+		logger.Error(err, "Failed to list launcher Pods for metrics",
+			"node", key.NodeName, "config", key.LauncherConfigName)
+	} else {
+		ctl.recordLauncherPhases(key, pods, snap.templateHash)
+	}
+
 	if !snap.exists {
 		// Key not in digest: no policy wants this (node, LC) pair.
 		// Clean up any orphaned launchers.

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -34,6 +34,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 
 	fmav1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	genctlr "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/generic"
@@ -58,25 +59,28 @@ func NewController(
 	corev1PreInformers corev1preinformers.Interface,
 	fmaInformerFactory fmainformers.SharedInformerFactory,
 	expectationTimeout time.Duration,
+	pendingThreshold time.Duration,
 	stuckThreshold time.Duration,
 ) (*controller, error) {
 	registerMetrics()
 	ctl := &controller{
-		enqueueLogger:  logger.WithName(ControllerName),
-		coreclient:     coreClient,
-		fmaclient:      fmaClient,
-		namespace:      namespace,
-		podInformer:    corev1PreInformers.Pods().Informer(),
-		podLister:      corev1PreInformers.Pods().Lister(),
-		nodeInformer:   corev1PreInformers.Nodes().Informer(),
-		nodeLister:     corev1PreInformers.Nodes().Lister(),
-		lppInformer:    fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
-		lppLister:      fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
-		lcInformer:     fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
-		lcLister:       fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
-		expectations:   newPendingExpectations(expectationTimeout),
-		stuckThreshold: stuckThreshold,
-		metrics:        newMetricsState(),
+		enqueueLogger:    logger.WithName(ControllerName),
+		coreclient:       coreClient,
+		fmaclient:        fmaClient,
+		namespace:        namespace,
+		podInformer:      corev1PreInformers.Pods().Informer(),
+		podLister:        corev1PreInformers.Pods().Lister(),
+		nodeInformer:     corev1PreInformers.Nodes().Informer(),
+		nodeLister:       corev1PreInformers.Nodes().Lister(),
+		lppInformer:      fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
+		lppLister:        fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
+		lcInformer:       fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
+		lcLister:         fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
+		expectations:     newPendingExpectations(expectationTimeout),
+		pendingThreshold: pendingThreshold,
+		stuckThreshold:   stuckThreshold,
+		clock:            clock.RealClock{},
+		metrics:          newMetricsState(),
 	}
 	ctl.policy = newDigestedPolicy()
 
@@ -156,14 +160,25 @@ type controller struct {
 	// Written only by the digestQueue worker; read by keyQueue workers.
 	policy *digestedPolicy
 
-	// stuckThreshold is the minimum age (from scheduling, or from creation when
-	// not scheduled) after which a not-yet-Ready launcher is reported in the
-	// "stuck" phase of the fma_launcher_pod_count metric. It does not change
-	// reconcile behavior.
+	// pendingThreshold is the greatest age (since creation) at which an
+	// unscheduled, not-yet-Ready launcher is still considered not "pending":
+	// once its age exceeds this, it is reported in the "pending" phase of the
+	// fma_launcher_pod_count metric. It does not change reconcile behavior.
+	pendingThreshold time.Duration
+
+	// stuckThreshold is the greatest age (since scheduling) at which a scheduled,
+	// not-yet-Ready launcher is still considered not "stuck": once its age
+	// exceeds this, it is reported in the "stuck" phase of the
+	// fma_launcher_pod_count metric. It does not change reconcile behavior.
 	stuckThreshold time.Duration
 
+	// clock is the time source for metric classification; real in production,
+	// a fake in tests so time-dependent classification can be controlled.
+	clock clock.Clock
+
 	// metrics backs the fma_launcher_pod_count gauge; it is updated from
-	// reconcileKey as launcher Pods are observed.
+	// processKey (per-key launcher tallies) and from updateDigestForLC (whether a
+	// LauncherConfig object exists).
 	metrics *metricsState
 }
 
@@ -380,25 +395,22 @@ func (ctl *controller) processKey(ctx context.Context, key NodeLauncherKey) (err
 
 	snap := ctl.policy.snapshotForKey(key)
 
-	// Update the fma_launcher_pod_count metric for this key from the observed
-	// launcher Pods (classifying all of them, including any being deleted). This
-	// runs for every key reconcile — before the desired-state and node-existence
-	// branches below — so a LauncherConfig's series never go stale when a Node is
-	// deleted or the key becomes handsOff, and are dropped once no launcher Pods
-	// remain.
-	if pods, err := ctl.listPodsFromCache(key); err != nil {
-		logger.Error(err, "Failed to list launcher Pods for metrics",
-			"node", key.NodeName, "config", key.LauncherConfigName)
-	} else {
-		ctl.recordLauncherPhases(key, pods, snap.templateHash)
+	// List the launcher Pods once and reuse the slice for both the metric and the
+	// reconcile below. Recording here, before the branches that may return early,
+	// keeps the metric up to date even when a Node is deleted or the key is handsOff.
+	pods, err := ctl.listPodsFromCache(key)
+	if err != nil {
+		return fmt.Errorf("listing launcher Pods for node %s config %s: %w",
+			key.NodeName, key.LauncherConfigName, err), true
 	}
+	ctl.recordLauncherPhases(key, pods, snap.templateHash)
 
 	if !snap.exists {
 		// Key not in digest: no policy wants this (node, LC) pair.
 		// Clean up any orphaned launchers.
 		logger.V(4).Info("Key not in digest, cleaning up orphaned launchers",
 			"node", key.NodeName, "config", key.LauncherConfigName)
-		return ctl.reconcileKey(ctx, key, 0, snap.templateHash, nil)
+		return ctl.reconcileKey(ctx, key, 0, snap.templateHash, nil, pods)
 	}
 
 	if snap.desiredCount < 0 {
@@ -408,11 +420,13 @@ func (ctl *controller) processKey(ctx context.Context, key NodeLauncherKey) (err
 		return nil, false
 	}
 
-	return ctl.reconcileKey(ctx, key, snap.desiredCount, snap.templateHash, snap.nodeIndependentLauncherTemplate)
+	return ctl.reconcileKey(ctx, key, snap.desiredCount, snap.templateHash, snap.nodeIndependentLauncherTemplate, pods)
 }
 
-// reconcileKey adjusts launcher pods for a single NodeLauncherKey to match the desired count.
-func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, desiredCount int, templateHash string, nodeIndependentLauncherTemplate *corev1.Pod) (error, bool) {
+// reconcileKey adjusts launcher pods for a single NodeLauncherKey to match the
+// desired count. cachePods is the caller's launcher-Pod cache snapshot for the
+// key, reused to avoid a second cache List.
+func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, desiredCount int, templateHash string, nodeIndependentLauncherTemplate *corev1.Pod, cachePods []*corev1.Pod) (error, bool) {
 	logger := klog.FromContext(ctx)
 
 	// Check node existence.
@@ -426,7 +440,7 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	}
 
 	// Get current launchers and check expectations.
-	currentLaunchers, expectStatus, err := ctl.getCurrentLaunchersOnNode(ctx, key)
+	currentLaunchers, expectStatus, err := ctl.getCurrentLaunchersOnNode(ctx, key, cachePods)
 	if err != nil {
 		logger.Error(err, "Failed to get current launchers", "node", key.NodeName, "config", key.LauncherConfigName)
 		return err, true
@@ -534,24 +548,20 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	return nil, false
 }
 
-// getCurrentLaunchersOnNode returns launcher pods for a specific config on a specific node.
-// It reads the informer cache and uses the resulting UID set to reconcile any
-// pending expectations, then returns one of:
+// getCurrentLaunchersOnNode reconciles pending expectations for a specific
+// config on a specific node against the caller's cache snapshot (cachePods), then
+// returns one of:
 //   - ExpectationsSatisfied with the cache snapshot, when no expectations are
 //     pending (or all have been satisfied by the current snapshot);
 //   - ExpectationsWaiting with a nil slice, indicating the caller should
 //     requeue without acting on this key;
 //   - ExpectationsTimedOut with the authoritative apiserver snapshot, after
 //     resetting the (now stale) expectations.
-func (ctl *controller) getCurrentLaunchersOnNode(ctx context.Context, key NodeLauncherKey) ([]*corev1.Pod, ExpectationStatus, error) {
+func (ctl *controller) getCurrentLaunchersOnNode(ctx context.Context, key NodeLauncherKey, cachePods []*corev1.Pod) ([]*corev1.Pod, ExpectationStatus, error) {
 	logger := klog.FromContext(ctx)
 
-	pods, err := ctl.listPodsFromCache(key)
-	if err != nil {
-		return nil, ExpectationsSatisfied, err
-	}
 	presentUIDs := sets.New[types.UID]()
-	for _, p := range pods {
+	for _, p := range cachePods {
 		presentUIDs.Insert(p.UID)
 	}
 
@@ -559,7 +569,7 @@ func (ctl *controller) getCurrentLaunchersOnNode(ctx context.Context, key NodeLa
 	switch status {
 	case ExpectationsSatisfied:
 		// Fast path: informer cache is considered up-to-date.
-		return pods, status, nil
+		return cachePods, status, nil
 
 	case ExpectationsWaiting:
 		// Pending mutations not yet reflected; caller should requeue.

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -59,28 +59,28 @@ func NewController(
 	corev1PreInformers corev1preinformers.Interface,
 	fmaInformerFactory fmainformers.SharedInformerFactory,
 	expectationTimeout time.Duration,
-	pendingThreshold time.Duration,
-	stuckThreshold time.Duration,
+	stuckSchedulingThreshold time.Duration,
+	stuckStartingThreshold time.Duration,
 ) (*controller, error) {
 	registerMetrics()
 	ctl := &controller{
-		enqueueLogger:    logger.WithName(ControllerName),
-		coreclient:       coreClient,
-		fmaclient:        fmaClient,
-		namespace:        namespace,
-		podInformer:      corev1PreInformers.Pods().Informer(),
-		podLister:        corev1PreInformers.Pods().Lister(),
-		nodeInformer:     corev1PreInformers.Nodes().Informer(),
-		nodeLister:       corev1PreInformers.Nodes().Lister(),
-		lppInformer:      fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
-		lppLister:        fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
-		lcInformer:       fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
-		lcLister:         fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
-		expectations:     newPendingExpectations(expectationTimeout),
-		pendingThreshold: pendingThreshold,
-		stuckThreshold:   stuckThreshold,
-		clock:            clock.RealClock{},
-		metrics:          newMetricsState(),
+		enqueueLogger:            logger.WithName(ControllerName),
+		coreclient:               coreClient,
+		fmaclient:                fmaClient,
+		namespace:                namespace,
+		podInformer:              corev1PreInformers.Pods().Informer(),
+		podLister:                corev1PreInformers.Pods().Lister(),
+		nodeInformer:             corev1PreInformers.Nodes().Informer(),
+		nodeLister:               corev1PreInformers.Nodes().Lister(),
+		lppInformer:              fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Informer(),
+		lppLister:                fmaInformerFactory.Fma().V1alpha1().LauncherPopulationPolicies().Lister(),
+		lcInformer:               fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Informer(),
+		lcLister:                 fmaInformerFactory.Fma().V1alpha1().LauncherConfigs().Lister(),
+		expectations:             newPendingExpectations(expectationTimeout),
+		stuckSchedulingThreshold: stuckSchedulingThreshold,
+		stuckStartingThreshold:   stuckStartingThreshold,
+		clock:                    clock.RealClock{},
+		metrics:                  newMetricsState(),
 	}
 	ctl.policy = newDigestedPolicy()
 
@@ -160,17 +160,16 @@ type controller struct {
 	// Written only by the digestQueue worker; read by keyQueue workers.
 	policy *digestedPolicy
 
-	// pendingThreshold is the greatest age (since creation) at which an
-	// unscheduled, not-yet-Ready launcher is still considered not "pending":
-	// once its age exceeds this, it is reported in the "pending" phase of the
+	// stuckSchedulingThreshold is the minimum age (since creation) at which an
+	// unscheduled launcher is reported in the "stuck_scheduling" phase of the
 	// fma_launcher_pod_count metric. It does not change reconcile behavior.
-	pendingThreshold time.Duration
+	stuckSchedulingThreshold time.Duration
 
-	// stuckThreshold is the greatest age (since scheduling) at which a scheduled,
-	// not-yet-Ready launcher is still considered not "stuck": once its age
-	// exceeds this, it is reported in the "stuck" phase of the
-	// fma_launcher_pod_count metric. It does not change reconcile behavior.
-	stuckThreshold time.Duration
+	// stuckStartingThreshold is the minimum age (since scheduling) at which a
+	// scheduled, not-yet-Ready launcher is reported in the "stuck_starting"
+	// phase of the fma_launcher_pod_count metric. It does not change reconcile
+	// behavior.
+	stuckStartingThreshold time.Duration
 
 	// clock is the time source for metric classification; real in production,
 	// a fake in tests so time-dependent classification can be controlled.
@@ -548,7 +547,7 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	return nil, false
 }
 
-// getCurrentLaunchersOnNode reconciles pending expectations for a specific
+// getCurrentLaunchersOnNode compares pending expectations for a specific
 // config on a specific node against the caller's cache snapshot (cachePods), then
 // returns one of:
 //   - ExpectationsSatisfied with the cache snapshot, when no expectations are

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -459,7 +459,7 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 			deletionInProgress = true
 			continue
 		}
-		isBound, _ := ctl.isLauncherBoundToServerRequestingPod(pod)
+		isBound, _ := isLauncherBoundToServerRequestingPod(pod)
 		if isBound {
 			liveBoundCount++
 			continue


### PR DESCRIPTION
This is the first part of the PR aimed at addressing the issue raised in #585.

The launcher-populator previously exposed no metrics. This PR wires pkg/observability into it (Prometheus /metrics + Go /debug/pprof) and adds a gauge:

fma_launcher_pod_count{lcfg_name, phase}

phase is one of bound, unbound, stuck, or stale. A launcher is stuck when it uses the current template, is unbound, has been scheduled longer than a configurable threshold, and is not yet Ready — surfacing launchers that fail to start