### PR TITLE
Switch unit tests to new-style coverage data

### DIFF
--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -26,13 +26,13 @@ jobs:
         run: make test
 
       - name: analyze coverage by func
-        run: go tool cover -func=cover/unit-profile.txt -o cover/unit-func.txt
+        run: go tool covdata func -i cover/unit > cover/unit-func.txt
 
-      - name: upload unit test coverage profile
+      - name: upload unit test coverage data
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: cover/unit-profile.txt
-          archive: false
+          name: cover-unit-data
+          path: cover/unit
           retention-days: 14
 
       - name: upload unit test func analysis

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,9 @@ build-populator:
 
 .PHONY: test
 test: ## Run unit tests.
-	mkdir -p cover
+	mkdir -p cover/unit
 	@echo "Running unit tests..."
-	go test $$(go list ./pkg/... | grep -Ev '/pkg/(api|generated|spi)(/|$$)') -coverprofile=cover/unit-profile.txt
+	go test $$(go list ./pkg/... | grep -Ev '/pkg/(api|generated|spi)(/|$$)') -cover -args -test.gocoverdir=$$PWD/cover/unit
 
 .PHONY: echo-var
 echo-var:


### PR DESCRIPTION
Using technique mentioned in https://github.com/golang/go/issues/51430#issuecomment-1344749218 and https://dustinspecker.com/posts/go-combined-unit-integration-code-coverage/#run-unit-tests-to-collect-coverage