### PR TITLE
Add the requester's TCP proxy, without using it yet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/llm-d-incubation/llm-d-fast-model-actuation
 go 1.25.0
 
 require (
+	github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048
 	github.com/prometheus/client_golang v1.24.1
 	github.com/spf13/pflag v1.0.10
 	k8s.io/api v0.34.10

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -35,6 +36,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048 h1:jaqViOFFlZtkAwqvwZN+id37fosQqR5l3Oki9Dk4hz8=
+github.com/inetaf/tcpproxy v0.0.0-20250222171855-c4b9df066048/go.mod h1:Di7LXRyUcnvAcLicFhtM9/MlZl/TNgRSDHORM2c6CMI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/server/requester/proxy/server.go
+++ b/pkg/server/requester/proxy/server.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/inetaf/tcpproxy"
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog/v2"
+
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
+)
+
+// ProxyConfig holds the proxy server's runtime parameters that are provided
+// at requester startup, via the requester command line. It is distinct from
+// stubapi.ProxyTargetConfig, which holds the runtime parameters provided
+// later by the dual-pods controller (the backend the proxy forwards to).
+type ProxyConfig struct {
+	// Port is the port the proxy listens on.
+	Port uint16
+	// DialTimeout is the timeout for dialing backend connections.
+	DialTimeout time.Duration
+}
+
+// DefaultProxyConfig provides sensible defaults.
+var DefaultProxyConfig = ProxyConfig{
+	Port:        8082,
+	DialTimeout: 10 * time.Second,
+}
+
+// AddToFlagSet registers command-line flags for all proxy configuration fields.
+func (cfg *ProxyConfig) AddToFlagSet(fs *pflag.FlagSet) {
+	fs.Uint16Var(&cfg.Port, "proxy-port", cfg.Port, "port for TCP proxy")
+	fs.DurationVar(&cfg.DialTimeout, "proxy-dial-timeout", cfg.DialTimeout, "timeout for proxy backend dial")
+}
+
+// Server is a TCP reverse proxy that waits for a backend target to be
+// delivered via Configure, then forwards all connections to that target.
+type Server struct {
+	cfg ProxyConfig
+
+	// configCh carries the target from Configure to Run; sent on at most once.
+	configCh chan stubapi.ProxyTargetConfig
+	// startedCh carries the result of starting the listener (nil on success).
+	// Run sends exactly one value then closes: nil on success, an error on
+	// Start failure or shutdown-before-configuration.
+	startedCh chan error
+
+	// target is the delivered backend target; guarded by stateMu because GET
+	// and the duplicate-PUT check race with the first PUT writer.
+	stateMu sync.Mutex
+	target  *stubapi.ProxyTargetConfig
+}
+
+// New creates a Server with the given configuration.
+func New(cfg ProxyConfig) *Server {
+	return &Server{
+		cfg:       cfg,
+		configCh:  make(chan stubapi.ProxyTargetConfig, 1),
+		startedCh: make(chan error, 1),
+	}
+}
+
+// Run starts the TCP proxy server. It blocks waiting for Configure to deliver
+// the backend target, then constructs and starts a tcpproxy.Proxy listening on
+// cfg.Port. It returns when the context is cancelled or the proxy stops.
+//
+// Run and Configure may be invoked in either order from different goroutines.
+func (s *Server) Run(ctx context.Context) error {
+	logger := klog.FromContext(ctx).WithName("proxy-server")
+	logger.Info("Starting TCP proxy server", "port", s.cfg.Port, "dialTimeout", s.cfg.DialTimeout)
+
+	var tgt stubapi.ProxyTargetConfig
+	select {
+	case tgt = <-s.configCh:
+		logger.V(2).Info("Received proxy target from Configure", "target", tgt)
+	case <-ctx.Done():
+		logger.V(2).Info("Context cancelled before proxy was configured")
+		s.startedCh <- fmt.Errorf("proxy shut down before configuration")
+		close(s.startedCh)
+		return nil
+	}
+
+	targetAddr := tgt.String()
+	p := &tcpproxy.Proxy{}
+	p.AddRoute(fmt.Sprintf(":%d", s.cfg.Port), &tcpproxy.DialProxy{
+		Addr:        targetAddr,
+		DialTimeout: s.cfg.DialTimeout,
+	})
+
+	if err := p.Start(); err != nil {
+		startErr := fmt.Errorf("failed to start proxy listener on port %d: %w", s.cfg.Port, err)
+		s.startedCh <- startErr
+		close(s.startedCh)
+		logger.Error(err, "Failed to start TCP proxy listener", "port", s.cfg.Port)
+		return startErr
+	}
+	s.startedCh <- nil
+	close(s.startedCh)
+	logger.Info("TCP proxy server listening", "port", s.cfg.Port, "target", targetAddr)
+
+	go func() {
+		<-ctx.Done()
+		logger.V(2).Info("Shutting down TCP proxy server")
+		_ = p.Close()
+	}()
+
+	waitErr := p.Wait()
+	if ctx.Err() != nil {
+		logger.V(2).Info("TCP proxy server stopped after context cancellation", "waitErr", waitErr)
+		return nil
+	}
+	if waitErr != nil {
+		logger.Error(waitErr, "TCP proxy server stopped unexpectedly")
+		return waitErr
+	}
+	logger.Info("TCP proxy server stopped")
+	return nil
+}
+
+// Configure handles the proxy configuration HTTP endpoint at ProxyConfigPath.
+//
+// GET returns the configured target (200) or 404 if not yet configured.
+// PUT delivers the backend target. PUT may succeed only once; subsequent PUTs
+// return 409. PUT does not return until the proxy is actively listening, so
+// callers can rely on a 200 response to mean the proxy is ready to accept
+// connections.
+func (s *Server) Configure(w http.ResponseWriter, r *http.Request) {
+	logger := klog.FromContext(r.Context()).WithName("proxy-server")
+
+	switch r.Method {
+	case http.MethodGet:
+		s.stateMu.Lock()
+		cur := s.target
+		s.stateMu.Unlock()
+		if cur == nil {
+			http.Error(w, "proxy not configured", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(cur)
+		return
+	case http.MethodPut:
+		// fall through to body handling below
+	default:
+		http.Error(w, "method not allowed, use GET or PUT", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var cfg stubapi.ProxyTargetConfig
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		http.Error(w, fmt.Sprintf("failed to parse JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	if cfg.Address == "" {
+		http.Error(w, "address is required", http.StatusBadRequest)
+		return
+	}
+	if cfg.Port == 0 {
+		http.Error(w, "invalid port", http.StatusBadRequest)
+		return
+	}
+
+	s.stateMu.Lock()
+	if s.target != nil {
+		s.stateMu.Unlock()
+		http.Error(w, "proxy already configured", http.StatusConflict)
+		return
+	}
+	s.target = &cfg
+	s.stateMu.Unlock()
+
+	logger.V(2).Info("Delivering proxy target to Run", "target", cfg)
+
+	// configCh has cap=1 and is reachable at most once per process lifetime,
+	// so the send never blocks.
+	s.configCh <- cfg
+
+	// Wait for Run to confirm the listener is up. Abort if the request
+	// is cancelled; Run always sends on startedCh (nil, start error, or
+	// shutdown error), so this select is guaranteed to unblock.
+	select {
+	case startErr := <-s.startedCh:
+		if startErr != nil {
+			http.Error(w, fmt.Sprintf("proxy failed to start: %v", startErr), http.StatusInternalServerError)
+			return
+		}
+	case <-r.Context().Done():
+		http.Error(w, "request cancelled before proxy started listening", http.StatusServiceUnavailable)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, "configured proxy to: %s", cfg.String())
+}

--- a/pkg/server/requester/proxy/server_test.go
+++ b/pkg/server/requester/proxy/server_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	stubapi "github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/spi"
+)
+
+// CI machines can be heavily loaded, so use generous timeouts for any
+// operation that crosses the proxy or talks to the network.
+const (
+	testDialTimeout = 10 * time.Second
+	testReadTimeout = 10 * time.Second
+	// Unlike the two above, this one is spent in full on every successful run.
+	testQuietPeriod = 2 * time.Second
+)
+
+// startProxy runs Run in a goroutine and returns a stop function.
+// Calling stop cancels the context and waits for the goroutine to exit,
+// ensuring no goroutine leaks between tests.
+func startProxy(t *testing.T, srv *Server) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := srv.Run(ctx); err != nil {
+			t.Logf("proxy Run error: %v", err)
+		}
+	}()
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+// startTestEchoServer starts a TCP server that echoes back any data it
+// receives. The returned closer shuts the listener AND any accepted
+// connections so tests do not leak goroutines.
+func startTestEchoServer(t *testing.T) (addr string, port uint16, closer func()) {
+	t.Helper()
+	ln, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("failed to start echo server: %v", err)
+	}
+	tcpAddr := ln.Addr().(*net.TCPAddr) // ListenTCP guarantees *TCPAddr
+	addr = tcpAddr.String()
+	port = uint16(tcpAddr.Port)
+
+	var (
+		connsMu sync.Mutex
+		conns   []net.Conn
+	)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			connsMu.Lock()
+			conns = append(conns, conn)
+			connsMu.Unlock()
+			go func(c net.Conn) {
+				_, _ = io.Copy(c, c)
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+
+	return addr, port, func() {
+		_ = ln.Close()
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}
+}
+
+// findFreePort returns a free TCP port.
+func findFreePort(t *testing.T) uint16 {
+	t.Helper()
+	ln, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	port := uint16(ln.Addr().(*net.TCPAddr).Port)
+	_ = ln.Close()
+	return port
+}
+
+func TestProxy_EchoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	_, backendPort, backendCloser := startTestEchoServer(t)
+	defer backendCloser()
+
+	proxyPort := findFreePort(t)
+	srv := New(ProxyConfig{Port: proxyPort, DialTimeout: testDialTimeout})
+	stop := startProxy(t, srv)
+	defer stop()
+
+	body := stubapi.ProxyTargetConfig{Address: "127.0.0.1", Port: backendPort}
+	jsonBody, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPut, stubapi.ProxyConfigPath, bytes.NewReader(jsonBody))
+	w := httptest.NewRecorder()
+	srv.Configure(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Configure failed: %d — %s", w.Code, w.Body.String())
+	}
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), testDialTimeout)
+	if err != nil {
+		t.Fatalf("failed to dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	testMsg := "hello proxy\n"
+	if _, err := conn.Write([]byte(testMsg)); err != nil {
+		t.Fatalf("failed to write to proxy: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(testReadTimeout))
+	got := make([]byte, len(testMsg))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("failed to read echo: %v", err)
+	}
+	if string(got) != testMsg {
+		t.Errorf("expected echo of %q, got %q", testMsg, got)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(testQuietPeriod))
+	extra := make([]byte, 1)
+	if n, _ := conn.Read(extra); n > 0 {
+		t.Errorf("unexpected trailing byte %q after echo", extra[:n])
+	}
+}
+
+func TestProxy_NoListenerBeforeConfigure(t *testing.T) {
+	t.Parallel()
+
+	proxyPort := findFreePort(t)
+	srv := New(ProxyConfig{Port: proxyPort, DialTimeout: DefaultProxyConfig.DialTimeout})
+	stop := startProxy(t, srv)
+	defer stop()
+
+	// Run is blocked waiting for Configure, so the proxy port has no listener.
+	time.Sleep(500 * time.Millisecond)
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), 2*time.Second)
+	if err == nil {
+		_ = conn.Close()
+		t.Errorf("expected dial to fail before Configure, but it succeeded")
+	}
+}
+
+// TestConfigure_Lifecycle walks the /v1/proxy/config resource through its
+// whole state sequence: unconfigured GET, the one PUT that takes effect, the
+// GET that reports it, and a second PUT that is refused.
+func TestConfigure_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	srv := New(ProxyConfig{Port: findFreePort(t), DialTimeout: testDialTimeout})
+
+	// Before Configure, GET should return 404. This needs no running proxy.
+	req1 := httptest.NewRequest(http.MethodGet, stubapi.ProxyConfigPath, nil)
+	w1 := httptest.NewRecorder()
+	srv.Configure(w1, req1)
+	if w1.Code != http.StatusNotFound {
+		t.Errorf("GET before configure should return 404, got %d", w1.Code)
+	}
+
+	// PUT requires Run to be active, since Configure waits for listener readiness.
+	stop := startProxy(t, srv)
+	defer stop()
+
+	_, backendPort, backendCloser := startTestEchoServer(t)
+	defer backendCloser()
+
+	body := stubapi.ProxyTargetConfig{Address: "127.0.0.1", Port: backendPort}
+	jsonBody, _ := json.Marshal(body)
+	req2 := httptest.NewRequest(http.MethodPut, stubapi.ProxyConfigPath, bytes.NewReader(jsonBody))
+	w2 := httptest.NewRecorder()
+	srv.Configure(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("Configure failed: %d — %s", w2.Code, w2.Body.String())
+	}
+
+	req3 := httptest.NewRequest(http.MethodGet, stubapi.ProxyConfigPath, nil)
+	w3 := httptest.NewRecorder()
+	srv.Configure(w3, req3)
+	if w3.Code != http.StatusOK {
+		t.Errorf("GET after configure should return 200, got %d", w3.Code)
+	}
+
+	var got stubapi.ProxyTargetConfig
+	if err := json.Unmarshal(w3.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to parse response JSON: %v", err)
+	}
+	if got != body {
+		t.Errorf("GET returned %+v, want %+v", got, body)
+	}
+
+	// Reconfigure with a DIFFERENT config — should be rejected, so the 409
+	// actually proves "reconfigure is blocked" rather than "duplicate write
+	// is a no-op".
+	differentBody := stubapi.ProxyTargetConfig{Address: "10.0.0.1", Port: backendPort + 1}
+	diffJSON, _ := json.Marshal(differentBody)
+	req4 := httptest.NewRequest(http.MethodPut, stubapi.ProxyConfigPath, bytes.NewReader(diffJSON))
+	w4 := httptest.NewRecorder()
+	srv.Configure(w4, req4)
+	if w4.Code != http.StatusConflict {
+		t.Errorf("reconfigure with different config should return 409, got %d — body: %s", w4.Code, w4.Body.String())
+	}
+}
+
+func TestConfigure_BadRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		expectCode int
+	}{
+		{"DELETE not allowed", http.MethodDelete, "", http.StatusMethodNotAllowed},
+		{"invalid JSON", http.MethodPut, `{invalid json}`, http.StatusBadRequest},
+		{"missing address", http.MethodPut, `{"address":"","port":8080}`, http.StatusBadRequest},
+		{"invalid port zero", http.MethodPut, `{"address":"127.0.0.1","port":0}`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := New(ProxyConfig{Port: findFreePort(t), DialTimeout: testDialTimeout})
+			req := httptest.NewRequest(tt.method, stubapi.ProxyConfigPath, bytes.NewReader([]byte(tt.body)))
+			w := httptest.NewRecorder()
+			srv.Configure(w, req)
+
+			if w.Code != tt.expectCode {
+				t.Errorf("expected status %d, got %d — body: %s", tt.expectCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/spi/interface.go
+++ b/pkg/spi/interface.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package spi
 
+import (
+	"net"
+	"strconv"
+)
+
 // This file defines interface of the stub.
 
 // AcceleratorQueryPath is the path part of the URL that is polled
@@ -59,3 +64,26 @@ const SetLogPath = "/v1/set-log"
 // LogStartPosParam is the name of the query parameter that
 // holds that starting position of a log chunk.
 const LogStartPosParam = "startPos"
+
+// ProxyConfigPath is the path for the proxy configuration resource.
+// Supports two HTTP methods:
+//   - GET: retrieves the configuration status of the proxy.
+//     Returns 200 if configured, 404 if not.
+//   - PUT: configures the proxy with a target address and port.
+//     After successful configuration, the proxy will forward TCP
+//     connections to the configured target.
+const ProxyConfigPath = "/v1/proxy/config"
+
+// ProxyTargetConfig is the request and response body for configuring the proxy
+// with a target address and port (sent by the dual-pods controller).
+type ProxyTargetConfig struct {
+	// Address is the target host to proxy to.
+	Address string `json:"address"`
+	// Port is the target port number.
+	Port uint16 `json:"port"`
+}
+
+// String returns the target formatted as a "host:port" network address.
+func (t ProxyTargetConfig) String() string {
+	return net.JoinHostPort(t.Address, strconv.FormatUint(uint64(t.Port), 10))
+}


### PR DESCRIPTION
Introduce `pkg/server/requester/proxy`: a TCP reverse proxy that blocks until a backend target is delivered through its /v1/proxy/config HTTP handler, then forwards every accepted connection to that target. Add the SPI path and request/response type that handler speaks, plus the `github.com/inetaf/tcpproxy dependency` it is built on.

Nothing wires this into any binary, so no behavior changes. This is the first half of #498, split so that it can merge before parallel development accumulates more conflicts against it. 

Relative to that PR, it also applies the review comments still open against the proxy code, except as noted below:

  - `AddFlags` is renamed `AddToFlagSet`, matching Options.AddToFlagSet in `pkg/observability/prom-and-debug.go`.
  - The PUT body is decoded straight off `r.Body` rather than through `io.ReadAll`, so an oversized body cannot be turned into an OOM.
  - The needless defer `r.Body.Close()` is gone; `net/http` closes it.
  - "proxy shutdown cancelled before configuration" described the wrong end of the lifecycle, and "most recently" described a value that is delivered at most once. Both reworded.
  - `TestConfigure_DifferentConfigReturnsConflict` is folded into `TestConfigure_GetStatus`, together now `TestConfigure_Lifecycle`.
  - The "no trailing byte" assertion waits `testQuietPeriod` (2s) instead of 100ms, which is thin on a loaded CI machine.
