### PR TITLE
Fix stale-pointer issue in configureRequiredEnvVars

### DIFF
--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -135,7 +135,7 @@ func GPUIndexFunc(obj any) ([]string, error) {
 		return []string{}, nil
 	}
 	isCtr := &pod.Spec.Containers[isIdx]
-	ev := utils.SliceGetByFeature(isCtr.Env, EnvVarName, "CUDA_VISIBLE_DEVICES")
+	ev := utils.SliceGetByFeature(isCtr.Env, utils.EnvVarName, "CUDA_VISIBLE_DEVICES")
 	if ev == nil || len(ev.Value) == 0 {
 		return []string{}, nil
 	}
@@ -145,8 +145,6 @@ func GPUIndexFunc(obj any) ([]string, error) {
 	})
 	return keys, nil
 }
-
-func EnvVarName(ev *corev1.EnvVar) string { return ev.Name }
 
 const nominalHashIndexName = "nominal"
 

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -1913,7 +1913,7 @@ func (serverDat *serverData) getNominalServerProvidingPod(ctx context.Context, r
 		isCtr := &pod.Spec.Containers[cIdx]
 
 		// ensure the value of CUDA_VISIBLE_DEVICES envar for the inference server container
-		if ev := utils.SliceGetByFeature(isCtr.Env, EnvVarName, "CUDA_VISIBLE_DEVICES"); ev == nil {
+		if ev := utils.SliceGetByFeature(isCtr.Env, utils.EnvVarName, "CUDA_VISIBLE_DEVICES"); ev == nil {
 			isCtr.Env = append(isCtr.Env, corev1.EnvVar{
 				Name:  "CUDA_VISIBLE_DEVICES",
 				Value: *serverDat.GPUIndicesStr,

--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -321,36 +321,25 @@ func SpecializeLauncherTemplateToNode(nodeIndependent *corev1.Pod, nodeName stri
 	return nodeDependent
 }
 
-// configureRequiredEnvVars adds or updates required environment variables
+var requiredEnvVars = []corev1.EnvVar{
+	{Name: "PYTHONPATH", Value: "/app"},
+	{Name: "NVIDIA_VISIBLE_DEVICES", Value: "all"},
+	{Name: "NVIDIA_DRIVER_CAPABILITIES", Value: "compute,utility"},
+	{Name: "VLLM_SERVER_DEV_MODE", Value: "1"},
+}
+
+// configureRequiredEnvVars adds or updates required environment variables.
 func configureRequiredEnvVars(container *corev1.Container) {
-	envVars := map[string]string{
-		"PYTHONPATH":                 "/app",
-		"NVIDIA_VISIBLE_DEVICES":     "all",
-		"NVIDIA_DRIVER_CAPABILITIES": "compute,utility",
-		"VLLM_SERVER_DEV_MODE":       "1",
-	}
-
-	// Create a mapping of existing environment variables for easy lookup
-	existingEnv := make(map[string]*corev1.EnvVar)
-	for i := range container.Env {
-		envVar := &container.Env[i]
-		existingEnv[envVar.Name] = envVar
-	}
-
-	// Add or update required environment variables
-	for envName, envValue := range envVars {
-		if envVar, exists := existingEnv[envName]; exists {
-			// If it already exists, update its value
-			envVar.Value = envValue
+	for _, r := range requiredEnvVars {
+		if i := SliceIndexFeature(container.Env, EnvVarName, r.Name); i >= 0 {
+			container.Env[i] = r
 		} else {
-			// If it doesn't exist, add a new environment variable
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  envName,
-				Value: envValue,
-			})
+			container.Env = append(container.Env, r)
 		}
 	}
 }
+
+func EnvVarName(ev *corev1.EnvVar) string { return ev.Name }
 
 // removeGPUResourceLimits removes nvidia.com/gpu from container resource limits and requests
 func removeGPUResourceLimits(container *corev1.Container) {

--- a/pkg/controller/utils/pod-helper_test.go
+++ b/pkg/controller/utils/pod-helper_test.go
@@ -221,3 +221,33 @@ func TestBuildLauncherPodFromTemplate_NodeIndependentTemplateHash(t *testing.T) 
 		t.Fatalf("legacy launcher-config-hash must differ between nodes, both = %q", legacyA)
 	}
 }
+
+// TestConfigureRequiredEnvVars verifies that required vars are updated in place
+// when present and appended otherwise (in declaration order), while non-required
+// vars are preserved.
+func TestConfigureRequiredEnvVars(t *testing.T) {
+	initial := []corev1.EnvVar{
+		{Name: "CUSTOM_VAR", Value: "custom-value"},
+		{Name: "PYTHONPATH", Value: "/old"},
+	}
+	container := &corev1.Container{Env: initial}
+
+	configureRequiredEnvVars(container)
+
+	// Pre-existing entries are kept in place at the front, with required ones
+	// updated in place.
+	if container.Env[0] != (corev1.EnvVar{Name: "CUSTOM_VAR", Value: "custom-value"}) {
+		t.Errorf("non-required var not preserved: %+v", container.Env[0])
+	}
+	if container.Env[1] != (corev1.EnvVar{Name: "PYTHONPATH", Value: "/app"}) {
+		t.Errorf("pre-existing required var not updated in place: %+v", container.Env[1])
+	}
+	// Missing required vars are appended in requiredEnvVars declaration order.
+	tail := container.Env[len(initial):]
+	want := requiredEnvVars[1:] // PYTHONPATH already present; rest are appended
+	for i := range want {
+		if tail[i] != want[i] {
+			t.Errorf("appended[%d] = %+v, want %+v (declaration order)", i, tail[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
1. Fix a dangling pointer issue: The original implementation stored *EnvVar pointers into the underlying array of container.Env, then called append in the random iteration order of a map within the same loop. If append happened to run before an in‑place update and triggered a reallocation of the backing array, that update would write to a stale old address and be silently lost. The fix now accesses each required variable by index (container.Env[i]), re‑evaluated on every iteration—which is safe against reallocation—thus eliminating the problem at its root.

2. Provide ordered and deterministic environment‑variable setting: The required‑variable table has been changed from map[string]string to `[]corev1.EnvVar`. This makes the iteration order fixed, and the append order follows the declaration order, guaranteeing that the function is idempotent.