### PR TITLE
Switch order of dual-pods and launcher in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Design
 
-- [Launcher](launcher.md)
 - [Fast Model Actuation with Process Flexibility and Dual Pods](dual-pods.md)
+- [Launcher](launcher.md)
 - [Cluster Sharing](cluster-sharing.md)
 - [Prometheus Metrics](metrics.md)
 - [Design Rules](../DESIGN_RULES.md)


### PR DESCRIPTION
The dual-pods doc is about the whole technique, so should come first.