### PR TITLE
Make E2E run on pok-prod instead of vllm-d

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -590,6 +590,19 @@ jobs:
         if: always()
         run: kubectl get all -n "$FMA_NAMESPACE"
 
+      - name: Dump DCGM_FI_DEV_FB_USED on testnode
+        if: always()
+        run: |
+          if [ -r testnode ]
+          then
+            curl -sSkG \
+              -H "Authorization: Bearer $(oc whoami -t)" \
+              --data-urlencode "query=DCGM_FI_DEV_FB_USED{Hostname=\"$(cat testnode)\"}" \
+              https://prometheus-k8s-openshift-monitoring.apps.pokprod001.ete14.res.ibm.com/api/v1/query \
+            | jq '.data.result[]'
+          else echo there is no readable testnode file
+          fi
+
       - name: Dump select node info after test
         if: always()
         run: |

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -426,7 +426,7 @@ jobs:
           echo "Cluster domain: $CLUSTER_DOMAIN"
           if echo "$CLUSTER_DOMAIN" | grep -q "pokprod"; then
             echo "Detected pokprod cluster"
-            echo "RUNTIME_CLASS_NAME=nvidia" >> $GITHUB_ENV
+            echo "RUNTIME_CLASS_NAME=nvidia-legacy" >> $GITHUB_ENV
           fi
 
       - name: Clean up resources for this PR

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -355,7 +355,7 @@ jobs:
 
   # Run e2e tests on OpenShift self-hosted runner
   e2e-openshift:
-    runs-on: [self-hosted, openshift, vllm-d]
+    runs-on: [self-hosted, openshift, pok-prod]
     needs: [gate, build-image]
     if: needs.gate.outputs.should_run == 'true'
     env:

--- a/.github/workflows/fma-e2e-namespace-sweep.yaml
+++ b/.github/workflows/fma-e2e-namespace-sweep.yaml
@@ -8,7 +8,8 @@ name: Sweep expired FMA E2E namespaces
 
 on:
   schedule:
-    - cron: '13 3 * * *'
+#    - cron: '13 3 * * *' # 03:13 every day
+    - cron: '40 * * * *' # for testing: 40 minutes past every hour
   workflow_dispatch:
 
 permissions:
@@ -16,7 +17,10 @@ permissions:
 
 jobs:
   sweep:
-    runs-on: [self-hosted, openshift, vllm-d]
+    runs-on: [self-hosted, openshift, ${{ matrix.cluster }} ]
+    strategy:
+      matrix:
+        cluster: [vllm-d, pok-prod]
     steps:
       - name: Install kubectl if missing
         run: |

--- a/.github/workflows/fma-e2e-namespace-sweep.yaml
+++ b/.github/workflows/fma-e2e-namespace-sweep.yaml
@@ -8,19 +8,15 @@ name: Sweep expired FMA E2E namespaces
 
 on:
   schedule:
-#    - cron: '13 3 * * *' # 03:13 every day
-    - cron: '40 * * * *' # for testing: 40 minutes past every hour
+    - cron: '13 3 * * *'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  sweep:
-    runs-on: [self-hosted, openshift, ${{ matrix.cluster }} ]
-    strategy:
-      matrix:
-        cluster: [vllm-d, pok-prod]
+  sweep-old:
+    runs-on: [self-hosted, openshift, vllm-d]
     steps:
       - name: Install kubectl if missing
         run: |
@@ -36,22 +32,31 @@ jobs:
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/
 
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Delete expired namespaces
+        run: hack/delete-expired-namespaces.sh
+
+  sweep-new:
+    runs-on: [self-hosted, openshift, pok-prod]
+    steps:
+      - name: Install kubectl if missing
         run: |
