### PR TITLE
Add options to test a release

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -546,6 +546,7 @@ jobs:
             subject=(--image-tag "$IMAGE_TAG"
                      --oci-registry "${CONTAINER_IMG_REG,,}"
                      --config-dir config
+                     --chart-set global.local=false
                     )
           else
             subject=(--release "$FMA_RELEASE")

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -57,6 +57,10 @@ on:
         description: 'Skip cleanup after tests'
         required: false
         default: 'false'
+      fma_release:
+        description: 'FMA release to test, sans leading v; empty string tests local copy'
+        required: false
+        default: ''
 
 jobs:
   # Gate: Check permissions and handle /ok-to-test for fork PRs
@@ -274,7 +278,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.build.outputs.image_tag }}
-      controller_image: ${{ steps.build.outputs.controller_image }}
       requester_image: ${{ steps.build.outputs.requester_image }}
       launcher_image: ${{ steps.build.outputs.launcher_image }}
     steps:
@@ -313,6 +316,7 @@ jobs:
         id: build
         env:
           GIT_REF: ${{ needs.gate.outputs.pr_head_sha }}
+          FMA_RELEASE: ${{ github.event.inputs.fma_release || '' }}
         run: |
           # Use first 8 chars of the git ref (POSIX-compliant)
           IMAGE_TAG="ref-$(printf '%s' "$GIT_REF" | cut -c1-8)-$(date +%Y%m%d)"
@@ -321,6 +325,10 @@ jobs:
 
           echo "Building images with tag: $IMAGE_TAG"
           echo "Registry: $CONTAINER_IMG_REG"
+          echo "FMA_RELEASE=<$FMA_RELEASE>"
+
+          if [ -z "$FMA_RELEASE" ]; then
+          echo building FMA platform images
 
           # Build controller (ko)
           make build-controller \
@@ -331,6 +339,8 @@ jobs:
           make build-populator \
             CONTAINER_IMG_REG="$CONTAINER_IMG_REG" \
             IMAGE_TAG="$IMAGE_TAG"
+
+          fi
 
           # Build requester (Docker, multi-platform)
           make build-and-push-requester \
@@ -343,7 +353,6 @@ jobs:
             LAUNCHER_IMG_TAG="$IMAGE_TAG"
 
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "controller_image=${CONTAINER_IMG_REG}/dual-pods-controller:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "requester_image=${CONTAINER_IMG_REG}/requester:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "launcher_image=${CONTAINER_IMG_REG}/launcher:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "All images built and pushed"
@@ -531,12 +540,18 @@ jobs:
       - name: Install FMA
         env:
           CONTAINER_IMG_REG: ghcr.io/${{ github.repository }}
+          FMA_RELEASE: ${{ github.event.inputs.fma_release || '' }}
         run: |
+          if [ -z "$FMA_RELEASE" ]; then
+            subject=(--image-tag "$IMAGE_TAG"
+                     --oci-registry "${CONTAINER_IMG_REG,,}"
+                     --config-dir config
+                    )
+          else
+            subject=(--release "$FMA_RELEASE")
+          fi
           scripts/install-fma.sh \
-            --image-tag "$IMAGE_TAG" \
-            --oci-registry "${CONTAINER_IMG_REG,,}" \
-            --config-dir config \
-            --chart-set global.local=false \
+            "${subject[@]}" \
             --chart-set global.produceCoverdata=true \
             --namespace "$FMA_NAMESPACE" \
             --ensure-node-view-cluster-role "${FMA_CHART_INSTANCE_NAME}-node-view" \

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -60,7 +60,14 @@ on:
       fma_release:
         description: 'FMA release to test, sans leading v; empty string tests local copy'
         required: false
+        type: string
         default: ''
+      run_cluster:
+        description: 'the cluster to run the test'
+        required: false
+        type: choice
+        options: [ vllm-d, pok-prod ]
+        default: 'pok-prod'
 
 jobs:
   # Gate: Check permissions and handle /ok-to-test for fork PRs
@@ -364,7 +371,7 @@ jobs:
 
   # Run e2e tests on OpenShift self-hosted runner
   e2e-openshift:
-    runs-on: [self-hosted, openshift, pok-prod]
+    runs-on: [self-hosted, openshift, "${{ github.event.inputs.run_cluster || 'pok-prod' }}"]
     needs: [gate, build-image]
     if: needs.gate.outputs.should_run == 'true'
     env:
@@ -619,10 +626,16 @@ jobs:
         run: |
           if [ -r testnode ]
           then
+            case "${{ github.event.inputs.run_cluster || 'pok-prod' }}" in
+              (vllm-d)   ingdom=fmaas-vllm-d.fmaas.res.ibm.com;;
+              (pok-prod) ingdom=pokprod001.ete14.res.ibm.com;;
+              (*) echo "Impossible run_cluster '${{ github.event.inputs.run_cluster }}'"
+                  exit 1;;
+            esac
             curl -sSkG \
               -H "Authorization: Bearer $(oc whoami -t)" \
               --data-urlencode "query=DCGM_FI_DEV_FB_USED{Hostname=\"$(cat testnode)\"}" \
-              https://prometheus-k8s-openshift-monitoring.apps.pokprod001.ete14.res.ibm.com/api/v1/query \
+              https://prometheus-k8s-openshift-monitoring.apps.${ingdom}/api/v1/query \
             | jq '.data.result[]'
           else echo there is no readable testnode file
           fi

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -65,6 +65,9 @@ jobs:
           echo "GITHUB_ACTION_REF=$GITHUB_ACTION_REF"
 
   run-launcher-test:
