### PR TITLE
Note hands-off case in LPP meaning

### DIFF
--- a/api/fma/v1alpha1/launcherpopulationpolicy_types.go
+++ b/api/fma/v1alpha1/launcherpopulationpolicy_types.go
@@ -26,18 +26,21 @@ import (
 // for a given type of Node.
 // Here we introduce and use a particular definition of "type" for Nodes.
 // All the LauncherPopulationPolicy objects together define a map,
-// from (Node, LauncherConfig) to count.
+// from (Node, LauncherConfig name) to count.
 // Call this map `PopulationPolicy`.
-// When multiple CountForLauncher apply to the same (Node, LauncherConfig) pair
+// When multiple CountForLauncher apply to the same (Node, LauncherConfig name) pair
 // the maximum of their counts is what appears in `PopulationPolicy`.
-// When no CountForLauncher applies to a given (Node, LauncherConfig),
+// When no CountForLauncher applies to a given (Node, LauncherConfig name),
 // `PopulationPolicy` implicitly maps that pair to zero.
 //
 // The collective meaning of all the LauncherPopulationPolicy objects
-// and all the server-requesting Pods is that for a given (Node, LauncherConfig)
+// and all the server-requesting Pods is that for a given (Node, LauncherConfig name)
 // the number of launchers that should exist is the larger of
 // (a) what `PopulationPolicy` says for that pair, and
 // (b) the number needed to satisfy the server-requesting Pods.
+// While there is no LauncherConfig with the given name or that LauncherConfig
+// exists and has a malformed Pod template,
+// the controllers will not create or delete launchers.
 //
 // +genclient
 // +kubebuilder:object:root=true

--- a/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml
+++ b/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml
@@ -24,18 +24,21 @@ spec:
           for a given type of Node.
           Here we introduce and use a particular definition of "type" for Nodes.
           All the LauncherPopulationPolicy objects together define a map,
-          from (Node, LauncherConfig) to count.
+          from (Node, LauncherConfig name) to count.
           Call this map `PopulationPolicy`.
-          When multiple CountForLauncher apply to the same (Node, LauncherConfig) pair
+          When multiple CountForLauncher apply to the same (Node, LauncherConfig name) pair
           the maximum of their counts is what appears in `PopulationPolicy`.
-          When no CountForLauncher applies to a given (Node, LauncherConfig),
+          When no CountForLauncher applies to a given (Node, LauncherConfig name),
           `PopulationPolicy` implicitly maps that pair to zero.
 
           The collective meaning of all the LauncherPopulationPolicy objects
-          and all the server-requesting Pods is that for a given (Node, LauncherConfig)
+          and all the server-requesting Pods is that for a given (Node, LauncherConfig name)
           the number of launchers that should exist is the larger of
           (a) what `PopulationPolicy` says for that pair, and
           (b) the number needed to satisfy the server-requesting Pods.
+          While there is no LauncherConfig with the given name or that LauncherConfig
+          exists and has a malformed Pod template,
+          the controllers will not create or delete launchers.
         properties:
           apiVersion:
             description: |-

--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -158,20 +158,24 @@ objects call for a proactive population of launchers, as follows.
   implicitly applied to all Nodes to find the relevant ones.
 
 - Each `LauncherPopulationPolicy` defines a partial map from
-  `LauncherConfig` to a desired number of launcher Pods.
+  `LauncherConfig` name to a desired number of launcher Pods.
 
 - All the `LauncherPopulationPolicy` objects together collectively
-  define a map, called `PopulationPolicy`, from (Node, LauncherConfig)
-  to count. For a given (N, C) this count is the maximum of the counts
-  prescribed by the `LauncherPopulationPolicy` objects that select N
-  and declare a count for C (zero if there are none).
+  define a map, called `PopulationPolicy`, from (`Node`,
+  `LauncherConfig` name) to count. For a given (N, C) this count is
+  the maximum of the counts prescribed by the
+  `LauncherPopulationPolicy` objects that select N and declare a count
+  for C (zero if there are none).
 
 - The collective meaning of all the `LauncherPopulationPolicy` objects
-  and all the server-requesting Pods is that for a given (Node,
-  LauncherConfig) the number of launchers that should exist is the
-  larger of
+  and all the server-requesting Pods is that for a given (`Node`,
+  `LauncherConfig` name) the number of launchers that should exist
+  is the larger of
     (a) what `PopulationPolicy` says for that pair, and
     (b) the number needed to satisfy the existing server-requesting Pods.
+  However: while there is no `LauncherConfig` with the given name or
+  that `LauncherConfig` exists and has a malformed Pod template, the
+  FMA controllers will not create or delete launchers.
 
 ### User-initiated changes to relevant API objects
 


### PR DESCRIPTION
Update the API documentation to include the hands-off case: no launchers created or deleted while the LauncherConfig is missing or malformed.

This is not an API change, it is fixing an oversight in the prose describing the API.