### PR TITLE
Rename DPC test coverage files

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -743,26 +743,25 @@ jobs:
           kubectl scale -n "$FMA_NAMESPACE" "deploy/${FMA_CHART_INSTANCE_NAME}-dpc-coverdata-inspector" --replicas=1
           kubectl wait -n "$FMA_NAMESPACE" "deploy/${FMA_CHART_INSTANCE_NAME}-dpc-coverdata-inspector" --for condition=Available
           insp=$(kubectl get -n "$FMA_NAMESPACE" pods -l app.kubernetes.io/component=dpc-coverdata-inspector -o name | sed s:^pod/::)
-          mkdir -p dpc-cover/data
+          mkdir -p cover-dpc/data
           kubectl wait -n "$FMA_NAMESPACE" pod "${insp}" --for condition=Ready
-          kubectl cp -n "$FMA_NAMESPACE" "${insp}:var/coverdata" dpc-cover/data
-          ls -l dpc-cover/data
-          go tool covdata textfmt -i=dpc-cover/data -o dpc-cover/profile.txt
-          go tool cover -func=dpc-cover/profile.txt -o dpc-cover-func.txt
+          kubectl cp -n "$FMA_NAMESPACE" "${insp}:var/coverdata" cover-dpc/data
+          ls -l cover-dpc/data
+          go tool covdata textfmt -i=cover-dpc/data -o cover-dpc/profile.txt
+          go tool cover -func=cover-dpc/profile.txt -o cover-dpc-func.txt
           kubectl scale -n "$FMA_NAMESPACE" "deploy/${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" --replicas=1
 
       - name: upload coverage data from dual pods controller
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dpc-cover-data
-          path: dpc-cover/data
+          name: cover-dpc-data
+          path: cover-dpc/data
           retention-days: 14
 
       - name: upload coverage summary from dual pods controller
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dpc-cover-func.txt
-          path: dpc-cover-func.txt
+          path: cover-dpc-func.txt
           archive: false
           retention-days: 14
 

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -167,6 +167,8 @@ jobs:
         run: cat scrape2p.metrics || true
 
       - name: extract coverage data from dual pods controller
+        env:
+          COVERDIR: "cover-dpc-${{ matrix.release || 'local' }}"
         run: |
           kubectl scale deploy/fma-dual-pods-controller --replicas=0
           let try=1
@@ -178,25 +180,23 @@ jobs:
           kubectl scale deploy/fma-dpc-coverdata-inspector --replicas=1
           kubectl wait deploy/fma-dpc-coverdata-inspector --for condition=Available
           insp=$(kubectl get pods -l app.kubernetes.io/component=dpc-coverdata-inspector -o name | sed s:^pod/::)
-          mkdir -p dpc-cover/data
+          mkdir -p ${COVERDIR}/data
           kubectl wait pod "${insp}" --for condition=Ready
-          kubectl cp "${insp}:var/coverdata" dpc-cover/data
-          ls -l dpc-cover/data
-          go tool covdata textfmt -i=dpc-cover/data -o dpc-cover/profile.txt
-          go tool cover -func=dpc-cover/profile.txt -o dpc-cover-func.txt
+          kubectl cp "${insp}:var/coverdata" ${COVERDIR}/data
+          ls -l ${COVERDIR}/data
+          go tool covdata func -i=${COVERDIR}/data > ${COVERDIR}-func.txt
 
       - name: upload coverage data from dual pods controller
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dpc-cover-data
-          path: dpc-cover/data
+          name: cover-dpc-${{ matrix.release || 'local' }}-data
+          path: "cover-dpc-${{ matrix.release || 'local' }}/data"
           retention-days: 14
 
       - name: upload coverage summary from dual pods controller
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dpc-cover-func.txt
-          path: dpc-cover-func.txt
+          path: "cover-dpc-${{ matrix.release || 'local' }}-func.txt"
           archive: false
           retention-days: 14
 

--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -66,6 +66,8 @@ jobs:
     strategy:
       matrix:
         release: [ "", "0.6.5-alpha.1" ]
+    env:
+      coverdir: "cover-dpc-${{ matrix.release || 'local' }}"
     runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -167,8 +169,6 @@ jobs:
         run: cat scrape2p.metrics || true
 
       - name: extract coverage data from dual pods controller
-        env:
-          COVERDIR: "cover-dpc-${{ matrix.release || 'local' }}"
         run: |
           kubectl scale deploy/fma-dual-pods-controller --replicas=0
           let try=1
@@ -180,23 +180,23 @@ jobs:
           kubectl scale deploy/fma-dpc-coverdata-inspector --replicas=1
           kubectl wait deploy/fma-dpc-coverdata-inspector --for condition=Available
           insp=$(kubectl get pods -l app.kubernetes.io/component=dpc-coverdata-inspector -o name | sed s:^pod/::)
-          mkdir -p ${COVERDIR}/data
+          mkdir -p "${{ env.coverdir }}/data"
           kubectl wait pod "${insp}" --for condition=Ready
-          kubectl cp "${insp}:var/coverdata" ${COVERDIR}/data
-          ls -l ${COVERDIR}/data
-          go tool covdata func -i=${COVERDIR}/data > ${COVERDIR}-func.txt
+          kubectl cp "${insp}:var/coverdata" "${{ env.coverdir }}/data"
+          ls -l "${{ env.coverdir }}/data"
+          go tool covdata func -i "${{ env.coverdir }}/data" > "${{ env.coverdir }}-func.txt"
 
       - name: upload coverage data from dual pods controller
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cover-dpc-${{ matrix.release || 'local' }}-data
-          path: "cover-dpc-${{ matrix.release || 'local' }}/data"
+          name: "${{ env.coverdir }}-data"
+          path: "${{ env.coverdir }}/data"
           retention-days: 14
 
       - name: upload coverage summary from dual pods controller
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: "cover-dpc-${{ matrix.release || 'local' }}-func.txt"
+          path: "${{ env.coverdir }}-func.txt"
           archive: false
           retention-days: 14
 


### PR DESCRIPTION
1. Use "cover-dpc" instead of "dpc-cover", to complement "cover-unit".

2. Inject the release (or "local") into the name, so that the two jobs in the one workflow produce artifacts with different names.