### PR TITLE
Test install of release more seriously

### DIFF
--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -730,7 +730,7 @@ jobs:
         if: always()
         run: |
           for pod in $(kubectl get pods -n "$FMA_NAMESPACE" -o 'jsonpath={.items[*].metadata.name} ') ; do
-            containers=$(kubectl get pod -n "$FMA_NAMESPACE" "$pod" -o 'jsonpath={.spec.containers[*].name}')
+            containers=$(kubectl get pod -n "$FMA_NAMESPACE" "$pod" -o 'jsonpath={.spec.containers[*].name}' || true)
             for container in $containers ; do
               echo ""
               echo "=== Previous log of $pod (container: $container) ==="

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -584,7 +584,7 @@ jobs:
           FMA_RELEASE: ${{ github.event.inputs.fma_release || '' }}
         run: |
           echo "github.repository='${{ github.repository }}'"
-          echo "$GITHUB_HEAD_REF='$GITHUB_HEAD_REF'"
+          echo "GITHUB_HEAD_REF='$GITHUB_HEAD_REF'"
           echo "github.event_name='${{ github.event_name }}'"
           echo "github.ref_type='${{ github.ref_type }}'"
           echo "github.ref_name='${{ github.ref_name }}'"

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -622,7 +622,7 @@ jobs:
           MKOBJS_SCRIPT: ./test/e2e/mkobjs-openshift.sh
           POLL_LIMIT_SECS: "720"
         run: |
-          if [ "${{ github.event.inputs.run_cluster || 'pod-prod' }}" = "pok-prod" ]
+          if [ "${{ github.event.inputs.run_cluster || 'pok-prod' }}" = "pok-prod" ]
           then export REQUESTER_PRIORITY_CLASS=nightly-llm-d-cicd-critical
                echo Setting REQUESTER_PRIORITY_CLASS
           else echo Not setting REQUESTER_PRIORITY_CLASS

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -334,16 +334,16 @@ jobs:
           FMA_RELEASE: ${{ github.event.inputs.fma_release || '' }}
         run: |
           # Use first 8 chars of the git ref (POSIX-compliant)
-          IMAGE_TAG="ref-$(printf '%s' "$GIT_REF" | cut -c1-8)-$(date +%Y%m%d)"
           reg="${{ github.repository }}"
           CONTAINER_IMG_REG="ghcr.io/${reg@L}"
 
-          echo "Building images with tag: $IMAGE_TAG"
           echo "Registry: $CONTAINER_IMG_REG"
           echo "FMA_RELEASE=<$FMA_RELEASE>"
 
           if [ -z "$FMA_RELEASE" ]; then
-          echo building FMA platform images
+
+          IMAGE_TAG="ref-$(printf '%s' "$GIT_REF" | cut -c1-8)-$(date +%Y%m%d)"
+          echo "Building images with tag: $IMAGE_TAG"
 
           # Build controller (ko)
           make build-controller \
@@ -354,8 +354,6 @@ jobs:
           make build-populator \
             CONTAINER_IMG_REG="$CONTAINER_IMG_REG" \
             IMAGE_TAG="$IMAGE_TAG"
-
-          fi
 
           # Build requester (Docker, multi-platform)
           make build-and-push-requester \
@@ -371,6 +369,14 @@ jobs:
           echo "requester_image=${CONTAINER_IMG_REG}/requester:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "launcher_image=${CONTAINER_IMG_REG}/launcher:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "All images built and pushed"
+
+          else
+          echo Using release "'$FMA_RELEASE'"
+          echo "image_tag=v${FMA_RELEASE}" >> $GITHUB_OUTPUT
+          echo "requester_image=${CONTAINER_IMG_REG}/requester:v${FMA_RELEASE}" >> $GITHUB_OUTPUT
+          echo "launcher_image=${CONTAINER_IMG_REG}/launcher:v${FMA_RELEASE}" >> $GITHUB_OUTPUT
+
+          fi
 
       - name: Characterize filesystem space at end
         if: always()
