### PR TITLE
Address unresolved review threads from #635 and #673

### DIFF
--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -649,8 +649,7 @@ that from 0.9.
 ### FYI labels and annotations
 
 The FMA controllers put some labels and annotations on Pods primarily
-for observability. Except where noted below, the controllers do not
-consume them. They are as follows.
+for observability. They are as follows.
 
 - annotation **dual-pods.llm-d.ai/accelerators**. Put on both
   requester and provider Pods. Value is a comma-separated list of GPU
@@ -676,9 +675,10 @@ consume them. They are as follows.
   unbound launcher Pod when the launcher has remained unscheduled or
   not Ready for at least the corresponding configured stuck
   threshold. Its value is "true". The launcher population controller
-  consumes this label to avoid publishing a duplicate `LauncherStuck`
-  Event on every reconciliation, and removes it if the launcher
-  recovers. To list currently stuck launchers, use:
+  maintains this label, publishing a `LauncherStuck` Warning Event
+  when it marks a launcher as stuck and removing the label if the
+  launcher recovers. The label keeps the condition discoverable after
+  the Event expires. To list currently stuck launchers, use:
 
   ```shell
   kubectl get pods -l dual-pods.llm-d.ai/launcher-stuck=true
@@ -695,6 +695,12 @@ Such an `Event` is associated with a launcher Pod, is a `Warning`, has
 reason `LauncherStuck`, and its message is "Launcher is stuck (phase);
 leaving it in place for investigation". Here `(phase)` is either
 `(stuck_scheduling)` or `(stuck_starting)`.
+
+A stuck launcher remains in place and continues to count toward the
+desired launcher population. The controller does not automatically
+replace or retry it; users decide how to respond using the
+`fma_launcher_pod_count` metric, the Event, and the
+`dual-pods.llm-d.ai/launcher-stuck` label.
 
 #### OutdatedRoutingMetadata events
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -71,14 +71,6 @@ Labels are as follows.
 
 - `isc_name`: Name of the relevant InferenceServerConfig
 
-### fma_isc_count
-
-Vector of gauges: Number of InferenceServerConfig objects.
-
-Labels are as follows.
-
-- `launcher_config_name`: Name of the relevant LauncherConfig
-
 ### fma_launcher_pod_count
 
 Vector of gauges: Number of launcher Pods for each LauncherConfig and
@@ -102,21 +94,19 @@ Labels are as follows.
 
 The launcher-populator's `--stuck-scheduling-threshold` and
 `--stuck-starting-threshold` flags configure the two stuck thresholds.
-When the controller observes a retained launcher in either stuck phase without
-the stuck label, it publishes a `LauncherStuck` Warning Event and sets the
-`dual-pods.llm-d.ai/launcher-stuck=true` label. The label makes the current
-condition discoverable after the Event expires and suppresses further Events
-while the Pod remains stuck. If the launcher recovers, the controller removes
-the label.
+The same classification also drives the
+`dual-pods.llm-d.ai/launcher-stuck` label and the `LauncherStuck`
+Warning Event; see [the observability section of the dual-pods
+documentation](dual-pods.md#observability) for those and for how the
+controller treats a stuck launcher.
 
-The Event is emitted before the label Patch is attempted. Because they are
-separate Kubernetes API transactions, a controller failure between them or a
-failed Patch can produce a duplicate Event on a later reconcile. This ordering
-deliberately favors a possible duplicate over losing the Event entirely.
+### fma_isc_count
 
-A stuck launcher remains in place and continues to count toward the desired
-launcher population. The controller does not automatically replace or retry
-it; users decide how to respond using the metric, Event, and label.
+Vector of gauges: Number of InferenceServerConfig objects.
+
+Labels are as follows.
+
+- `launcher_config_name`: Name of the relevant LauncherConfig
 
 ## FMA requester-provider binding
 

--- a/pkg/controller/launcher-populator/metrics.go
+++ b/pkg/controller/launcher-populator/metrics.go
@@ -137,14 +137,14 @@ func (pc *phaseCounts) increment(phase launcherPhase) {
 	}
 }
 
-// forEach calls yield once for every supported metric phase, including phases
-// whose count is zero.
-func (pc phaseCounts) forEach(yield func(launcherPhase, int)) {
-	yield(phaseBound, pc.bound)
-	yield(phaseUnbound, pc.unbound)
-	yield(phaseStuckScheduling, pc.stuckScheduling)
-	yield(phaseStuckStarting, pc.stuckStarting)
-	yield(phaseStale, pc.stale)
+// forEach is an iterator (in the range-over-function sense) over every
+// supported metric phase and its count, including phases whose count is zero.
+func (pc phaseCounts) forEach(yield func(launcherPhase, int) bool) {
+	_ = yield(phaseBound, pc.bound) &&
+		yield(phaseUnbound, pc.unbound) &&
+		yield(phaseStuckScheduling, pc.stuckScheduling) &&
+		yield(phaseStuckStarting, pc.stuckStarting) &&
+		yield(phaseStale, pc.stale)
 }
 
 // metricsState is the source of truth backing launcherPodCountGauge: it holds
@@ -222,15 +222,15 @@ func (ms *metricsState) setLCExists(lcfg string, exists bool) {
 func (ms *metricsState) republishLocked(lcfg string) {
 	if !ms.lcExists.Has(lcfg) && len(ms.perLCFG[lcfg]) == 0 {
 		delete(ms.agg, lcfg)
-		phaseCounts{}.forEach(func(phase launcherPhase, _ int) {
+		for phase := range (phaseCounts{}).forEach {
 			launcherPodCountGauge.DeleteLabelValues(lcfg, string(phase))
-		})
+		}
 		return
 	}
 	agg := ms.agg[lcfg] // zero value when the LC exists but has no launchers
-	agg.forEach(func(phase launcherPhase, count int) {
+	for phase, count := range agg.forEach {
 		launcherPodCountGauge.WithLabelValues(lcfg, string(phase)).Set(float64(count))
-	})
+	}
 }
 
 // launcherPhaseOf classifies a launcher Pod into a phase (see the launcherPhase

--- a/pkg/controller/launcher-populator/metrics_test.go
+++ b/pkg/controller/launcher-populator/metrics_test.go
@@ -650,7 +650,7 @@ func TestComputeKeyPhases(t *testing.T) {
 			t.Errorf("total=%d want %d (every pod must be counted)", counts.total(), len(pods))
 		}
 		wantCounts := phaseCounts{bound: 1, unbound: 2, stuckStarting: 1, stale: 1}
-		if !reflect.DeepEqual(counts, wantCounts) {
+		if counts != wantCounts {
 			t.Errorf("counts=%+v want %+v", counts, wantCounts)
 		}
 		// Only the not-Ready, counting-down unbound pod drives earliestTransition.

--- a/pkg/controller/launcher-populator/populator.go
+++ b/pkg/controller/launcher-populator/populator.go
@@ -545,9 +545,9 @@ func (ctl *controller) reconcileKey(ctx context.Context, key NodeLauncherKey, de
 	// Report stuck launchers among only the Pods not targeted for excess
 	// deletion in this reconcile. Skipped in orphan cleanup (nil template).
 	if nodeIndependentLauncherTemplate != nil {
-		retained := utils.SliceFilter(liveUnboundCurrentPods, utils.Not1(func(pod *corev1.Pod) bool {
-			return excessDeletionTargets.Has(pod.UID)
-		}))
+		retained := utils.SliceFilter(liveUnboundCurrentPods, func(pod *corev1.Pod) bool {
+			return !excessDeletionTargets.Has(pod.UID)
+		})
 		if err := ctl.reportStuckLaunchers(ctx, retained, templateHash); err != nil {
 			return err, true
 		}
@@ -596,11 +596,7 @@ func (ctl *controller) reportStuckLaunchers(ctx context.Context, retained []*cor
 		if err := ctl.setStuckLabel(ctx, pod, stuck); err != nil {
 			return err
 		}
-		if stuck {
-			logger.Info("Reported stuck launcher", "pod", pod.Name, "uid", pod.UID, "phase", phase)
-		} else {
-			logger.Info("Cleared stuck label from recovered launcher", "pod", pod.Name, "uid", pod.UID)
-		}
+		logger.Info("Updated launcher stuck condition", "pod", pod.Name, "uid", pod.UID, "phase", phase, "stuck", stuck)
 	}
 
 	return nil

--- a/pkg/controller/utils/generics.go
+++ b/pkg/controller/utils/generics.go
@@ -70,13 +70,6 @@ func SliceFilter[Elt any](slice []Elt, keep func(Elt) bool) []Elt {
 	return filtered
 }
 
-// Not1 negates a single-argument predicate.
-func Not1[Arg any](predicate func(Arg) bool) func(Arg) bool {
-	return func(arg Arg) bool {
-		return !predicate(arg)
-	}
-}
-
 // SliceRemoveOnce removes the first occurrence of the given element from the given slice.
 // This returns a new slice rather than side-effecting the given one.
 func SliceRemoveOnce[Elt comparable](slice []Elt, goner Elt) ([]Elt, bool) {

--- a/pkg/controller/utils/generics_test.go
+++ b/pkg/controller/utils/generics_test.go
@@ -30,15 +30,3 @@ func TestSliceFilterKeepsMatchingElementsInOrder(t *testing.T) {
 		t.Errorf("SliceFilter result = %v, want %v", got, want)
 	}
 }
-
-func TestNot1NegatesPredicate(t *testing.T) {
-	isOdd := Not1(func(value int) bool {
-		return value%2 == 0
-	})
-	if isOdd(2) {
-		t.Error("negated predicate accepted a value accepted by the original")
-	}
-	if !isOdd(3) {
-		t.Error("negated predicate rejected a value rejected by the original")
-	}
-}


### PR DESCRIPTION
## Summary

This is a follow-up to [PR #635](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/635) and [PR #673](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673), addressing their remaining unresolved review comments.

| Review comment | Resolution |
|---|---|
| [Make `phaseCounts.forEach` usable with `range`](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/635#discussion_r3616139844) | Converted it to a range-over-function iterator and updated its callers. |
| [Use ordinary equality for `phaseCounts`](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/635#discussion_r3616182689) | Replaced `!reflect.DeepEqual` with `!=`. |
| [Keep the two Pod metrics first](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673#discussion_r3675084190) | Moved `fma_launcher_pod_count` before `fma_isc_count`. |
| [Correct the FYI labels and annotations overview](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673#discussion_r3675011999) | Removed the inaccurate claim that controllers generally do not consume this metadata. |
| [Clarify the role of the `launcher-stuck` label](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673#discussion_r3675007509) | Described it as controller-maintained observable state associated with `LauncherStuck` Events. |
| [Remove transaction details from user-facing documentation](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673#discussion_r3675126855) | Removed the Event/Patch ordering and duplicate-Event discussion from `metrics.md`. |
| [Move general stuck-launcher behavior out of the metrics chapter](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673#discussion_r3675140064) | Moved it to the observability section of `dual-pods.md` and added a reference from `metrics.md`. |
| [Use direct predicate negation instead of `utils.Not1`](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673#discussion_r3675173721) | Inlined the negation and removed the now-unused helper and test. |
| [Combine stuck-state log branches](https://github.com/llm-d-incubation/llm-d-fast-model-actuation/pull/673#discussion_r3675192579) | Replaced them with one structured log containing `phase` and `stuck`. |