+    strategy:
+      matrix:
+        release: [ "", "0.6.5-alpha.1" ]
     runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -83,7 +86,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Run launcher-based E2E test
-        run: test/e2e/run-launcher-based.sh
+        run: test/e2e/run-launcher-based.sh --release "${{ matrix.release }}"
 
       - name: list all pods
         if: always()

--- a/scripts/install-fma.sh
+++ b/scripts/install-fma.sh
@@ -226,7 +226,7 @@ if [[ "$install_crds" == "true" ]]; then
         if ! kubectl get crd "$crd_name" &>/dev/null; then
             kubectl create -f - <<<$obj
         elif kubectl get crd "$crd_name" -o json 2>/dev/null | jq -e --slurpfile desired <(jq .spec <<<$obj) '.spec as $existing | ($existing * $desired[0]) == $existing' &>/dev/null; then
-            echo "  CRD $crd_name already exists with adequate rules"
+            echo "  CRD $crd_name already exists with adequate definition"
         else
             echo "  CRD $crd_name needs updating"
             kubectl apply --server-side -f - <<<$obj

--- a/test/e2e/run-launcher-based.sh
+++ b/test/e2e/run-launcher-based.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-# Usage: $0
+# Usage: $0 [--local | --release $semver]
 # Current working directory must be the root of the Git repository.
-# This script tests launcher-based server-providing pods independently.
+#
+# This script creates a `kind` cluster and uses it to test
+# launcher-based server-providing pods independently.
 #
 # Required tools: kubectl, helm, curl, jq, yq (https://github.com/mikefarah/yq),
 # kind (defaulting to Kubernetes 1.30 or higher).
@@ -24,12 +26,55 @@ set -euo pipefail
 
 set -x
 
+release=""
+
+function usage() {
+    (
+        (( $# > 0 )) && echo "$*" || true
+        cat <<EOF
+$0 usage: OPTIONS
+
+where OPTIONS are any of the following.
+
+    --release[=]\$semver
+    --local
+EOF
+    ) >& 2
+}
+
+while (( $# > 0 )); do
+    case "$1" in
+        (--release=*)
+            release=${1#--release=};;
+        (--release) if (( $# > 1 ))
+                    then release="$2"; shift
+                    else usage missing value for --release; exit 1
+                    fi;;
+
+        (--local) release="";;
+
+        (*) usage "Unknown argument $1"
+            exit 1;;
+    esac
+    shift
+done
+
+if [[ "$release" == v* ]]; then
+    echo "$0: do not include the leading 'v' in a release string" >&2
+    exit 1
+fi
+
+if [ -n "$release" ] && ! wc -w <<<"$release" | grep -w 1; then
+    echo "$0: the release must be a single shell 'word'" >&2
+    exit 1
+fi
+
 nl=$'\n'
 
 function clear_img_repo() (
     set +o pipefail
     docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.CreatedAt}}" $1 | fgrep -v '<none>' | grep -vw REPOSITORY | while read name tag rest; do
-	docker rmi $name:$tag
+        docker rmi $name:$tag
     done
 )
 
@@ -52,14 +97,17 @@ fi
 clear_img_repo ko.local/test-requester
 clear_img_repo my-registry/my-namespace/test-requester
 clear_img_repo my-registry/my-namespace/test-launcher
-clear_img_repo ko.local/dual-pods-controller
-clear_img_repo my-registry/my-namespace/dual-pods-controller
-clear_img_repo ko.local/launcher-populator
-clear_img_repo my-registry/my-namespace/launcher-populator
 make build-test-requester-local
 make build-test-launcher-local
-make build-controller-local
-make build-populator-local
+
+if [ -z "$release" ]; then
+    clear_img_repo ko.local/dual-pods-controller
+    clear_img_repo my-registry/my-namespace/dual-pods-controller
+    clear_img_repo ko.local/launcher-populator
+    clear_img_repo my-registry/my-namespace/launcher-populator
+    make build-controller-local
+    make build-populator-local
+fi
 
 : Set up the kind cluster
 
@@ -247,8 +295,10 @@ done
 
 make load-test-requester-local
 make load-test-launcher-local
-make load-controller-local
-make load-populator-local
+if [ -z "$release" ]; then
+    make load-controller-local
+    make load-populator-local
+fi
 
 : Populate GPU map for testing
 
@@ -261,14 +311,21 @@ done
 
 : Deploy FMA controllers
 
+if [ -z "$release" ]; then
+    what=(--image-tag "$(make echo-var VAR=IMAGE_TAG)"
+          --oci-registry "$(make echo-var VAR=CONTAINER_IMG_REG)"
+          --chart-set global.local=true
+         )
+else
+    what=(--release "$release")
+fi
+
 ./scripts/install-fma.sh \
-    --image-tag "$(make echo-var VAR=IMAGE_TAG)" \
-    --oci-registry "$(make echo-var VAR=CONTAINER_IMG_REG)" \
+    "${what[@]}" \
     --ensure-node-view-cluster-role node-viewer \
     --install-crds true \
     --install-admission-policies true \
     --chart-set global.produceCoverdata=true \
-    --chart-set global.local=true
 
 : Run launcher-based E2E tests
 


### PR DESCRIPTION
Generalize the E2E-on-OpenShift workflow so that it can optionally be told a release to test instead of the local copy. I chose to not make this workflow test both because of resource limitations on the test cluster.

Expand the kind and launcher based E2E workflow to test both release 0.6.5-alpha.1 and the local copy.

Generalize `test/e2e/run-launcher-based.sh` so that it can optionally be given a release to test instead of the local copy.