@@ -429,7 +435,7 @@ jobs:
 
       - name: Verify cluster access
         run: |
-          echo "Verifying cluster access..."
+          echo "Verifying access to cluster ${{ github.event.inputs.run_cluster || 'pok-prod' }}..."
           kubectl cluster-info
           kubectl get nodes
 

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -401,11 +401,6 @@ jobs:
       LAUNCHER_IMAGE: ${{ needs.build-image.outputs.launcher_image }}
       REQUESTER_IMAGE: ${{ needs.build-image.outputs.requester_image }}
     steps:
-      - name: Checkout source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.gate.outputs.pr_head_sha }}
-
       - name: Install tools (kubectl, oc, helm)
         run: |
           # Install kubectl - pinned version for reproducible CI builds
@@ -558,6 +553,12 @@ jobs:
               matchLabels: {"scrape": "true"}
           EOF
 
+      - name: Checkout source
+        if: "'${{ github.event.inputs.fma_release || '' }}' == ''"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.pr_head_sha }}
+
       - name: Install FMA
         env:
           CONTAINER_IMG_REG: ghcr.io/${{ github.repository }}
@@ -591,6 +592,12 @@ jobs:
       - name: Dump LauncherPopulationPolicy CRD
         if: always()
         run: kubectl get crd launcherpopulationpolicies.fma.llm-d.ai -o yaml
+
+      - name: Checkout source
+        if: "'${{ github.event.inputs.fma_release || '' }}' != ''"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.pr_head_sha }}
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -590,7 +590,7 @@ jobs:
           echo "github.ref_name='${{ github.ref_name }}'"
           echo "github.ref='${{ github.ref }}'"
           subject=(--release "$FMA_RELEASE")
-          bash <(curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/install-fma.sh) \
+          bash <(curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/install-fma.sh) \
             "${subject[@]}" \
             --chart-set global.produceCoverdata=true \
             --namespace "$FMA_NAMESPACE" \
@@ -612,7 +612,7 @@ jobs:
         run: kubectl get crd launcherpopulationpolicies.fma.llm-d.ai -o yaml
 
       - name: Checkout source before run
-        if: "${{ (github.event.inputs.fma_release || '') != '' }}"
+        if: always() && (github.event.inputs.fma_release || '') != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.gate.outputs.pr_head_sha }}
@@ -624,8 +624,6 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.run_cluster || 'pok-prod' }}" = "pok-prod" ]
           then export REQUESTER_PRIORITY_CLASS=nightly-llm-d-cicd-critical
-               echo Setting REQUESTER_PRIORITY_CLASS
-          else echo Not setting REQUESTER_PRIORITY_CLASS
           fi
           ./test/e2e/test-cases.sh
 

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -583,11 +583,14 @@ jobs:
           CONTAINER_IMG_REG: ghcr.io/${{ github.repository }}
           FMA_RELEASE: ${{ github.event.inputs.fma_release || '' }}
         run: |
-          echo "github.repository=<${{ github.repository }}>"
-          echo "$GITHUB_HEAD_REF=<$GITHUB_HEAD_REF>"
-          echo "Invoking https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_HEAD_REF/scripts/install-fma.sh"
+          echo "github.repository='${{ github.repository }}'"
+          echo "$GITHUB_HEAD_REF='$GITHUB_HEAD_REF'"
+          echo "github.event_name='${{ github.event_name }}'"
+          echo "github.ref_type='${{ github.ref_type }}'"
+          echo "github.ref_name='${{ github.ref_name }}'"
+          echo "github.ref='${{ github.ref }}'"
           subject=(--release "$FMA_RELEASE")
-          bash <(curl https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_HEAD_REF/scripts/install-fma.sh) \
+          bash <(curl https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/install-fma.sh) \
             "${subject[@]}" \
             --chart-set global.produceCoverdata=true \
             --namespace "$FMA_NAMESPACE" \

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -621,7 +621,11 @@ jobs:
         env:
           MKOBJS_SCRIPT: ./test/e2e/mkobjs-openshift.sh
           POLL_LIMIT_SECS: "720"
