### PR TITLE
Quieten test

### DIFF
--- a/test/e2e/run-launcher-based.sh
+++ b/test/e2e/run-launcher-based.sh
@@ -64,7 +64,7 @@ if [[ "$release" == v* ]]; then
     exit 1
 fi
 
-if [ -n "$release" ] && ! wc -w <<<"$release" | grep -w 1; then
+if [ -n "$release" ] && ! wc -w <<<"$release" | grep -qw 1; then
     echo "$0: the release must be a single shell 'word'" >&2
     exit 1
 fi


### PR DESCRIPTION
This PR is built on #724 and adds one small improvement: the test in run-launcher-based.sh for whether the "release" value is a "word" in shell grammar is changed to not emit spurious noise.

If #724 gets merged first then I will rebase this. Alternatively, this could be approved and merged, that would implicitly approve and merge #724 as well.