### PR TITLE
Refactor requester to expose server start

### DIFF
--- a/cmd/requester/main.go
+++ b/cmd/requester/main.go
@@ -56,6 +56,7 @@ func main() {
 	serveSPI, err := coordination.Start(ctx, spiPort, &ready, os.Stdout)
 	if err != nil {
 		logger.Error(err, "Failed to start requester SPI server")
+		os.Exit(10)
 		return
 	}
 

--- a/cmd/requester/main.go
+++ b/cmd/requester/main.go
@@ -53,12 +53,16 @@ func main() {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	serveSPI, err := coordination.Start(ctx, spiPort, &ready, os.Stdout)
+	if err != nil {
+		logger.Error(err, "Failed to start requester SPI server")
+		return
+	}
+
 	go func() {
 		defer wg.Done()
-
-		err := coordination.Run(ctx, spiPort, &ready, os.Stdout)
-		if err != nil {
-			logger.Error(err, "failed to start requester SPI server")
+		if err := serveSPI(); err != nil {
+			logger.Error(err, "Failed to run requester SPI server")
 		}
 	}()
 

--- a/cmd/test-requester/main.go
+++ b/cmd/test-requester/main.go
@@ -112,12 +112,16 @@ func main() {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	serveSPI, err := coordination.StartWithGPUUUIDs(ctx, strconv.FormatInt(int64(spiPort), 10), &ready, os.Stdout, gpuUUIDs)
+	if err != nil {
+		logger.Error(err, "Failed to start requester SPI server")
+		os.Exit(10)
+	}
 	go func() {
 		defer wg.Done()
 
-		err := coordination.RunWithGPUUUIDs(ctx, strconv.FormatInt(int64(spiPort), 10), &ready, os.Stdout, gpuUUIDs)
-		if err != nil {
-			logger.Error(err, "failed to start requester SPI server")
+		if err := serveSPI(); err != nil {
+			logger.Error(err, "Failed to run requester SPI server")
 		}
 	}()
 

--- a/pkg/server/requester/coordination/server.go
+++ b/pkg/server/requester/coordination/server.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os/exec"
 	"strconv"
@@ -71,9 +72,12 @@ func getGpuUUIDs() ([]string, error) {
 	return uuids, nil
 }
 
-// Run starts an HTTP server managing the endpoints
+// Start starts an HTTP server managing the endpoints
 // consumed by the dual-pods controller.
-func Run(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer) error {
+// Returns two values.
+// The second is the error, if any, that arose from trying to start the network listener.
+// The first is the func that will do the serving and return any error that arose (nil for clean shutdown).
+func Start(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer) (func() error, error) {
 	logger := klog.FromContext(ctx).WithName("spi-server")
 
 	gpuUUIDs, err := getGpuUUIDs()
@@ -85,7 +89,7 @@ func Run(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writ
 	} else {
 		logger.Info("Got GPU UUIDs", "uuids", gpuUUIDs)
 	}
-	return RunWithGPUUUIDs(ctx, port, ready, logWriter, gpuUUIDs)
+	return StartWithGPUUUIDs(ctx, port, ready, logWriter, gpuUUIDs)
 }
 
 func gpuMemoryHandler(logger klog.Logger) func(w http.ResponseWriter, r *http.Request) {
@@ -204,7 +208,10 @@ func newSetLogHandler(logger klog.Logger, logWriter io.Writer) func(w http.Respo
 	}
 }
 
-func RunWithGPUUUIDs(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer, gpuUUIDs []string) error {
+// StartWithGPUUUIDs returns two values.
+// The second is the error, if any, that arose from trying to start the network listener.
+// The first is the func that will do the serving and return any error that arose (nil for clean shutdown).
+func StartWithGPUUUIDs(ctx context.Context, port string, ready *atomic.Bool, logWriter io.Writer, gpuUUIDs []string) (func() error, error) {
 	logger := klog.FromContext(ctx).WithName("spi-server")
 	mux := http.NewServeMux()
 	mux.HandleFunc(strings.Join([]string{"GET", stubapi.AcceleratorQueryPath}, " "), gpuHandler(gpuUUIDs))
@@ -214,27 +221,33 @@ func RunWithGPUUUIDs(ctx context.Context, port string, ready *atomic.Bool, logWr
 	mux.HandleFunc("POST "+stubapi.SetLogPath, newSetLogHandler(logger, logWriter))
 
 	server := &http.Server{
-		Addr:    ":" + port,
-		Handler: mux,
+		Addr:        ":" + port,
+		BaseContext: func(l net.Listener) context.Context { return ctx },
+		Handler:     mux,
 	}
 
-	// Setup graceful termination
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return nil, err
+	}
 	go func() {
 		<-ctx.Done()
-		logger.Info("shutting down")
+		logger.Info("Shutting down requester SPI server")
 
 		ctx, cancelFn := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancelFn()
 		if err := server.Shutdown(ctx); err != nil {
-			logger.Error(err, "failed to gracefully shutdown")
+			logger.Error(err, "failed to gracefully shutdown in 60 seconds")
 		}
+		_ = listener.Close()
 	}()
-
-	logger.Info("starting server", "port", port)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("listen and serve error: %w", err)
-	}
-
-	logger.Info("server stopped")
-	return nil
+	return func() error {
+		logger.Info("Starting requester SPI server", "port", port)
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		logger.Info("Stopped requester SPI server")
+		_ = listener.Close()
+		return nil
+	}, nil
 }

--- a/pkg/server/requester/coordination/server_test.go
+++ b/pkg/server/requester/coordination/server_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
@@ -38,10 +39,13 @@ func FuzzServer(f *testing.F) {
 	var ready atomic.Bool
 	ctx, cancel := context.WithCancel(f.Context())
 	port := "28083"
+	serveSPI, err := StartWithGPUUUIDs(ctx, port, &ready, nil, gpuIDs)
+	if err != nil {
+		f.Fatalf("Server start failed: %s", err.Error())
+	}
 	go func() {
-		err := RunWithGPUUUIDs(ctx, port, &ready, nil, gpuIDs)
-		if err != nil {
-			f.Logf("Run failed: %s", err.Error())
+		if err := serveSPI(); err != nil {
+			f.Logf("Server run failed: %s", err.Error())
 		}
 	}()
 	paths := map[bool]string{false: stubapi.BecomeUnreadyPath, true: stubapi.BecomeReadyPath}
@@ -88,10 +92,13 @@ func TestLogChunking(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	var ready atomic.Bool
 	port := "28084"
+	serveSPI, err := StartWithGPUUUIDs(ctx, port, &ready, &logBuilder, []string{"x"})
+	if err != nil {
+		t.Fatalf("Server start failed: %s", err.Error())
+	}
 	go func() {
-		err := RunWithGPUUUIDs(ctx, port, &ready, &logBuilder, []string{"x"})
-		if err != nil {
-			t.Logf("Run failed: %s", err.Error())
+		if err := serveSPI(); err != nil {
+			t.Logf("Server run failed: %s", err.Error())
 		}
 	}()
 	for {
@@ -143,4 +150,76 @@ func TestLogChunking(t *testing.T) {
 		}
 	}
 	cancel()
+}
+
+// TestRequestBeforeServe tests what happens if a request is sent between
+// listener creation and `http.Serve`.
+func TestRequestBeforeServe(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	var ready atomic.Bool
+	var logBuilder strings.Builder
+	port := "28085"
+	serveSPI, err := StartWithGPUUUIDs(ctx, port, &ready, &logBuilder, []string{"x"})
+	if err != nil {
+		t.Fatalf("Server start failed: %s", err.Error())
+	}
+	responseCh := make(chan *http.Response)
+	shutdownCh := make(chan struct{})
+	go func() {
+		resp, err := http.Get("http://localhost:" + port + stubapi.AcceleratorQueryPath)
+		if err != nil {
+			t.Errorf("Failed to GET: %s", err.Error())
+		} else {
+			body, bodyErr := io.ReadAll(resp.Body)
+			t.Logf("Succeeded to GET: body=%v, bodyErr=%v", string(body), bodyErr)
+			_ = resp.Body.Close()
+		}
+		responseCh <- resp
+	}()
+	time.Sleep(10 * time.Second)
+	go func() {
+		if err := serveSPI(); err != nil {
+			t.Logf("Server run failed: %s", err.Error())
+		} else {
+			t.Log("serveSPI returned clean")
+		}
+		close(shutdownCh)
+	}()
+	timer := time.NewTimer(20 * time.Second)
+	defer func() { timer.Stop() }()
+	select {
+	case <-responseCh:
+	case <-timer.C:
+		t.Fatalf("Response not received in time")
+	}
+	cancel()
+	<-shutdownCh
+}
+
+func TestShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	var ready atomic.Bool
+	var logBuilder strings.Builder
+	port := "28086"
+	shutdownCh := make(chan struct{})
+	serveSPI, err := StartWithGPUUUIDs(ctx, port, &ready, &logBuilder, []string{"x"})
+	if err != nil {
+		t.Fatalf("Server start failed: %s", err.Error())
+	}
+	go func() {
+		if err := serveSPI(); err != nil {
+			t.Logf("Server run failed: %s", err.Error())
+		} else {
+			t.Log("serveSPI returned clean")
+		}
+		close(shutdownCh)
+	}()
+	cancel()
+	timer := time.NewTimer(20 * time.Second)
+	defer func() { timer.Stop() }()
+	select {
+	case <-shutdownCh:
+	case <-timer.C:
+		t.Fatalf("Server shutdown did not happen in time")
+	}
 }


### PR DESCRIPTION
This PR refactors the SPI part of the requester, renaming RunWithGPUUUIDs to StartWithGPUUUIDs and making it return the func that does the server on the now-open listener.

This is hoped to address Issue #641 .