-        run: ./test/e2e/test-cases.sh
+        run: |
+          if [ "${{ github.event.inputs.run_cluster || 'pod-prod' }}" = "pok-prod" ]
+          then export REQUESTER_PRIORITY_CLASS=nightly-llm-d-cicd-critical
+          fi
+          ./test/e2e/test-cases.sh
 
       - name: Dump Role objects
         if: always()

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -554,7 +554,7 @@ jobs:
           EOF
 
       - name: Checkout source
-        if: "'${{ github.event.inputs.fma_release || '' }}' == ''"
+        if: "${{ (github.event.inputs.fma_release || '') == '' }}"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.gate.outputs.pr_head_sha }}
@@ -594,7 +594,7 @@ jobs:
         run: kubectl get crd launcherpopulationpolicies.fma.llm-d.ai -o yaml
 
       - name: Checkout source
-        if: "'${{ github.event.inputs.fma_release || '' }}' != ''"
+        if: "${{ (github.event.inputs.fma_release || '') != '' }}"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.gate.outputs.pr_head_sha }}

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -624,6 +624,8 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.run_cluster || 'pod-prod' }}" = "pok-prod" ]
           then export REQUESTER_PRIORITY_CLASS=nightly-llm-d-cicd-critical
+               echo Setting REQUESTER_PRIORITY_CLASS
+          else echo Not setting REQUESTER_PRIORITY_CLASS
           fi
           ./test/e2e/test-cases.sh
 

--- a/.github/workflows/ci-e2e-openshift.yaml
+++ b/.github/workflows/ci-e2e-openshift.yaml
@@ -553,26 +553,41 @@ jobs:
               matchLabels: {"scrape": "true"}
           EOF
 
-      - name: Checkout source
+      - name: Checkout source before build
         if: "${{ (github.event.inputs.fma_release || '') == '' }}"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.gate.outputs.pr_head_sha }}
 
-      - name: Install FMA
+      - name: Install FMA using local checkout
+        if: "${{ (github.event.inputs.fma_release || '') == '' }}"
+        env:
+          CONTAINER_IMG_REG: ghcr.io/${{ github.repository }}
+        run: |
+          subject=(--image-tag "$IMAGE_TAG"
+                   --oci-registry "${CONTAINER_IMG_REG,,}"
+                   --config-dir config
+                  )
+          scripts/install-fma.sh \
+            "${subject[@]}" \
+            --chart-set global.produceCoverdata=true \
+            --namespace "$FMA_NAMESPACE" \
+            --ensure-node-view-cluster-role "${FMA_CHART_INSTANCE_NAME}-node-view" \
+            --install-crds true \
+            --install-admission-policies true \
+            --chart-instance-name "$FMA_CHART_INSTANCE_NAME"
+
+      - name: Install FMA using curl-to-bash
+        if: "${{ (github.event.inputs.fma_release || '') != '' }}"
         env:
           CONTAINER_IMG_REG: ghcr.io/${{ github.repository }}
           FMA_RELEASE: ${{ github.event.inputs.fma_release || '' }}
         run: |
-          if [ -z "$FMA_RELEASE" ]; then
-            subject=(--image-tag "$IMAGE_TAG"
-                     --oci-registry "${CONTAINER_IMG_REG,,}"
-                     --config-dir config
-                    )
-          else
-            subject=(--release "$FMA_RELEASE")
-          fi
-          scripts/install-fma.sh \
+          echo "github.repository=<${{ github.repository }}>"
+          echo "$GITHUB_HEAD_REF=<$GITHUB_HEAD_REF>"
+          echo "Invoking https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_HEAD_REF/scripts/install-fma.sh"
+          subject=(--release "$FMA_RELEASE")
+          bash <(curl https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_HEAD_REF/scripts/install-fma.sh) \
             "${subject[@]}" \
             --chart-set global.produceCoverdata=true \
             --namespace "$FMA_NAMESPACE" \
