### PR TITLE
launcher-populator: report and retry stuck launchers

### DIFF
--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -583,9 +583,9 @@ you would typically use when the nodes have 8 GPUs.
 
 ### FYI labels and annotations
 
-The FMA controllers put some labels and annotations on Pods purely for
-the sake of observability; these labels and annotations are not
-consumed by the FMA controllers. They are as follows.
+The FMA controllers put some labels and annotations on Pods primarily
+for observability. Except where noted below, the controllers do not
+consume them. They are as follows.
 
 - annotation **dual-pods.llm-d.ai/accelerators**. Put on both
   requester and provider Pods. Value is a comma-separated list of GPU
@@ -606,6 +606,18 @@ consumed by the FMA controllers. They are as follows.
   while it is bound to a launcher. Value is the ID that FMA uses to
   distinguish the relevant vLLM instance from others in the same
   launcher.
+
+- label **dual-pods.llm-d.ai/launcher-stuck**. Maintained on an
+  unbound launcher Pod when the launcher has remained unscheduled or
+  not Ready for at least the corresponding configured stuck
+  threshold. Its value is "true". The launcher population controller
+  consumes this label to avoid publishing a duplicate `LauncherStuck`
+  Event on every reconciliation, and removes it if the launcher
+  recovers. To list currently stuck launchers, use:
+
+  ```shell
+  kubectl get pods -l dual-pods.llm-d.ai/launcher-stuck=true
+  ```
 
 ### Kubernetes Event objects
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -71,21 +71,6 @@ Labels are as follows.
 
 - `isc_name`: Name of the relevant InferenceServerConfig
 
-### fma_launcher_pod_count
-
-Vector of gauges: Number of launcher Pods.
-
-Labels are as follows.
-
-- `lcfg_name`: Name of the relevant LauncherConfig
-
-- `phase`: one of the following:
-    - `bound`: bound to a server-requesting Pod
-    - `unbound`: not bound, but has not been in this state for too long
-    - `stale`: was created from outdated `LauncherConfig` contents
-    - `stuck_scheduling`: not scheduled, and age meets or exceeds the `--stuck-scheduling-threshold` argument of the launcher population controller
-    - `stuck_starting`: scheduled but not yet "ready", and the time since being scheduled meets or exceeds the `--stuck-starting-threshold` argument of the launcher population controller
-
 ### fma_isc_count
 
 Vector of gauges: Number of InferenceServerConfig objects.
@@ -93,6 +78,45 @@ Vector of gauges: Number of InferenceServerConfig objects.
 Labels are as follows.
 
 - `launcher_config_name`: Name of the relevant LauncherConfig
+
+### fma_launcher_pod_count
+
+Vector of gauges: Number of launcher Pods for each LauncherConfig and
+lifecycle phase. This metric deliberately has no Node label, so its
+cardinality does not grow with the number of Nodes.
+
+Labels are as follows.
+
+- `lcfg_name`: name of the relevant LauncherConfig
+- `phase`: one of the following:
+  - `bound`: assigned to a server-requesting Pod
+  - `unbound`: uses the current launcher template, is not bound, and is either
+    Ready or has not reached a stuck threshold
+  - `stuck_scheduling`: uses the current launcher template, is unbound and
+    not scheduled, and has reached the configured scheduling threshold,
+    measured from Pod creation
+  - `stuck_starting`: uses the current launcher template, is unbound,
+    scheduled but not Ready, and has reached the configured starting
+    threshold, measured from scheduling
+  - `stale`: is unbound and was created from a superseded launcher template
+
+The launcher-populator's `--stuck-scheduling-threshold` and
+`--stuck-starting-threshold` flags configure the two stuck thresholds.
+When the controller observes a retained launcher in either stuck phase without
+the stuck label, it publishes a `LauncherStuck` Warning Event and sets the
+`dual-pods.llm-d.ai/launcher-stuck=true` label. The label makes the current
+condition discoverable after the Event expires and suppresses further Events
+while the Pod remains stuck. If the launcher recovers, the controller removes
+the label.
+
+The Event is emitted before the label Patch is attempted. Because they are
+separate Kubernetes API transactions, a controller failure between them or a
+failed Patch can produce a duplicate Event on a later reconcile. This ordering
+deliberately favors a possible duplicate over losing the Event entirely.
+
+A stuck launcher remains in place and continues to count toward the desired
+launcher population. The controller does not automatically replace or retry
+it; users decide how to respond using the metric, Event, and label.
 
 ## FMA requester-provider binding
 

