### PR TITLE
launcher-populator: requeue LPPs on LC existence transitions

### DIFF
--- a/pkg/controller/launcher-populator/digest-updater.go
+++ b/pkg/controller/launcher-populator/digest-updater.go
@@ -44,6 +44,7 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 	var templateErr, templateHash, prevTemplateHash string
 	var nodeIndep *corev1.Pod
 	var good bool
+	var exists bool
 
 	prevDigest := ctl.policy.lcs[name]
 	prevExists := prevDigest != nil && prevDigest.object != nil
@@ -81,12 +82,13 @@ func (ctl *controller) updateDigestForLC(ctx context.Context, name string) error
 			templateHash:    templateHash,
 			nodeIndependent: nodeIndep,
 		}
+		exists = true
 		// The LauncherConfig object exists, so its fma_launcher_pod_count series
 		// must exist (as explicit zeros until launchers arrive).
 		ctl.metrics.setLCExists(name, true)
 	}
 
-	if prevGood != good || good && (prevTemplateHash != templateHash) {
+	if prevExists != exists || prevGood != good || good && (prevTemplateHash != templateHash) {
 		for _, lppName := range ctl.policy.lppNamesRefByLC(name) {
 			ctl.digestQueue.Queue.Add(funcItem{Kind: kindLPP, Name: lppName})
 		}


### PR DESCRIPTION
`updateDigestForLC` does not re‑queue the referencing `LPP`when an `LC` undergoes an existential transition (i.e., it appears or disappears). As a result, the `Status.Errors` in the LPP and the `desiredCount` in the digest become stale.

This manifests in two symmetric scenarios:

| # | Transition                | prevGood | good | Old condition `prevGood != good` | Outcome |
|---|---------------------------|----------|------|----------------------------------|---------|
| 1 | Invalid LC is deleted     | false    | false | false                            | No re‑queue — LPP Status permanently retains the error for that LC |
| 2 | LC reappears with an invalid template | false | false | false | No re‑queue — LPP Status keeps reporting "LC does not exist" |

What both scenarios have in common: `prevGood` and `good` are both `false`, so `prevGood != good` does not trigger; and `good && (hash changed)` short‑circuits because `good` is `false`. No condition captures the fact that *the very existence of the object has changed*.

Therefore, an exists field was added to indicate whether the LC currently exists, and it is compared with preExists to decide whether a re‑queue is needed.

## concrete behavior of the two fixed scenarios
  Scenario 1: an invalid LC is deleted
| |Before fix|After fix|
|---|---|---|
|Status.Errors|Remains empty (no "missing" reported) |Correctly adds "LauncherConfig X ... does not exist" |



  Scenario 2: an LC appears with an invalid template
| |Before fix|After fix|
|---|---|---|
|Status.Errors| Retains "does not exist"  |Correctly cleared (the LC now exists, no longer missing)  |
