### PR TITLE
Add reference to well-lit path PR of llm-d

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,10 @@
 - [Prometheus Metrics](metrics.md)
 - [Design Rules](../DESIGN_RULES.md)
 
+# Well-Lit Path
+
+There is an llm-d "well-lit path" document [in the llm-d repo](https://github.com/llm-d/llm-d/tree/main/guides/fast-model-actuation).
+
 # Dev/test
 
 - [Local dev/test in a `kind` cluster](local-test.md)


### PR DESCRIPTION
Because a well-lit path document must be part of the llm-d repo, the best we can do now is point to that PR.