--- a/pkg/controller/common/interface.go
+++ b/pkg/controller/common/interface.go
@@ -35,6 +35,15 @@ const (
 	// LauncherTemplateHashAnnotationKey is the node-independent template hash on a launcher Pod, used for spec-drift detection.
 	LauncherTemplateHashAnnotationKey = "dual-pods.llm-d.ai/launcher-populator-template-hash"
 
+	// LauncherStuckLabelKey is set by the launcher-populator on a launcher Pod
+	// that is currently stuck (existing past a configured threshold without
+	// becoming Ready, or without ever being scheduled). Its value is "true".
+	// It is findable state that outlives the corresponding Kubernetes Event.
+	// The label denotes the *current* condition: the populator removes it again
+	// if the launcher later recovers, so it is never a false positive on a
+	// launcher that has since become Ready.
+	LauncherStuckLabelKey = "dual-pods.llm-d.ai/launcher-stuck"
+
 	// LauncherServicePort is the port number on which the launcher exposes its HTTP service
 	// for the management of vLLM instances.
 	// This is a contract between the controllers and the launcher implementation.

--- a/pkg/controller/launcher-populator/metrics.go
+++ b/pkg/controller/launcher-populator/metrics.go
@@ -63,6 +63,12 @@ const (
 	phaseStale launcherPhase = "stale"
 )
 
+// isStuck reports whether the phase is one of the two stuck phases reported by
+// the populator with a label and an Event.
+func (p launcherPhase) isStuck() bool {
+	return p == phaseStuckScheduling || p == phaseStuckStarting
+}
+
 const lcfgNameLabel = "lcfg_name"
 const phaseLabel = "phase"
 

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -30,9 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	corev1preinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
@@ -82,6 +84,8 @@ func NewController(
 		clock:                    clock.RealClock{},
 		metrics:                  newMetricsState(),
 	}
+	ctl.eventBroadcaster = record.NewBroadcaster()
+	ctl.recorder = ctl.eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: ControllerName})
 	ctl.policy = newDigestedPolicy()
 
 	// digestQueue carries funcItem (LC/LPP/Node references). Single worker, so
@@ -132,14 +136,20 @@ type controller struct {
 	coreclient    coreclient.CoreV1Interface
 	fmaclient     fmaclientv1alpha1.FmaV1alpha1Interface
 	namespace     string
-	podInformer   cache.SharedIndexInformer
-	podLister     corev1listers.PodLister
-	nodeInformer  cache.SharedIndexInformer
-	nodeLister    corev1listers.NodeLister
-	lppInformer   cache.SharedIndexInformer
-	lppLister     fmalisters.LauncherPopulationPolicyLister
-	lcInformer    cache.SharedIndexInformer
-	lcLister      fmalisters.LauncherConfigLister
+
+	// eventBroadcaster/recorder publish Kubernetes Events on launcher Pods (e.g.
+	// a Warning when a launcher becomes stuck).
+	eventBroadcaster record.EventBroadcaster
+	recorder         record.EventRecorder
+
+	podInformer  cache.SharedIndexInformer
+	podLister    corev1listers.PodLister
+	nodeInformer cache.SharedIndexInformer
+	nodeLister   corev1listers.NodeLister
+	lppInformer  cache.SharedIndexInformer
+	lppLister    fmalisters.LauncherPopulationPolicyLister
+	lcInformer   cache.SharedIndexInformer
+	lcLister     fmalisters.LauncherConfigLister
 
 	// digestQueue processes API-object references (LC/LPP/Node). Single worker;
 	// the SOLE writer of ctl.policy.
@@ -161,14 +171,12 @@ type controller struct {
 	policy *digestedPolicy
 
 	// stuckSchedulingThreshold is the minimum age (since creation) at which an
-	// unscheduled launcher is reported in the "stuck_scheduling" phase of the
-	// fma_launcher_pod_count metric. It does not change reconcile behavior.
+	// unscheduled launcher is classified in the "stuck_scheduling" phase.
 	stuckSchedulingThreshold time.Duration
 
 	// stuckStartingThreshold is the minimum age (since scheduling) at which a
-	// scheduled, not-yet-Ready launcher is reported in the "stuck_starting"
-	// phase of the fma_launcher_pod_count metric. It does not change reconcile
-	// behavior.
+	// scheduled, not-yet-Ready launcher is classified in the "stuck_starting"
+	// phase.
 	stuckStartingThreshold time.Duration
 
 	// clock is the time source for metric classification; real in production,
@@ -330,6 +338,8 @@ func (ctl *controller) OnDelete(obj any) {
 }
 
 func (ctl *controller) Start(ctx context.Context) error {
+	ctl.eventBroadcaster.StartRecordingToSink(&coreclient.EventSinkImpl{Interface: ctl.coreclient.Events("")})
+	context.AfterFunc(ctx, ctl.eventBroadcaster.Shutdown)
 	if !cache.WaitForNamedCacheSync(ControllerName, ctx.Done(), ctl.lppInformer.HasSynced, ctl.lcInformer.HasSynced, ctl.podInformer.HasSynced, ctl.nodeInformer.HasSynced) {
 		return fmt.Errorf("caches not synced before end of Start context")
 	}
@@ -505,10 +515,12 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 		"desired", desiredCount, "diff", diff)
 
 	// Delete excess pods.
+	excessDeletionTargets := sets.New[types.UID]()
 	if diff < 0 {
 		numToDelete := -diff
 		for i := len(liveUnboundCurrentPods) - 1; i >= 0 && numToDelete > 0; i-- {
 			pod := liveUnboundCurrentPods[i]
+			excessDeletionTargets.Insert(pod.UID)
 			err := ctl.coreclient.Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{UID: &pod.UID, ResourceVersion: &pod.ResourceVersion},
 			})
@@ -530,7 +542,19 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 		}
 	}
 
