### PR TITLE
Make production of coverage data optional

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -537,6 +537,7 @@ jobs:
             --oci-registry "${CONTAINER_IMG_REG,,}" \
             --config-dir config \
             --chart-set global.local=false \
+            --chart-set global.produceCoverdata=true \
             --namespace "$FMA_NAMESPACE" \
             --ensure-node-view-cluster-role "${FMA_CHART_INSTANCE_NAME}-node-view" \
             --install-crds true \

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -537,7 +537,6 @@ jobs:
             --oci-registry "${CONTAINER_IMG_REG,,}" \
             --config-dir config \
             --chart-set global.local=false \
-            --chart-set global.produceCoverdata=true \
             --namespace "$FMA_NAMESPACE" \
             --ensure-node-view-cluster-role "${FMA_CHART_INSTANCE_NAME}-node-view" \
             --install-crds true \

--- a/charts/fma-controllers/templates/dual-pods-controller/deployment.yaml
+++ b/charts/fma-controllers/templates/dual-pods-controller/deployment.yaml
@@ -1,5 +1,6 @@
 # This file has been modified with the assistance of Claude Opus 4.6
 {{- if .Values.dualPodsController.enabled }}
+{{- if .Values.global.produceCoverdata }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -11,54 +12,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    {{- include "fma-controllers.labels" . | nindent 4 }}
-    app.kubernetes.io/component: dual-pods-controller
-  name: "{{ .Release.Name }}-dual-pods-controller"
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: fma-controllers
-      app.kubernetes.io/component: dual-pods-controller
-      app.kubernetes.io/instance: {{ .Release.Name }}
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: fma-controllers
-        app.kubernetes.io/component: dual-pods-controller
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        scrape: "true"
-    spec:
-      containers:
-      - name: controller
-        image: "{{ .Values.global.imageRegistry }}/dual-pods-controller:{{ .Values.global.imageTag }}"
-        imagePullPolicy: {{ include "fma-controllers.dpc.imagePullPolicy" . }}
-        command:
-        - /ko-app/dual-pods-controller
-        - "-v=5"
-        - "--namespace={{ .Release.Namespace }}"
-        - "--sleeper-limit={{ .Values.dualPodsController.sleeperLimit }}"
-        - "--debug-accelerator-memory={{ .Values.dualPodsController.debugAcceleratorMemory }}"
-        env:
-        - name: GOCOVERDIR
-          value: /var/coverdata
-        ports:
-        - containerPort: 8002
-          name: metrics
-          protocol: TCP
-        volumeMounts:
-        - name: coverdata
-          mountPath: "/var/coverdata"
-      serviceAccountName: {{ .Release.Name }}-fma-controllers
-      volumes:
-      - name: coverdata
-        persistentVolumeClaim:
-          claimName: "{{ .Release.Name }}-coverdata-dual-pods-controller"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -96,4 +49,55 @@ spec:
       - name: coverdata
         persistentVolumeClaim:
           claimName: "{{ .Release.Name }}-coverdata-dual-pods-controller"
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "fma-controllers.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dual-pods-controller
+  name: "{{ .Release.Name }}-dual-pods-controller"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fma-controllers
+      app.kubernetes.io/component: dual-pods-controller
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fma-controllers
+        app.kubernetes.io/component: dual-pods-controller
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        scrape: "true"
+    spec:
+      containers:
+      - name: controller
+        image: "{{ .Values.global.imageRegistry }}/dual-pods-controller:{{ .Values.global.imageTag }}"
+        imagePullPolicy: {{ include "fma-controllers.dpc.imagePullPolicy" . }}
+        command:
+        - /ko-app/dual-pods-controller
+        - "-v=5"
+        - "--namespace={{ .Release.Namespace }}"
+        - "--sleeper-limit={{ .Values.dualPodsController.sleeperLimit }}"
+        - "--debug-accelerator-memory={{ .Values.dualPodsController.debugAcceleratorMemory }}"
+        ports:
+        - containerPort: 8002
+          name: metrics
+          protocol: TCP
+{{- if .Values.global.produceCoverdata }}
+        env:
+        - name: GOCOVERDIR
+          value: /var/coverdata
+        volumeMounts:
+        - name: coverdata
+          mountPath: "/var/coverdata"
+      volumes:
+      - name: coverdata
+        persistentVolumeClaim:
+          claimName: "{{ .Release.Name }}-coverdata-dual-pods-controller"
+{{- end }}
+      serviceAccountName: {{ .Release.Name }}-fma-controllers
 {{- end }}

--- a/charts/fma-controllers/values.yaml
+++ b/charts/fma-controllers/values.yaml
@@ -19,7 +19,7 @@ global:
   # This suppresses image pulls for the dual-pods controller.
   local: false
 
-  # Set this to true to make the controllers produce coverage data
+  # Set this to true to make the controller(s) produce coverage data
   produceCoverdata: false
 
   # Defines the image used to create coverdata inspector Pods

--- a/charts/fma-controllers/values.yaml
+++ b/charts/fma-controllers/values.yaml
@@ -19,6 +19,9 @@ global:
   # This suppresses image pulls for the dual-pods controller.
   local: false
 
+  # Set this to true to make the controllers produce coverage data
+  produceCoverdata: false
+
   # Defines the image used to create coverdata inspector Pods
   coverdataInspectorImage: busybox:1.38.0
 

--- a/docs/dual-pods.md
+++ b/docs/dual-pods.md
@@ -479,7 +479,7 @@ spec:
     options: >-
       --model TinyLlama/TinyLlama-1.1B-Chat-v1.0
       --enable-sleep-mode
-      --gpu-memory-utilization 0.85
+      --gpu-memory-utilization 0.825
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -492,7 +492,7 @@ spec:
 ```
 
 For an explanation of the principles that led to the
-`--gpu-memory-utilization 0.85` setting, see [GPU memory
+`--gpu-memory-utilization 0.825` setting, see [GPU memory
 planning](#gpu-memory-planning) below.
 
 The configuration objects exhibited here and the FMA container images

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -115,7 +115,7 @@ spec:
     options: >-
       --model HuggingFaceTB/SmolLM2-360M-Instruct
       --enable-sleep-mode
-      --gpu-memory-utilization 0.85
+      --gpu-memory-utilization 0.825
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -137,7 +137,7 @@ spec:
     options: >-
       --model Qwen/Qwen2.5-0.5B-Instruct
       --enable-sleep-mode
-      --gpu-memory-utilization 0.85
+      --gpu-memory-utilization 0.825
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -159,7 +159,7 @@ spec:
     options: >-
       --model TinyLlama/TinyLlama-1.1B-Chat-v1.0
       --enable-sleep-mode
-      --gpu-memory-utilization 0.85
+      --gpu-memory-utilization 0.825
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"

--- a/test/e2e/run-launcher-based.sh
+++ b/test/e2e/run-launcher-based.sh
@@ -267,6 +267,7 @@ done
     --ensure-node-view-cluster-role node-viewer \
     --install-crds true \
     --install-admission-policies true \
+    --chart-set global.produceCoverdata=true \
     --chart-set global.local=true
 
 : Run launcher-based E2E tests


### PR DESCRIPTION
This PR introduces a "value" in the Helm chart (`global.produceCoverdata`) that controls whether the controllers produce coverage data. The default is `false`, but the CI workflows that run E2E tests turn it on and attach results. Eschewing the production of coverage data is a normal thing to do in production usage, and will save everyone else from the grief suffered by the CI tests reported in #707 .

This PR also changes the GPU memory utilization target from 0.85 to 0.825, hoping that this will make the symptoms reported in #712 and #720 stop appearing.