### PR TITLE
Bring docs/upstream-versions.md up to date

### DIFF
--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -7,11 +7,14 @@
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |-----------|-------------|----------|---------------|---------------|
-| **Go** | `1.24.2` | version | `go.mod` line 3 | [golang/go](https://github.com/golang/go) |
-| **k8s.io/api** | `v0.34.9` | tag | `go.mod` line 8 | [kubernetes/api](https://github.com/kubernetes/api) |
-| **k8s.io/apimachinery** | `v0.34.9` | tag | `go.mod` line 9 | [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery) |
-| **k8s.io/client-go** | `v0.34.9` | tag | `go.mod` line 10 | [kubernetes/client-go](https://github.com/kubernetes/client-go) |
+| **Go (language version)** | `1.25.0` | version | `go.mod` line 3 | [golang/go](https://github.com/golang/go) |
+| **k8s.io/api** | `v0.34.10` | tag | `go.mod` line 8 | [kubernetes/api](https://github.com/kubernetes/api) |
+| **k8s.io/apimachinery** | `v0.34.10` | tag | `go.mod` line 9 | [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery) |
+| **k8s.io/client-go** | `v0.34.10` | tag | `go.mod` line 10 | [kubernetes/client-go](https://github.com/kubernetes/client-go) |
+| **k8s.io/component-base** | `v0.34.10` | tag | `go.mod` line 11 | [kubernetes/component-base](https://github.com/kubernetes/component-base) |
 | **sigs.k8s.io/controller-runtime** | `v0.22.5` | tag | `go.mod` line 14 | [kubernetes-sigs/controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) |
-| **vllm/vllm-openai** | `v0.23.0` | tag | `cmd/requester/README.md` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
-| **vllm (CPU build)** | `v0.23.0` | tag | `dockerfiles/Dockerfile.launcher.cpu` | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
-| **nvidia/cuda** | `12.8.0-base-ubuntu22.04` | tag | `dockerfiles/Dockerfile.requester` | [NVIDIA CUDA](https://hub.docker.com/r/nvidia/cuda) |
+| **github.com/prometheus/client_golang** | `v1.24.1` | tag | `go.mod` line 6 | [prometheus/client_golang](https://github.com/prometheus/client_golang) |
+| **vllm/vllm-openai** | `v0.23.0` | tag | `cmd/requester/README.md`; `dockerfiles/Dockerfile.launcher.benchmark` line 1 (`BASE_IMAGE`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
+| **vllm (CPU build)** | `v0.23.0` | tag | `dockerfiles/Dockerfile.launcher.cpu` line 5 (`VLLM_VERSION`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
+| **nvidia/cuda** | `12.8.0-base-ubuntu22.04` | tag | `dockerfiles/Dockerfile.requester` line 31 | [NVIDIA CUDA](https://hub.docker.com/r/nvidia/cuda) |
+| **projectquay/golang (builder image)** | `1.26` | tag | `dockerfiles/Dockerfile.requester` line 2 | [projectquay/golang](https://quay.io/repository/projectquay/golang) |


### PR DESCRIPTION
## What

Refreshes the upstream dependency version table, which had drifted from the actual pins in the repo.

**Corrected stale pins:**

| Dependency | Was | Now |
|---|---|---|
| Go | `1.24.2` | `1.25.0` |
| k8s.io/api | `v0.34.9` | `v0.34.10` |
| k8s.io/apimachinery | `v0.34.9` | `v0.34.10` |
| k8s.io/client-go | `v0.34.9` | `v0.34.10` |

**Added upstreams** that are pinned in this repo but were missing from the table:

- `k8s.io/component-base` `v0.34.10`
- `github.com/prometheus/client_golang` `v1.24.1` (bumped recently in #680)
- `projectquay/golang` `1.26`, the builder image in `Dockerfile.requester`

**Sharpened the file locations** so each pin is actually findable: added line numbers and the relevant `ARG` names, and recorded `dockerfiles/Dockerfile.launcher.benchmark` as a third location for the `vllm/vllm-openai` pin (it was previously listed only under `cmd/requester/README.md`).

The vllm pins (all consistent at `v0.23.0`), `nvidia/cuda`, and `controller-runtime` were already accurate and are unchanged.

## Notes for reviewers

Two things deliberately left out of scope:

1. **The broken link in the header** to `.github/workflows/upstream-monitor.md`. That workflow is not in the repo (it was present at 8988875, and it and its `.lock.yml` were later removed), so the file's claim to be "the source of truth" for it currently describes nothing. This is an artifact of an imperfect clone from the llm-d organization; leaving it visibly broken and fixing it separately is intentional. Worth deciding then whether the header sentence should survive at all.

2. **Go version skew across CI**, which this PR does not reconcile. The Go row tracks `go.mod` (`1.25.0`), but the workflows disagree among themselves: `code-quality.yml` uses `1.25`, while `go-unit-tests.yml`, `ci-e2e-openshift.yaml`, and `launcher-based-e2e-test.yml` use `1.26`, and `verify-idl-consumption.yml` pins `1.26.4`. That looks like genuine drift rather than intentional pinning, but normalizing it is a code change rather than a docs refresh.

## Verification

`typos` clean on the changed file; all pins re-read from their sources (`go.mod`, the three `dockerfiles/Dockerfile.*`, `cmd/requester/README.md`) rather than carried over from the old table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)