### PR TITLE
Defaulting VLLM_WORKER_MULTIPROC_METHOD=fork in launcher code for faster vLLM startup

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -172,6 +172,9 @@ class VllmInstance:
         :param log_dir: Directory for log files (defaults to /tmp)
         """
 
+        if config.env_vars is None:
+            config.env_vars = {}
+
         # Check for CUDA device UUIDs and set CUDA_VISIBLE_DEVICES accordingly
         if config.gpu_uuids:
             cuda_indices = []
@@ -182,13 +185,21 @@ class VllmInstance:
                 f"Translated GPU UUIDs {config.gpu_uuids} to indices {cuda_indices}."
             )
 
-            if config.env_vars is None:
-                config.env_vars = {}
             config.env_vars["CUDA_VISIBLE_DEVICES"] = ",".join(cuda_indices)
             logger.info(
                 "Set CUDA_VISIBLE_DEVICES to %s based on UUIDs.",
                 config.env_vars["CUDA_VISIBLE_DEVICES"],
             )
+
+        # Default vLLM's worker multiprocessing method to "fork" unless the
+        # ISC's env_vars already set it. Injected into config.env_vars so it
+        # flows through set_env_vars() alongside every other vLLM env var
+        # (e.g. CUDA_VISIBLE_DEVICES above) instead of being special-cased.
+        config.env_vars.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "fork")
+        logger.info(
+            "Set VLLM_WORKER_MULTIPROC_METHOD to %s.",
+            config.env_vars["VLLM_WORKER_MULTIPROC_METHOD"],
+        )
 
         # Initialize instance variables
         self.instance_id = instance_id

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -173,6 +173,35 @@ class TestVllmInstance:
         assert instance.config == vllm_config
         assert instance.process is None
 
+    def test_instance_sets_default_multiproc_method(self, gpu_translator, tmp_log_dir):
+        """VLLM_WORKER_MULTIPROC_METHOD defaults to 'fork' when the ISC omits it."""
+        config = VllmConfig(options="--model test-model --port 8000")
+        assert config.env_vars is None  # ISC provided none
+        instance = VllmInstance("test-id", config, gpu_translator, log_dir=tmp_log_dir)
+        assert instance.config.env_vars is not None
+        assert instance.config.env_vars["VLLM_WORKER_MULTIPROC_METHOD"] == "fork"
+
+    def test_instance_multiproc_method_override_wins(self, gpu_translator, tmp_log_dir):
+        """An explicit VLLM_WORKER_MULTIPROC_METHOD in ISC's env is preserved."""
+        config = VllmConfig(
+            options="--model test-model --port 8000",
+            env_vars={"VLLM_WORKER_MULTIPROC_METHOD": "spawn"},
+        )
+        instance = VllmInstance("test-id", config, gpu_translator, log_dir=tmp_log_dir)
+        assert instance.config.env_vars["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+    def test_instance_multiproc_method_preserves_other_env_vars(
+        self, gpu_translator, tmp_log_dir
+    ):
+        """The default is added without clobbering the ISC's other env vars."""
+        config = VllmConfig(
+            options="--model test-model --port 8000",
+            env_vars={"CUSTOM_VAR": "custom_value"},
+        )
+        instance = VllmInstance("test-id", config, gpu_translator, log_dir=tmp_log_dir)
+        assert instance.config.env_vars["CUSTOM_VAR"] == "custom_value"
+        assert instance.config.env_vars["VLLM_WORKER_MULTIPROC_METHOD"] == "fork"
+
     @patch("launcher.multiprocessing.Process")
     def test_instance_start(
         self, mock_process_class, vllm_config: VllmConfig, gpu_translator, tmp_log_dir


### PR DESCRIPTION
FMA launcher does not set `VLLM_WORKER_MULTIPROC_METHOD`, so the vLLM instances it spawns fell back to vLLM's implicit default for how it launches its EngineCore/worker processes. This PR defaults it to fork (unless the ISC already sets it), injected into `config.env_vars` so it flows through the launcher's existing `set_env_vars()` path — the same way `CUDA_VISIBLE_DEVICES` is handled.

- Overridable: uses setdefault, so an explicit VLLM_WORKER_MULTIPROC_METHOD in the ISC's env_vars still wins.
- Observability: logs the effective value ("Set VLLM_WORKER_MULTIPROC_METHOD to fork."), mirroring the CUDA_VISIBLE_DEVICES log line.
- Low risk: no change when the default was already fork; only affects vLLM versions/paths whose implicit default drifted to spawn.

**Why this improves startup time**

vLLM spawns its EngineCore/worker process(es) using a Python multiprocessing start method:
- `fork` clones the already-warm launcher child (copy-on-write): torch, CUDA bindings, and vLLM modules are already imported, so the worker starts almost immediately.
- `spawn` launches a brand-new Python interpreter per worker that must re-import torch + vLLM and re-initialize from scratch — several seconds of overhead per worker, paid on every instance start (and multiplied under TP>1).

Testing

- [x] Unit: assert the launcher injects the default and that an ISC-provided value overrides it.
- [x] E2E: confirm the launcher log shows the new line and vLLM comes up serving.

🤖 Generated with Claude Code (https://claude.com/claude-code)