### PR TITLE
Always setup-go in ci-e2e-openshift.yaml

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -684,6 +684,7 @@ jobs:
 
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: always()
         with:
           go-version: '1.26'
 


### PR DESCRIPTION
Because the go tooling to extract coverage data is always used.

This fixes an oversight in the original coding. This fix prevents the job step that uses the go tooling from failing.

This fix only removes an annoyance; in cases where this makes a difference, there is no coverage data to extract.