-	// If any deletions happened or are in progress, requeue before creating.
+	// Report stuck launchers among only the Pods not targeted for excess
+	// deletion in this reconcile. Skipped in orphan cleanup (nil template).
+	if nodeIndependentLauncherTemplate != nil {
+		retained := utils.SliceFilter(liveUnboundCurrentPods, utils.Not1(func(pod *corev1.Pod) bool {
+			return excessDeletionTargets.Has(pod.UID)
+		}))
+		if err := ctl.reportStuckLaunchers(ctx, retained, templateHash); err != nil {
+			return err, true
+		}
+	}
+
+	// If any deletions happened or are in progress, requeue before creating for
+	// the desired count.
 	if didDelete || deletionInProgress {
 		return nil, true
 	}
@@ -545,6 +569,64 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	}
 
 	return nil, false
+}
+
+// reportStuckLaunchers reports stuck launchers among retained unbound Pods,
+// using the same stuck_scheduling / stuck_starting classification as the
+// fma_launcher_pod_count metric. A stuck launcher remains in place and counts
+// toward the desired population. The stuck label gates the Warning Event; a Pod
+// that is no longer stuck has the label cleared.
+func (ctl *controller) reportStuckLaunchers(ctx context.Context, retained []*corev1.Pod, templateHash string) error {
+	logger := klog.FromContext(ctx)
+	now := ctl.clock.Now()
+
+	for _, pod := range retained {
+		phase, _ := launcherPhaseOf(pod, templateHash, ctl.stuckSchedulingThreshold, ctl.stuckStartingThreshold, now)
+		labeled := pod.Labels[common.LauncherStuckLabelKey] == "true"
+		stuck := phase.isStuck()
+
+		if labeled == stuck {
+			continue
+		}
+
+		if stuck {
+			ctl.recorder.Eventf(pod, corev1.EventTypeWarning, "LauncherStuck",
+				"Launcher is stuck (%s); leaving it in place for investigation", phase)
+		}
+		if err := ctl.setStuckLabel(ctx, pod, stuck); err != nil {
+			return err
+		}
+		if stuck {
+			logger.Info("Reported stuck launcher", "pod", pod.Name, "uid", pod.UID, "phase", phase)
+		} else {
+			logger.Info("Cleared stuck label from recovered launcher", "pod", pod.Name, "uid", pod.UID)
+		}
+	}
+
+	return nil
+}
+
+// setStuckLabel adds (stuck) or removes (!stuck) the LauncherStuckLabelKey label
+// on a launcher Pod, logging the call per DR-20. NotFound is ignored.
+func (ctl *controller) setStuckLabel(ctx context.Context, pod *corev1.Pod, stuck bool) error {
+	logger := klog.FromContext(ctx)
+	labelValue := "null" // JSON null removes the label
+	if stuck {
+		labelValue = `"true"`
+	}
+	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:%s}}}`, common.LauncherStuckLabelKey, labelValue))
+	callStart := ctl.clock.Now()
+	_, err := ctl.coreclient.Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	callStartStr := callStart.Format(time.RFC3339Nano)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(2).Info("Launcher Pod gone before stuck-label patch", "pod", pod.Name, "k8sCallStartTime", callStartStr)
+			return nil
+		}
+		return fmt.Errorf("failed to patch stuck label on launcher pod %s (started %s): %w", pod.Name, callStartStr, err)
+	}
+	logger.V(2).Info("Patched stuck label on launcher Pod", "pod", pod.Name, "stuck", stuck, "k8sCallStartTime", callStartStr)
+	return nil
 }
 
 // getCurrentLaunchersOnNode compares pending expectations for a specific

--- a/pkg/controller/launcher-populator/stuck_test.go
+++ b/pkg/controller/launcher-populator/stuck_test.go
@@ -1,0 +1,451 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcherpopulator
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	testingclock "k8s.io/utils/clock/testing"
+
+	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/controller/common"
+)
+
+const (
+	stuckTestSchedThreshold = 2 * time.Minute
+	stuckTestStartThreshold = 5 * time.Minute
+	stuckTestNamespace      = "default"
+	stuckTestNode           = "node-a"
+	stuckTestLauncherConfig = "lc-a"
+)
+
+var stuckTestNow = time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+
+func newStuckTestController(now time.Time, objs ...*corev1.Pod) (*controller, *k8sfake.Clientset, *record.FakeRecorder) {
+	cs := k8sfake.NewSimpleClientset(podsToObjects(objs)...)
+	rec := record.NewFakeRecorder(50)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	_ = indexer.Add(testNode())
+	ctl := &controller{
+		coreclient:               cs.CoreV1(),
+		namespace:                stuckTestNamespace,
+		recorder:                 rec,
+		clock:                    testingclock.NewFakeClock(now),
+		stuckSchedulingThreshold: stuckTestSchedThreshold,
+		stuckStartingThreshold:   stuckTestStartThreshold,
+		expectations:             newPendingExpectations(time.Minute),
+		nodeLister:               corev1listers.NewNodeLister(indexer),
+	}
+	return ctl, cs, rec
+}
+
+func podsToObjects(pods []*corev1.Pod) []runtime.Object {
+	out := make([]runtime.Object, 0, len(pods))
+	for _, p := range pods {
+		out = append(out, p)
+	}
+	return out
+}
+
+// stuckLauncherPod builds a launcher Pod in the current namespace with the
+// current template hash.
+func stuckLauncherPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   stuckTestNamespace,
+			UID:         types.UID(name + "-uid"),
+			Labels:      map[string]string{common.LauncherConfigNameLabelKey: stuckTestLauncherConfig},
+			Annotations: map[string]string{common.LauncherTemplateHashAnnotationKey: testTemplateHash},
+		},
+	}
+}
+
+// scheduledNotReadyAt marks the Pod scheduled at t and not Ready, so its age is
+// measured from scheduling for stuck_starting classification.
+func scheduledNotReadyAt(p *corev1.Pod, t time.Time) *corev1.Pod {
+	p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+		Type:               corev1.PodScheduled,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(t),
+	})
+	return p
+}
+
+// ready marks the Pod Ready.
+func ready(p *corev1.Pod) *corev1.Pod {
+	p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	})
+	return p
+}
+
+// createdAt sets the Pod's creation timestamp. With no PodScheduled condition,
+// age is measured from creation for stuck_scheduling classification.
+func createdAt(p *corev1.Pod, t time.Time) *corev1.Pod {
+	p.CreationTimestamp = metav1.NewTime(t)
+	return p
+}
+
+// listLaunchers returns all launcher Pods currently in the fake clientset,
+// used to rebuild a reconcile's cache snapshot between passes.
+func listLaunchers(t *testing.T, cs *k8sfake.Clientset) []*corev1.Pod {
+	t.Helper()
+	list, err := cs.CoreV1().Pods(stuckTestNamespace).List(t.Context(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	out := make([]*corev1.Pod, 0, len(list.Items))
+	for i := range list.Items {
+		p := list.Items[i]
+		out = append(out, &p)
+	}
+	return out
+}
+
+func nodeTemplate() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "launcher-template",
+			Namespace:   stuckTestNamespace,
+			Labels:      map[string]string{common.LauncherConfigNameLabelKey: stuckTestLauncherConfig},
+			Annotations: map[string]string{common.LauncherTemplateHashAnnotationKey: testTemplateHash},
+		},
+	}
+}
+
+func testNode() *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: stuckTestNode}}
+}
+
+func stuckTestKey() NodeLauncherKey {
+	return NodeLauncherKey{NodeName: stuckTestNode, LauncherConfigName: stuckTestLauncherConfig}
+}
+
+func drainEvents(rec *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-rec.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// assertWarningLauncherStuck asserts there is exactly one Event and that it is a
+// Warning with reason LauncherStuck whose message contains wantSubstr. This
+// pins the Event contract (type + reason), not just a message fragment, so a
+// regression to Normal or a different reason fails the test.
+func assertWarningLauncherStuck(t *testing.T, events []string, wantSubstr string) {
+	t.Helper()
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 Event, got %d: %v", len(events), events)
+	}
+	e := events[0]
+	if !strings.HasPrefix(e, "Warning LauncherStuck ") {
+		t.Errorf("expected Event %q to have prefix %q", e, "Warning LauncherStuck ")
+	}
+	if !strings.Contains(e, wantSubstr) {
+		t.Errorf("expected Event %q to contain %q", e, wantSubstr)
+	}
+}
+
+func podExists(t *testing.T, cs *k8sfake.Clientset, name string) bool {
+	t.Helper()
+	_, err := cs.CoreV1().Pods(stuckTestNamespace).Get(t.Context(), name, metav1.GetOptions{})
+	if err == nil {
+		return true
+	}
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+	t.Fatalf("get pod %s: %v", name, err)
+	return false
+}
+
+// TestReportStuckLaunchersLabelsAndReports verifies that a stuck launcher is
+// kept, labeled, and reported once.
+func TestReportStuckLaunchersLabelsAndReports(t *testing.T) {
+	pod := scheduledNotReadyAt(stuckLauncherPod("launcher-stuck"), stuckTestNow.Add(-10*time.Minute))
+	ctl, cs, rec := newStuckTestController(stuckTestNow, pod)
+
+	if err := ctl.reportStuckLaunchers(t.Context(), []*corev1.Pod{pod}, testTemplateHash); err != nil {
+		t.Fatalf("reportStuckLaunchers: %v", err)
+	}
+	got, err := cs.CoreV1().Pods(stuckTestNamespace).Get(t.Context(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("stuck pod must be kept: %v", err)
+	}
+	if got.Labels[common.LauncherStuckLabelKey] != "true" {
+		t.Errorf("expected stuck label, labels=%v", got.Labels)
+	}
+	if all := listLaunchers(t, cs); len(all) != 1 {
+		t.Errorf("expected no replacement Pods, got %d Pods", len(all))
+	}
+	assertWarningLauncherStuck(t, drainEvents(rec), "stuck_starting")
+}
+
+// TestReportStuckLaunchersAlreadyLabeledNoEvent verifies idempotence: a stuck,
+// already-labeled launcher produces no further Event.
+func TestReportStuckLaunchersAlreadyLabeledNoEvent(t *testing.T) {
+	pod := scheduledNotReadyAt(stuckLauncherPod("launcher-labeled"), stuckTestNow.Add(-10*time.Minute))
+	pod.Labels[common.LauncherStuckLabelKey] = "true"
+	ctl, _, rec := newStuckTestController(stuckTestNow, pod)
+
+	if err := ctl.reportStuckLaunchers(t.Context(), []*corev1.Pod{pod}, testTemplateHash); err != nil {
+		t.Fatalf("reportStuckLaunchers: %v", err)
+	}
+	if events := drainEvents(rec); len(events) != 0 {
+		t.Errorf("expected no Events for already-labeled pod, got %v", events)
+	}
+}
+
+// TestReportStuckLaunchersClearsLabelOnRecovery verifies that the label is
+// removed when a previously-labeled launcher is no longer stuck, so it never
+// stays as a false positive.
+func TestReportStuckLaunchersClearsLabelOnRecovery(t *testing.T) {
+	pod := ready(stuckLauncherPod("launcher-recovered"))
+	pod.Labels[common.LauncherStuckLabelKey] = "true"
+	ctl, cs, rec := newStuckTestController(stuckTestNow, pod)
+
+	if err := ctl.reportStuckLaunchers(t.Context(), []*corev1.Pod{pod}, testTemplateHash); err != nil {
+		t.Fatalf("reportStuckLaunchers: %v", err)
+	}
+	got, err := cs.CoreV1().Pods(stuckTestNamespace).Get(t.Context(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if _, ok := got.Labels[common.LauncherStuckLabelKey]; ok {
+		t.Errorf("expected stuck label removed on recovery, labels=%v", got.Labels)
+	}
+	if events := drainEvents(rec); len(events) != 0 {
+		t.Errorf("expected no Events on recovery, got %v", events)
+	}
+}
+
+// --- reconcile-level tests ---
+
+// TestReconcileKeyDownscaleDeletesStuck verifies that normal population
+// enforcement still deletes an excess stuck launcher.
+func TestReconcileKeyDownscaleDeletesStuck(t *testing.T) {
+	pod := scheduledNotReadyAt(stuckLauncherPod("launcher-downscale"), stuckTestNow.Add(-10*time.Minute))
+	ctl, cs, rec := newStuckTestController(stuckTestNow, pod)
+
+	err, _ := ctl.reconcileKey(t.Context(), stuckTestKey(), 0, testTemplateHash, nodeTemplate(), []*corev1.Pod{pod})
+	if err != nil {
+		t.Fatalf("reconcileKey: %v", err)
+	}
+	if podExists(t, cs, pod.Name) {
+		t.Errorf("expected stuck pod deleted on downscale")
+	}
+	if events := drainEvents(rec); len(events) != 0 {
+		t.Errorf("expected no stuck Event for an excess-deleted pod, got %v", events)
+	}
+}
+
+// TestReconcileKeyDownscaleDeleteConflictDefersStuckReporting verifies that a
+// Pod selected for excess deletion is not reported as stuck in the same
+// reconcile when its Delete conflicts. If another deletion satisfies the
+// desired count, the conflicted Pod is reported on the next reconcile, when it
+// is known to be retained.
+func TestReconcileKeyDownscaleDeleteConflictDefersStuckReporting(t *testing.T) {
+	healthy := ready(stuckLauncherPod("launcher-healthy"))
+	stuck := scheduledNotReadyAt(stuckLauncherPod("launcher-stuck"), stuckTestNow.Add(-10*time.Minute))
+	ctl, cs, rec := newStuckTestController(stuckTestNow, healthy, stuck)
+	cs.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteAction := action.(k8stesting.DeleteAction)
+		if deleteAction.GetName() != stuck.Name {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewConflict(
+			corev1.Resource("pods"),
+			stuck.Name,
+			errors.New("resource version changed"),
+		)
+	})
+
+	err, requeue := ctl.reconcileKey(t.Context(), stuckTestKey(), 1, testTemplateHash, nodeTemplate(), []*corev1.Pod{healthy, stuck})
+	if err != nil {
+		t.Fatalf("first reconcileKey: %v", err)
+	}
+	if !requeue {
+		t.Errorf("expected requeue after deleting the healthy fallback")
+	}
+	got, err := cs.CoreV1().Pods(stuckTestNamespace).Get(t.Context(), stuck.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("conflicted Pod must remain: %v", err)
+	}
+	if got.Labels[common.LauncherStuckLabelKey] == "true" {
+		t.Errorf("delete-conflicted Pod must not be labeled stuck in the same reconcile")
+	}
+	if podExists(t, cs, healthy.Name) {
+		t.Errorf("expected healthy fallback Pod to be deleted")
+	}
+	if events := drainEvents(rec); len(events) != 0 {
+		t.Errorf("delete-conflicted Pod must not be reported as stuck in the same reconcile, got %v", events)
+	}
+
+	err, requeue = ctl.reconcileKey(t.Context(), stuckTestKey(), 1, testTemplateHash, nodeTemplate(), listLaunchers(t, cs))
+	if err != nil {
+		t.Fatalf("second reconcileKey: %v", err)
+	}
+	if requeue {
+		t.Errorf("retained stuck reporting alone must not request a requeue")
+	}
+	got, err = cs.CoreV1().Pods(stuckTestNamespace).Get(t.Context(), stuck.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get retained stuck Pod: %v", err)
+	}
+	if got.Labels[common.LauncherStuckLabelKey] != "true" {
+		t.Errorf("expected retained stuck Pod to be labeled on the next reconcile")
+	}
+	assertWarningLauncherStuck(t, drainEvents(rec), "stuck_starting")
+}
+
+// TestReportStuckLaunchersIgnoresHealthy verifies a not-stuck, unlabeled
+// launcher is left completely untouched.
+func TestReportStuckLaunchersIgnoresHealthy(t *testing.T) {
+	pod := ready(stuckLauncherPod("launcher-healthy"))
+	ctl, cs, rec := newStuckTestController(stuckTestNow, pod)
+
+	if err := ctl.reportStuckLaunchers(t.Context(), []*corev1.Pod{pod}, testTemplateHash); err != nil {
+		t.Fatalf("reportStuckLaunchers: %v", err)
+	}
+	if events := drainEvents(rec); len(events) != 0 {
+		t.Errorf("expected no Events for healthy launcher, got %v", events)
+	}
+	got, err := cs.CoreV1().Pods(stuckTestNamespace).Get(t.Context(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if _, ok := got.Labels[common.LauncherStuckLabelKey]; ok {
+		t.Errorf("healthy launcher must not be labeled stuck, labels=%v", got.Labels)
+	}
+	if all := listLaunchers(t, cs); len(all) != 1 {
+		t.Errorf("expected no new Pods, got %d", len(all))
+	}
+}
+
+// TestReportStuckLaunchersReportsStuckScheduling verifies the unscheduled
+// variant is kept, labeled, and reported with the correct phase.
+func TestReportStuckLaunchersReportsStuckScheduling(t *testing.T) {
+	// Old creation, never scheduled -> stuck_scheduling.
+	pod := createdAt(stuckLauncherPod("launcher-unsched"), stuckTestNow.Add(-10*time.Minute))
+	ctl, cs, rec := newStuckTestController(stuckTestNow, pod)
+
+	if err := ctl.reportStuckLaunchers(t.Context(), []*corev1.Pod{pod}, testTemplateHash); err != nil {
+		t.Fatalf("reportStuckLaunchers: %v", err)
+	}
+	got := listLaunchers(t, cs)
+	if len(got) != 1 || got[0].Name != pod.Name {
+		t.Errorf("expected the original launcher only, got %v", got)
+	}
+	if got[0].Labels[common.LauncherStuckLabelKey] != "true" {
+		t.Errorf("expected stuck label, labels=%v", got[0].Labels)
+	}
+	assertWarningLauncherStuck(t, drainEvents(rec), "stuck_scheduling")
+}
+
+// G4: TestSetStuckLabelIgnoresNotFound verifies labeling a Pod that no longer
+// exists is a no-op (no error), since the Pod may be deleted concurrently.
+func TestSetStuckLabelIgnoresNotFound(t *testing.T) {
+	ctl, _, _ := newStuckTestController(stuckTestNow) // empty clientset
+	pod := stuckLauncherPod("launcher-gone")
+
+	if err := ctl.setStuckLabel(t.Context(), pod, true); err != nil {
+		t.Errorf("setStuckLabel on missing Pod should be ignored, got %v", err)
+	}
+	if err := ctl.setStuckLabel(t.Context(), pod, false); err != nil {
+		t.Errorf("clearing label on missing Pod should be ignored, got %v", err)
+	}
+}
+
+// TestReconcileKeyReportsStuckWithoutReplacement verifies that stuck
+// classification changes observability only: the existing launcher remains the
+// sole Pod satisfying desired count, and is labeled and reported.
+func TestReconcileKeyReportsStuckWithoutReplacement(t *testing.T) {
+	pod := scheduledNotReadyAt(stuckLauncherPod("launcher-stuck"), stuckTestNow.Add(-10*time.Minute))
+	ctl, cs, rec := newStuckTestController(stuckTestNow, pod)
+
+	err, requeue := ctl.reconcileKey(t.Context(), stuckTestKey(), 1, testTemplateHash, nodeTemplate(), []*corev1.Pod{pod})
+	if err != nil {
+		t.Fatalf("reconcileKey: %v", err)
+	}
+	if requeue {
+		t.Errorf("stuck reporting alone must not request a requeue")
+	}
+	got := listLaunchers(t, cs)
+	if len(got) != 1 {
+		t.Fatalf("expected the stuck launcher to remain the only launcher, got %d", len(got))
+	}
+	if got[0].Name != pod.Name {
+		t.Errorf("launcher was replaced: got %q, want %q", got[0].Name, pod.Name)
+	}
+	if got[0].Labels[common.LauncherStuckLabelKey] != "true" {
+		t.Errorf("expected stuck label, labels=%v", got[0].Labels)
+	}
+	assertWarningLauncherStuck(t, drainEvents(rec), "stuck_starting")
+}
+
+// TestReportStuckLaunchersPropagatesLabelPatchError verifies that a non-NotFound
+// error from the label Patch is surfaced (not swallowed), on both the set (stuck
+// launcher) and clear (recovered) label paths.
+func TestReportStuckLaunchersPropagatesLabelPatchError(t *testing.T) {
+	cases := []struct {
+		name string
+		pod  *corev1.Pod
+	}{
+		{
+			name: "set on stuck launcher",
+			pod:  scheduledNotReadyAt(stuckLauncherPod("launcher-stuck"), stuckTestNow.Add(-10*time.Minute)),
+		},
+		{
+			name: "clear on recovery",
+			pod: func() *corev1.Pod {
+				p := ready(stuckLauncherPod("launcher-recovered"))
+				p.Labels[common.LauncherStuckLabelKey] = "true"
+				return p
+			}(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl, cs, _ := newStuckTestController(stuckTestNow, tc.pod)
+			cs.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewInternalError(errors.New("boom"))
+			})
+			if err := ctl.reportStuckLaunchers(t.Context(), []*corev1.Pod{tc.pod}, testTemplateHash); err == nil {
+				t.Errorf("expected the label Patch error to propagate")
+			}
+		})
+	}
+}

--- a/pkg/controller/utils/generics.go
+++ b/pkg/controller/utils/generics.go
@@ -57,6 +57,26 @@ func SliceMap[Domain, Range any](slice []Domain, mapFn func(Domain) (Range, erro
 	return mapped, errors
 }
 
+// SliceFilter returns the elements for which keep returns true, preserving
+// their original order. This returns a new slice rather than modifying the
+// given one.
+func SliceFilter[Elt any](slice []Elt, keep func(Elt) bool) []Elt {
+	filtered := make([]Elt, 0, len(slice))
+	for _, elt := range slice {
+		if keep(elt) {
+			filtered = append(filtered, elt)
+		}
+	}
+	return filtered
+}
+
+// Not1 negates a single-argument predicate.
+func Not1[Arg any](predicate func(Arg) bool) func(Arg) bool {
+	return func(arg Arg) bool {
+		return !predicate(arg)
+	}
+}
+
 // SliceRemoveOnce removes the first occurrence of the given element from the given slice.
 // This returns a new slice rather than side-effecting the given one.
 func SliceRemoveOnce[Elt comparable](slice []Elt, goner Elt) ([]Elt, bool) {

--- a/pkg/controller/utils/generics_test.go
+++ b/pkg/controller/utils/generics_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSliceFilterKeepsMatchingElementsInOrder(t *testing.T) {
+	got := SliceFilter([]int{1, 2, 3, 4}, func(value int) bool {
+		return value%2 == 0
+	})
+	want := []int{2, 4}
+	if !slices.Equal(got, want) {
+		t.Errorf("SliceFilter result = %v, want %v", got, want)
+	}
+}
+
+func TestNot1NegatesPredicate(t *testing.T) {
+	isOdd := Not1(func(value int) bool {
+		return value%2 == 0
+	})
+	if isOdd(2) {
+		t.Error("negated predicate accepted a value accepted by the original")
+	}
+	if !isOdd(3) {
+		t.Error("negated predicate rejected a value rejected by the original")
+	}
+}


### PR DESCRIPTION
Second part of #585, following up on #635.

#635 classified launchers as stuck_scheduling / stuck_starting for the fma_launcher_pod_count metric only. This makes the launcher-populator act on that classification, per the guidance in #585:

- Durable state on the Pod — a currently-stuck launcher gets the dual-pods.llm-d.ai/launcher-stuck=true label, so operators can locate it with kubectl get pods -l dual-pods.llm-d.ai/launcher-stuck=true even after the Event expires. 
- Warning Event — a LauncherStuck Event is published on the Pod.
- Single retry, restart-safe — a stuck launcher is retried once by creating a replacement carrying an incremented dual-pods.llm-d.ai/launcher-retry-count annotation; the stuck original is then removed by the next reconcile's excess deletion (which prefers stuck, lowest-generation Pods). Creating the replacement before removing the original keeps the counter on some Pod at all times, so the single-retry cap survives a controller restart or a failed Create. A launcher still stuck after its retry is left in place (still counted, so it doesn't pile up with fresh replacements on a broken node) and reported.