### PR TITLE
Add release name to Prometheus snap artifact

### DIFF
--- a/.github/workflows/launcher-based-e2e-test.yml
+++ b/.github/workflows/launcher-based-e2e-test.yml
@@ -204,6 +204,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: snap
+          name: "snap-${{ matrix.release || 'local' }}"
           path: snaps
           retention-days: 14


### PR DESCRIPTION
Needed now that launcher-based-e2e-test.yml has a matrix strategy.