### PR TITLE
Refactor probes server to expose listener start

### DIFF
--- a/cmd/requester/main.go
+++ b/cmd/requester/main.go
@@ -51,7 +51,6 @@ func main() {
 	var ready atomic.Bool
 
 	var wg sync.WaitGroup
-	wg.Add(2)
 
 	serveSPI, err := coordination.Start(ctx, spiPort, &ready, os.Stdout)
 	if err != nil {
@@ -60,6 +59,7 @@ func main() {
 		return
 	}
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		if err := serveSPI(); err != nil {
@@ -68,12 +68,18 @@ func main() {
 	}()
 
 	// Start the readiness probe server
+	serveProbes, err := probes.Start(ctx, probesPort, &ready)
+	if err != nil {
+		logger.Error(err, "Failed to start requester probes server")
+		os.Exit(11)
+		return
+	}
+
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
-
-		err := probes.Run(ctx, probesPort, &ready)
-		if err != nil {
-			logger.Error(err, "failed to start requester probes server")
+		if err := serveProbes(); err != nil {
+			logger.Error(err, "failed to run requester probes server")
 		}
 	}()
 

--- a/cmd/requester/main.go
+++ b/cmd/requester/main.go
@@ -56,7 +56,6 @@ func main() {
 	if err != nil {
 		logger.Error(err, "Failed to start requester SPI server")
 		os.Exit(10)
-		return
 	}
 
 	wg.Add(1)
@@ -72,7 +71,6 @@ func main() {
 	if err != nil {
 		logger.Error(err, "Failed to start requester probes server")
 		os.Exit(11)
-		return
 	}
 
 	wg.Add(1)

--- a/cmd/test-requester/main.go
+++ b/cmd/test-requester/main.go
@@ -110,13 +110,13 @@ func main() {
 	var ready atomic.Bool
 
 	var wg sync.WaitGroup
-	wg.Add(2)
 
 	serveSPI, err := coordination.StartWithGPUUUIDs(ctx, strconv.FormatInt(int64(spiPort), 10), &ready, os.Stdout, gpuUUIDs)
 	if err != nil {
 		logger.Error(err, "Failed to start requester SPI server")
 		os.Exit(10)
 	}
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
@@ -126,12 +126,17 @@ func main() {
 	}()
 
 	// Start the readiness probe server
+	serveProbes, err := probes.Start(ctx, strconv.FormatInt(int64(probesPort), 10), &ready)
+	if err != nil {
+		logger.Error(err, "Failed to start requester probes server")
+		os.Exit(11)
+	}
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
-		err := probes.Run(ctx, strconv.FormatInt(int64(probesPort), 10), &ready)
-		if err != nil {
-			logger.Error(err, "failed to start requester probes server")
+		if err := serveProbes(); err != nil {
+			logger.Error(err, "failed to run requester probes server")
 		}
 	}()
 

--- a/pkg/server/requester/probes/server.go
+++ b/pkg/server/requester/probes/server.go
@@ -30,7 +30,8 @@ import (
 	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
-// Start starts an HTTP server managing the /ready endpoint.
+// Start binds the network listener for an HTTP server managing the /ready endpoint.
+// It does not begin serving; the returned func does that when invoked.
 // Returns two values.
 // The second is the error, if any, that arose from trying to start the network listener.
 // The first is the func that will do the serving and return any error that arose (nil for clean shutdown).
@@ -71,6 +72,7 @@ func Start(ctx context.Context, port string, ready *atomic.Bool) (func() error, 
 			logger.Error(err, "failed to gracefully shutdown")
 		}
 		_ = listener.Close()
+		logger.Info("shut down completed")
 	}()
 
 	return func() error {

--- a/pkg/server/requester/probes/server.go
+++ b/pkg/server/requester/probes/server.go
@@ -18,7 +18,9 @@ package probes
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -28,8 +30,11 @@ import (
 	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
 
-// Run runs an HTTP server managing the /ready endpoint.
-func Run(ctx context.Context, port string, ready *atomic.Bool) error {
+// Start starts an HTTP server managing the /ready endpoint.
+// Returns two values.
+// The second is the error, if any, that arose from trying to start the network listener.
+// The first is the func that will do the serving and return any error that arose (nil for clean shutdown).
+func Start(ctx context.Context, port string, ready *atomic.Bool) (func() error, error) {
 	logger := klog.FromContext(ctx).WithName("probes-server")
 	ctx = klog.NewContext(ctx, logger)
 
@@ -45,8 +50,14 @@ func Run(ctx context.Context, port string, ready *atomic.Bool) error {
 	})
 
 	server := &http.Server{
-		Addr:    ":" + port,
-		Handler: mux,
+		Addr:        ":" + port,
+		BaseContext: func(l net.Listener) context.Context { return ctx },
+		Handler:     mux,
+	}
+
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return nil, err
 	}
 
 	// Setup graceful termination
@@ -59,13 +70,16 @@ func Run(ctx context.Context, port string, ready *atomic.Bool) error {
 		if err := server.Shutdown(ctx); err != nil {
 			logger.Error(err, "failed to gracefully shutdown")
 		}
+		_ = listener.Close()
 	}()
 
-	logger.Info("starting server", "port", port)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("listen and serve error: %w", err)
-	}
-
-	logger.Info("server stopped")
-	return nil
+	return func() error {
+		logger.Info("starting server", "port", port)
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve error: %w", err)
+		}
+		logger.Info("server stopped")
+		_ = listener.Close()
+		return nil
+	}, nil
 }

--- a/pkg/server/requester/probes/server_test.go
+++ b/pkg/server/requester/probes/server_test.go
@@ -38,7 +38,7 @@ func FuzzServer(f *testing.F) {
 	}
 	go func() {
 		if err := serve(); err != nil {
-			f.Logf("Run failed: %s", err.Error())
+			f.Logf("Serve failed: %s", err.Error())
 		}
 	}()
 	f.Fuzz(func(t *testing.T, beReady bool) {

--- a/pkg/server/requester/probes/server_test.go
+++ b/pkg/server/requester/probes/server_test.go
@@ -31,9 +31,12 @@ func FuzzServer(f *testing.F) {
 	var ready atomic.Bool
 	ctx, cancel := context.WithCancel(f.Context())
 	port := "28082"
+	serve, err := Start(ctx, port, &ready)
+	if err != nil {
+		f.Fatalf("Server start failed: %s", err.Error())
+	}
 	go func() {
-		err := Run(ctx, port, &ready)
-		if err != nil {
+		if err := serve(); err != nil {
 			f.Logf("Run failed: %s", err.Error())
 		}
 	}()

--- a/pkg/server/requester/probes/server_test.go
+++ b/pkg/server/requester/probes/server_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
 )
@@ -56,4 +57,37 @@ func FuzzServer(f *testing.F) {
 		}
 	})
 	cancel()
+}
+
+// TestShutdownBeforeServe covers the case where the context is canceled after
+// Start binds the listener but before the returned serve func is invoked. That
+// is a clean shutdown, so serve must return nil.
+func TestShutdownBeforeServe(t *testing.T) {
+	var ready atomic.Bool
+	ctx, cancel := context.WithCancel(t.Context())
+	port := "28087"
+	serve, err := Start(ctx, port, &ready)
+	if err != nil {
+		t.Fatalf("Server start failed: %s", err.Error())
+	}
+	// Cancel before serving, then wait for the shutdown goroutine to run so that
+	// serve deterministically observes the already-shut-down server.
+	cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		// Give the shutdown goroutine time to run Shutdown and close the listener.
+		time.Sleep(5 * time.Second)
+		errCh <- serve()
+	}()
+	timer := time.NewTimer(20 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("serve returned non-nil on clean shutdown-before-serve: %s", err.Error())
+		}
+		t.Log("serve returned nil on shutdown-before-serve, as expected")
+	case <-timer.C:
+		t.Fatalf("serve did not return in time")
+	}
 }


### PR DESCRIPTION
## What

The `FuzzServer` test in `pkg/server/requester/probes` flakes intermittently with `connection refused` (e.g. [CI run 29283726956](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/actions/runs/29283726956/job/86930990812)).

**Root cause:** `probes.Run` created the network listener and served in a single `server.ListenAndServe()` call. A test that starts `Run` in a goroutine has no synchronization point telling it the listener is bound, so its first request can race ahead of the bind → `connection refused`.

## How

This is the same class of bug as #641, fixed for the sibling `coordination` package in #642. This PR applies the same pattern to `probes`:

- Split `Run` into `Start(ctx, port, ready) (func() error, error)`, which calls `net.Listen` **synchronously** and returns the error on failure, then returns a closure that runs `server.Serve(listener)`. Callers know the listener is bound the moment `Start` returns.
- Updated `FuzzServer` to call `Start` before launching the serve goroutine, closing the race.
- Updated both callers (`cmd/requester`, `cmd/test-requester`) to the two-step form, and refactored their monolithic `wg.Add(2)` into a `wg.Add(1)` adjacent to each goroutine.
- Sentinel error check uses `errors.Is(err, http.ErrServerClosed)`.

## Testing

- `go build ./...` and `go vet` — clean
- `go test -race -run FuzzServer -count=200 ./pkg/server/requester/probes/` — passes every iteration
- `go test -race ./pkg/server/requester/...` — both packages pass

Fixes #653