@@ -593,7 +608,7 @@ jobs:
         if: always()
         run: kubectl get crd launcherpopulationpolicies.fma.llm-d.ai -o yaml
 
-      - name: Checkout source
+      - name: Checkout source before run
         if: "${{ (github.event.inputs.fma_release || '') != '' }}"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/scripts/install-fma.sh
+++ b/scripts/install-fma.sh
@@ -299,7 +299,7 @@ helm upgrade --install "$chart_instance_name" \
     --set global.imageRegistry="${oci_reg}" \
     --set global.imageTag="${img_tag:-v${release}}"
 
-kubectl wait -n "$ns" --for=condition=available --timeout=180s \
+kubectl wait -n "$ns" --for=condition=available --timeout=240s \
     deployment "${chart_instance_name}-dual-pods-controller"
 
 if [ "$enable_lp" != "false" ]; then

--- a/scripts/install-fma.sh
+++ b/scripts/install-fma.sh
@@ -198,6 +198,9 @@ EOF
     done
 )
 
+echo "Kubectl version:" >&2
+kubectl version >&2
+
 nvcr="${existing_nvcr}${ensure_nvcr}"
 
 if [ -z "$ensure_nvcr" ]; then true
@@ -250,6 +253,7 @@ if [[ "$install_crds" == "true" ]]; then
             echo "  CRD $crd_name needs updating"
             kubectl apply --server-side -f - <<<$obj
         fi
+        sleep 1
         kubectl wait crd "$crd_name" --for condition=Established
     done
 fi

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -72,6 +72,9 @@ else
     node_selector=""
 fi
 
