### PR TITLE
Retire global.local

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -553,7 +553,6 @@ jobs:
             subject=(--image-tag "$IMAGE_TAG"
                      --oci-registry "${CONTAINER_IMG_REG,,}"
                      --config-dir config
-                     --chart-set global.local=false
                     )
           else
             subject=(--release "$FMA_RELEASE")

--- a/charts/fma-controllers/templates/_helpers.tpl
+++ b/charts/fma-controllers/templates/_helpers.tpl
@@ -8,15 +8,3 @@ app.kubernetes.io/name: fma-controllers
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Image pull policy for dual-pods-controller.
-When global.local is true, use Never; otherwise Always.
-*/}}
-{{- define "fma-controllers.dpc.imagePullPolicy" -}}
-{{- if .Values.global.local -}}
-Never
-{{- else -}}
-Always
-{{- end -}}
-{{- end }}

--- a/charts/fma-controllers/templates/dual-pods-controller/deployment.yaml
+++ b/charts/fma-controllers/templates/dual-pods-controller/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       containers:
       - name: controller
         image: "{{ .Values.global.imageRegistry }}/dual-pods-controller:{{ .Values.global.imageTag }}"
-        imagePullPolicy: {{ include "fma-controllers.dpc.imagePullPolicy" . }}
+        imagePullPolicy: IfNotPresent
         command:
         - /ko-app/dual-pods-controller
         - "-v=5"

--- a/charts/fma-controllers/values.yaml
+++ b/charts/fma-controllers/values.yaml
@@ -15,10 +15,6 @@ global:
   # Empty string means no new binding is needed.
   nodeViewClusterRole: ""
 
-  # Set this to true when deploying in a local cluster.
-  # This suppresses image pulls for the dual-pods controller.
-  local: false
-
   # Set this to true to make the controller(s) produce coverage data
   produceCoverdata: false
 

--- a/docs/local-test.md
+++ b/docs/local-test.md
@@ -65,7 +65,6 @@ helm upgrade --install fma charts/fma-controllers \
   --set global.imageTag="$tag" \
   --set global.nodeViewClusterRole=node-viewer \
   --set dualPodsController.sleeperLimit=1 \
-  --set global.local=true \
   --set launcherPopulator.enabled=false
 
 function mkrs() {

--- a/inference_server/benchmark/kube_ops.py
+++ b/inference_server/benchmark/kube_ops.py
@@ -399,8 +399,6 @@ class KindKubernetesOps(KubernetesOps):
                     "--set",
                     "dualPodsController.sleeperLimit=2",
                     "--set",
-                    "global.local=true",
-                    "--set",
                     "launcherPopulator.enabled=false",
                 ]
             )

--- a/scripts/install-fma.sh
+++ b/scripts/install-fma.sh
@@ -245,7 +245,7 @@ fi
 if [ -n "$release" ]; then
     helm_args=("oci://${oci_reg}/charts/fma-controllers" --version "$release")
 else
-    helm_args=(charts/fma-controllers --set global.local=true)
+    helm_args=(charts/fma-controllers)
 fi
 
 

--- a/test/e2e/deploy_fma.sh
+++ b/test/e2e/deploy_fma.sh
@@ -29,7 +29,7 @@
 #   FMA_DEBUG            - "true" to enable shell tracing (set -x)
 #   HELM_EXTRA_ARGS     - additional Helm arguments appended to the
 #                         `helm upgrade --install` invocation
-#                         (e.g. "--set global.local=true --set dualPodsController.sleeperLimit=4")
+#                         (e.g. "--set dualPodsController.sleeperLimit=4")
 
 set -euo pipefail
 if [ "${FMA_DEBUG:-false}" = "true" ]; then
@@ -171,7 +171,7 @@ HELM_ARGS=(
     --set global.imageTag="${IMAGE_TAG}"
 )
 
-# Append any caller-supplied Helm arguments (e.g. --set global.local=true)
+# Append any caller-supplied Helm arguments
 if [ -n "${HELM_EXTRA_ARGS:-}" ]; then
     read -ra _extra <<< "$HELM_EXTRA_ARGS"
     HELM_ARGS+=("${_extra[@]}")

--- a/test/e2e/run-launcher-based.sh
+++ b/test/e2e/run-launcher-based.sh
@@ -314,7 +314,6 @@ done
 if [ -z "$release" ]; then
     what=(--image-tag "$(make echo-var VAR=IMAGE_TAG)"
           --oci-registry "$(make echo-var VAR=CONTAINER_IMG_REG)"
-          --chart-set global.local=true
          )
 else
     what=(--release "$release")

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -155,8 +155,7 @@ scripts/install-fma.sh --image-tag "$img_tag" --oci-registry "$img_reg" \
     --ensure-node-view-cluster-role node-viewer \
     --install-crds true \
     --install-admission-policies true \
-    --enable-launcher-populator false \
-    --chart-set global.local=true
+    --enable-launcher-populator false
 
 : Test Pod creation
 


### PR DESCRIPTION
This PR removes the "value" `global.local` from the Helm chart. It is a proven pain point; it has no proven value. It is used only for the dual-pods controller --- not for the launcher population controller.

This PR is built on #724 . Once that one merges, I will rebase this one onto `main`.