-          set -euo pipefail
-          today=$(date -u +%Y-%m-%d)
-          echo "Today (UTC): $today"
-          kubectl get namespace \
-            -l fma-e2e.llm-d.ai/sweep=true \
-            -o json \
-          | jq -r --arg today "$today" '
-              .items[]
-              | .metadata.annotations["fma-e2e.llm-d.ai/expires-at"] as $expires
-              | select($expires != null and $expires < $today)
-              | .metadata.name
-            ' \
-          | while read -r name; do
-              [ -n "$name" ] || continue
-              echo "Deleting expired namespace: $name"
-              kubectl delete namespace "$name" --ignore-not-found --timeout=180s || true
-            done
+          if command -v kubectl &>/dev/null; then
+            echo "kubectl already installed: $(kubectl version --client=true 2>/dev/null | head -1)"
+            exit 0
+          fi
+          KUBECTL_VERSION="v1.31.14"
+          KUBECTL_SHA256="8791ec7c8966b61420d55103a5fb948de9f0ca3d7306d789734975ad9704bdb0"
+          echo "Installing kubectl version: $KUBECTL_VERSION"
+          curl -fsSL --retry 3 --retry-delay 5 -o kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          echo "${KUBECTL_SHA256}  kubectl" | sha256sum --check
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Delete expired namespaces
+        run: hack/delete-expired-namespaces.sh

--- a/hack/delete-expired-namespaces.sh
+++ b/hack/delete-expired-namespaces.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# No command-line parameters.
+# Current working directory does not matter.
+# Current kubectl config: accesses the cluster in question.
+
+# Purpose: delete namespaces that are marked as "expired". These would
+# be namespaces in an OpenShift dev/test cluster that have been
+# retained so that OpenShift allows old Pod logs to be viewed.  They
+# are created by the `ci-e2e-openshift.yaml` GitHub workflow.
+
+set -euo pipefail
+today=$(date -u +%Y-%m-%d)
+echo "Today (UTC): $today"
+kubectl get namespace \
+  -l fma-e2e.llm-d.ai/sweep=true \
+  -o json \
+| jq -r --arg today "$today" '
+    .items[]
+    | .metadata.annotations["fma-e2e.llm-d.ai/expires-at"] as $expires
+    | select($expires != null and $expires < $today)
+    | .metadata.name
+  ' \
+| while read -r name; do
+    [ -n "$name" ] || continue
+    echo "Deleting expired namespace: $name"
+    kubectl delete namespace "$name" --ignore-not-found --timeout=180s || true
+  done

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -253,6 +253,8 @@ expect '[ -n "$(kubectl get pod -n '"$NS"' $req1 -o jsonpath={.metadata.annotati
 assigned_gpu_uuids=$(kubectl get pod "$req1" -n "$NS" -o jsonpath='{.metadata.annotations.dual-pods\.llm-d\.ai/accelerators}')
 echo "Assigned GPU UUID(s): $assigned_gpu_uuids"
 
+kubectl get -n "$NS" pod "$req1" -o yaml
+
 cheer Successful launcher-based pod creation
 
 # vllm inventory:
@@ -409,6 +411,8 @@ expect "kubectl get pods -n $NS -o name -l app=dp-example,instance=$inst | wc -l
 
 # Pin the GPU so the next scale-up reuses the same GPU on every platform.
 pin_gpu $rs
+
+kubectl get rs "$rs" -n "$NS" -o yaml
 
 # Patch requester ReplicaSet to stick to testnode
 kubectl patch rs $rs -n "$NS" -p '{"spec": {"template": {"spec": {"nodeSelector": {"kubernetes.io/hostname": "'$testnode'"} }} }}'

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -174,6 +174,8 @@ echo "GPU probe Pod $probe_pod scheduled on Node $testnode — using it for the 
 
 kubectl delete pod "$probe_pod" -n "$NS" --wait=true
 
+echo "$testnode" > testnode
+
 cheer "GPU probe complete — test node is $testnode"
 
 # ---------------------------------------------------------------------------

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -678,8 +678,10 @@ pfpid=""
 
 # Restart the dual-pods controller to test state recovery
 echo "Restarting dual-pods controller..."
-kubectl rollout restart deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" -n "$NS"
-kubectl rollout status deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" -n "$NS" --timeout=60s
+kubectl scale  -n "$NS" deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" --replicas=0
+expect 'kubectl get -n "$NS" pods -l app.kubernetes.io/component=dual-pods-controller -o name | wc -l | grep -w 0'
+kubectl scale  -n "$NS" deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" --replicas=1
+kubectl wait -n "$NS" --for=condition=available --timeout=100s deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller"
 
 # Wait for controller to be ready for ongoing checks
 # In detail: allow some time for the dual-pods controller to do something unexpected in the case


### PR DESCRIPTION
Because the vllm-d cluster has so much resource contention that `.github/workflows/ci-e2e-openshift.yaml` too often fails to find 2 available GPUs on one Node.