+# GPU utilization is temporarily hacked below 0.825 because we have
+# mysteries still to chase.
+
 if out=$(kubectl apply "${ns_flag[@]}" -f - 2>&1 <<EOF
 apiVersion: v1
 kind: ServiceAccount

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -61,6 +61,7 @@ fi
 
 if [ -n "${REQUESTER_PRIORITY_CLASS:-}" ]
 then echo "Requester pods will have PriorityClass $REQUESTER_PRIORITY_CLASS" >&2
+else echo "Requester pods will have no PriorityClass" >&2
 fi
 
 # When a node is specified, pin the ReplicaSet's pods to it.

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -215,7 +215,7 @@ spec:
             value: "/tmp"
           resources:
             limits:
-              ephemeral-storage: "4.5Gi"
+              ephemeral-storage: "5Gi"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: LauncherPopulationPolicy

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -120,7 +120,7 @@ spec:
     options: >-
       --model HuggingFaceTB/SmolLM2-360M-Instruct
       --enable-sleep-mode
-      --gpu-memory-utilization 0.825
+      --gpu-memory-utilization 0.8
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -142,7 +142,7 @@ spec:
     options: >-
       --model Qwen/Qwen2.5-0.5B-Instruct
       --enable-sleep-mode
-      --gpu-memory-utilization 0.825
+      --gpu-memory-utilization 0.8
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -164,7 +164,7 @@ spec:
     options: >-
       --model TinyLlama/TinyLlama-1.1B-Chat-v1.0
       --enable-sleep-mode
-      --gpu-memory-utilization 0.825
+      --gpu-memory-utilization 0.8
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -9,8 +9,9 @@
 #   REQUESTER_IMAGE  - container image for the requester pod
 #
 # Optional environment variables:
-#   RUNTIME_CLASS_NAME - if set, injects runtimeClassName into pod specs
-#   IMAGE_PULL_POLICY  - image pull policy (default: Always)
+#   RUNTIME_CLASS_NAME       - if set, injects runtimeClassName into pod specs
+#   IMAGE_PULL_POLICY        - image pull policy (default: Always)
+#   REQUESTER_PRIORITY_CLASS - name of PriorityClass for requester Pods
 #
 # Outputs (one per line, to be parsed by caller):
 #   isc_smol lc rs isc_qwen isc_tinyllama lpp
@@ -56,6 +57,10 @@ inst=$(date +%d-%H-%M-%S)
 runtime_class=""
 if [ -n "${RUNTIME_CLASS_NAME:-}" ]; then
     runtime_class="runtimeClassName: ${RUNTIME_CLASS_NAME}"
+fi
+
+if [ -n "${REQUESTER_PRIORITY_CLASS:-}" ]
+then echo "Requester pods will have PriorityClass $REQUESTER_PRIORITY_CLASS" >&2
 fi
 
 # When a node is specified, pin the ReplicaSet's pods to it.
@@ -250,6 +255,9 @@ spec:
         dual-pods.llm-d.ai/inference-server-config: "inference-server-config-smol-$inst"
     spec:
       ${runtime_class}
+$(if [ -n "${REQUESTER_PRIORITY_CLASS:-}" ]; then echo "
+      priorityClassName: $REQUESTER_PRIORITY_CLASS"
+fi)
       ${node_selector}
       containers:
         - name: inference-server

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -166,7 +166,7 @@ spec:
     resources:
       limits:
         nvidia.com/gpu: "2"
-        ephemeral-storage: "9Gi"
+        ephemeral-storage: "10Gi"
 $(if [ -n "${REQUESTER_PRIORITY_CLASS:-}" ]; then echo "
   priorityClassName: $REQUESTER_PRIORITY_CLASS"
 fi)
@@ -177,7 +177,7 @@ if ! expect '[ "$(kubectl get pod '"$probe_pod"' -n '"$NS"' -o jsonpath={.status
     echo "FAIL: GPU probe Pod $probe_pod did not reach Running." >&2
     echo "This probably means no node in the cluster has 2 GPUs available right now." >&2
     echo "But, for full disclosure, a dump of the probe pod follows" >&2
-    kubectl get -n "$NS" pod $probe_pod -o yaml >&2
+    kubectl get -n "$NS" pod "$probe_pod" -o yaml >&2
     kubectl events -n "$NS" --for "pod/$probe_pod" >&2
     kubectl delete pod "$probe_pod" -n "$NS" --wait=false 2>/dev/null || true
     exit 1

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -9,6 +9,10 @@
 #   FMA_NAMESPACE           - Kubernetes namespace to run tests in
 #   MKOBJS_SCRIPT           - path to the mkobjs script to call
 #
+# Conditionally required environment variables (if MKOBJS_SCRIPT needs them):
+#   LAUNCHER_IMAGE   - container image for the launcher pod
+#   REQUESTER_IMAGE  - container image for the requester pod
+#
 # Optional environment variables:
 #   FMA_CHART_INSTANCE_NAME - Helm release name prefix (default: fma)
 #   READY_TARGET            - minimum ready launchers before proceeding (default: 2)

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -123,8 +123,11 @@ get_launcher_total_instances() {
 
 echo "FMA_NAMESPACE=${FMA_NAMESPACE:-«unset»}"
 echo "MKOBJS_SCRIPT=${MKOBJS_SCRIPT:-«unset»}"
+echo "LAUNCHER_IMAGE=${LAUNCHER_IMAGE:-«unset»}"
+echo "REQUESTER_IMAGE=${REQUESTER_IMAGE:-«unset»}"
 echo "FMA_CHART_INSTANCE_NAME=${FMA_CHART_INSTANCE_NAME:-«unset»}"
 echo "READY_TARGET=${READY_TARGET:-«unset»}"
+echo "REQUESTER_PRIORITY_CLASS=${REQUESTER_PRIORITY_CLASS:-«unset»}"
 echo "POLICIES_ENABLED=${POLICIES_ENABLED:-«unset»}"
 echo "POLL_LIMIT_SECS=${POLL_LIMIT_SECS:-«unset»}"
 echo "FMA_DEBUG=${FMA_DEBUG:-«unset»}"

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -703,7 +703,7 @@ echo "Restarting dual-pods controller..."
 kubectl scale  -n "$NS" deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" --replicas=0
 expect 'kubectl get -n "$NS" pods -l app.kubernetes.io/component=dual-pods-controller -o name | wc -l | grep -w 0'
 kubectl scale  -n "$NS" deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller" --replicas=1
-kubectl wait -n "$NS" --for=condition=available --timeout=100s deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller"
+kubectl wait -n "$NS" --for=condition=available --timeout=240s deployment "${FMA_CHART_INSTANCE_NAME}-dual-pods-controller"
 
 # Wait for controller to be ready for ongoing checks
 # In detail: allow some time for the dual-pods controller to do something unexpected in the case

--- a/test/e2e/test-cases.sh
+++ b/test/e2e/test-cases.sh
@@ -14,11 +14,12 @@
 #   REQUESTER_IMAGE  - container image for the requester pod
 #
 # Optional environment variables:
-#   FMA_CHART_INSTANCE_NAME - Helm release name prefix (default: fma)
-#   READY_TARGET            - minimum ready launchers before proceeding (default: 2)
-#   POLICIES_ENABLED        - "true"/"false"; auto-detected if unset
-#   POLL_LIMIT_SECS         - polling timeout seconds (default: 600)
-#   FMA_DEBUG               - "true" to enable shell tracing (set -x)
+#   FMA_CHART_INSTANCE_NAME  - Helm release name prefix (default: fma)
+#   READY_TARGET             - minimum ready launchers before proceeding (default: 2)
+#   REQUESTER_PRIORITY_CLASS - name of PriorityClass for requester Pods (if MKOBJS_SCRIPT reads this)
+#   POLICIES_ENABLED         - "true"/"false"; auto-detected if unset
+#   POLL_LIMIT_SECS          - polling timeout seconds (default: 600)
+#   FMA_DEBUG                - "true" to enable shell tracing (set -x)
 
 set -euo pipefail
 if [ "${FMA_DEBUG:-false}" = "true" ]; then
@@ -163,12 +164,18 @@ spec:
       limits:
         nvidia.com/gpu: "2"
         ephemeral-storage: "9Gi"
+$(if [ -n "${REQUESTER_PRIORITY_CLASS:-}" ]; then echo "
+  priorityClassName: $REQUESTER_PRIORITY_CLASS"
+fi)
   terminationGracePeriodSeconds: 0
 PROBE
 
 if ! expect '[ "$(kubectl get pod '"$probe_pod"' -n '"$NS"' -o jsonpath={.status.phase})" = "Running" ]'; then
     echo "FAIL: GPU probe Pod $probe_pod did not reach Running." >&2
     echo "This probably means no node in the cluster has 2 GPUs available right now." >&2
+    echo "But, for full disclosure, a dump of the probe pod follows" >&2
+    kubectl get -n "$NS" pod $probe_pod -o yaml >&2
+    kubectl events -n "$NS" --for "pod/$probe_pod" >&2
     kubectl delete pod "$probe_pod" -n "$NS" --wait=false 2>/dev/null || true
     exit 1
 fi


### PR DESCRIPTION
This PR does a few things about installing a release in `ci-e2e-openshift.yaml`.

- Stop building the requester and launcher images. They are amongst those built for a release.
- Do not checkout the repo until after the install. Use curl-to-bash style of invocation of the install script.

This PR adds missing documentation about envars to `test-cases.sh`.

This PR also adds a mitigation and version diagnostic for the new flake in `kubectl wait crd "$crd_name" --for condition=Established`.

This PR also make the CI workflow that tests E2E on OpenShift assign the requester Pods a high PriorityClass if running in the pok-prod cluster.

This PR also lengthens some timeouts, based on observed slowness of pulling controller images from GHCR. Even the longer timeouts were observed to sometimes not be enough. Something odd is going on wrt that.

This PR also adds some guessed mitigation for mysterious crashes: increasing the ephemeral storage ask from 4.5 to 5 GiB per launcher, and decreasing the GPU memory utilization ask from 0.825 to 0.8. These need further investigation.