### PR TITLE
Add clunky logging of tail of stopped vLLM instance log

### DIFF
--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -741,7 +741,7 @@ Represents a single vLLM instance with its process and configuration.
 - `start()`: Start the vLLM process
 - `stop(timeout=10)`: Stop the vLLM process gracefully (or force kill after timeout)
 - `get_status()`: Get detailed status information
-- `get_log_bytes(start=0, end=None)`: Retrieve log bytes from the instance (start and end are both inclusive), returns `(bytes, total_size)`
+- `get_log_bytes(start=0, end=None)`: Retrieve log bytes from the instance (start and end are both inclusive, either --- but not both --- may be `None`), returns `(read_start, bytes, total_size)`
 
 #### `VllmMultiProcessManager`
 
@@ -754,7 +754,7 @@ Manages multiple VllmInstance objects.
 - `stop_all_instances(timeout=10)`: Stop all running instances
 - `get_instance_status(instance_id)`: Get status of a specific instance
 - `get_all_instances_status()`: Get status of all instances
-- `get_instance_log_bytes(instance_id, start=0, end=None)`: Retrieve log bytes from a specific instance, returns `(bytes, total_size)`
+- `get_instance_log_bytes(instance_id, start=0, end=None)`: Retrieve log bytes from a specific instance, returns `(read_start, bytes, total_size)`
 
 ## Best Practices
 

--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -309,35 +309,43 @@ class VllmInstance:
         return self._make_state("running" if self.process.is_alive() else "stopped")
 
     def get_log_bytes(
-        self, start: int = 0, end: int | None = None
-    ) -> tuple[bytes, int]:
+        self, start: int | None = 0, end: int | None = None
+    ) -> tuple[int, bytes, int]:
         """
         Retrieve log bytes from the child process.
-        :param start: First byte to read (inclusive, 0-based).
-        :param end: Last byte to read (inclusive, must be >= start).
+        :param start: First byte to read (inclusive, 0-based) or None for suffix.
+        :param end: if start is None then suffix length otherwise
+                    Last byte to read (inclusive, must be >= start).
                     None means up to start + MAX_LOG_RESPONSE_BYTES - 1
-                    or EOF, whichever comes first.
-        :return: (content_bytes, current_total_log_length)
+                    or EOF, whichever comes first; may not be None if start is None.
+        :return: (read_start, content_bytes, current_total_log_length)
         :raises LogRangeNotAvailable: If start is beyond available content
         """
         try:
             total = os.path.getsize(self._log_file_path)
         except FileNotFoundError:
-            total = 0
+            raise LogRangeNotAvailable(start, 0)
 
-        if start >= total:
+        if start is not None and start >= total:
             raise LogRangeNotAvailable(start, total)
 
-        if end is None:
+        if start is None:
+            if end is None:
+                raise LogRangeNotAvailable(None, total)
+            read_start = max(total - end, 0)
+            read_end = total - 1
+        elif end is None:
+            read_start = start
             read_end = min(start + MAX_LOG_RESPONSE_BYTES - 1, total - 1)
         else:
+            read_start = start
             read_end = min(end, total - 1)
 
-        nbytes = read_end - start + 1
+        nbytes = read_end - read_start + 1
         with open(self._log_file_path, "rb") as f:
-            f.seek(start)
+            f.seek(read_start)
             data = f.read(nbytes)
-        return (data, total)
+        return (read_start, data, total)
 
 
 # Multi-instance vLLM process manager
@@ -499,15 +507,16 @@ class VllmMultiProcessManager:
     def get_instance_log_bytes(
         self,
         instance_id: str,
-        start: int = 0,
+        start: int | None = 0,
         end: int | None = None,
-    ) -> tuple[bytes, int]:
+    ) -> tuple[int, bytes, int]:
         """
         Get log bytes from a specific instance.
         :param instance_id: ID of the instance
-        :param start: First byte to read (inclusive, 0-based)
-        :param end: Last byte to read (inclusive), or None for default limit
-        :return: (content_bytes, total_file_size)
+        :param start: First byte to read (inclusive, 0-based), or None for suffix
+        :param end: if start is None then suffix length otherwise
+                    Last byte to read (inclusive) or None for default limit
+        :return: (read_start, content_bytes, total_file_size)
         :raises LogRangeNotAvailable: If start is beyond available content
         """
         if instance_id not in self.instances:
@@ -539,26 +548,33 @@ app = FastAPI(
 )
 
 
-_RANGE_RE = re.compile(r"^bytes=(\d+)-(\d+)?$")
+_RANGE_RE = re.compile(r"^bytes=(\d+)?-(\d+)?$")
 
 
-def parse_range_header(range_header: str) -> tuple[int, int | None]:
+def parse_range_header(range_header: str) -> tuple[int | None, int | None]:
     """Parse an HTTP Range header value.
 
-    Accepts ``bytes=START-END`` (both inclusive) or ``bytes=START-``
-    (open-ended).  Returns ``(start, end)`` where *end* may be ``None``.
+    Accepts ``bytes=START-END`` (both inclusive) or ``bytes=START-`` (open-ended)
+    or ``bytes=-SUFFIX``.
+    Returns ``(start, end_or_suffix)`` where either may be ``None``.
 
     Raises :class:`ValueError` for unsupported or malformed values
-    (e.g. suffix ranges like ``bytes=-500``).
+    (e.g. suffix ranges like ``bytes=-0``).
     """
     m = _RANGE_RE.match(range_header)
     if m is None:
         raise ValueError(f"Unsupported or malformed Range header: {range_header}")
-    start = int(m.group(1))
+    start = int(m.group(1)) if m.group(1) else None
     # group(2) is the end value; absent in open-ended ranges like "bytes=100-"
     end = int(m.group(2)) if m.group(2) else None
-    if end is not None and end < start:
-        raise ValueError(f"Range end ({end}) must be >= start ({start})")
+    if start is None:
+        if end is None:
+            raise ValueError("Range must specify start or end_or_suffix")
+        if end <= 0:
+            raise ValueError(f"Range suffix must be positive, not {end}")
+    else:
+        if end is not None and end < start:
+            raise ValueError(f"Range end ({end}) must be >= start ({start})")
     return (start, end)
 
 
@@ -740,7 +756,7 @@ async def get_vllm_instance_status(
 
 
 @app.get("/v2/vllm/instances/{instance_id}/log")
-async def get_vllm_instance_logs(
+async def get_vllm_instance_log(
     instance_id: str = Path(..., description="Instance ID"),
     range: str | None = Header(None, alias="Range"),
 ):
@@ -751,9 +767,11 @@ async def get_vllm_instance_logs(
 
     Without a Range header the full log (up to 1 MB) is returned with
     200 OK.  With ``Range: bytes=START-END`` or ``Range: bytes=START-``
+    or ``Range: bytes=-SUFFIX``
     the requested slice is returned with 206 Partial Content.  In both
     cases the response includes a ``Content-Range`` header indicating the byte range
-    and current total log length.
+    and current total log length
+    --- except in the case of empty log, when no ``Content-Range`` header is returned.
     """
     try:
         if range is None:
@@ -766,13 +784,17 @@ async def get_vllm_instance_logs(
                 raise HTTPException(status_code=400, detail=str(exc))
             partial = True
 
-        data, total = vllm_manager.get_instance_log_bytes(instance_id, start, end)
+        read_start, data, total = vllm_manager.get_instance_log_bytes(
+            instance_id, start, end
+        )
 
-        actual_end = start + len(data) - 1
+        actual_end = read_start + len(data) - 1
         headers = {
             "Accept-Ranges": "bytes",
-            "Content-Range": f"bytes {start}-{actual_end}/{total}",
         }
+        if actual_end >= 0:
+            headers["Content-Range"] = f"bytes {read_start}-{actual_end}/{total}"
+        # There is no valid Content-Range when the file's length is zero
         if partial:
             status_code = HTTPStatus.PARTIAL_CONTENT
         else:

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -566,8 +566,9 @@ class TestVllmMultiProcessManager:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"Log line 1Log line 2Log line 3")
 
-        data, total = manager.get_instance_log_bytes("test-id", start=0)
+        read_start, data, total = manager.get_instance_log_bytes("test-id", start=0)
 
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert b"Log line 1" in data
         assert b"Log line 2" in data
@@ -595,8 +596,11 @@ class TestVllmMultiProcessManager:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"A" * 60 + b"B" * 60)
 
-        data, total = manager.get_instance_log_bytes("test-id", start=0, end=99)
+        read_start, data, total = manager.get_instance_log_bytes(
+            "test-id", start=0, end=99
+        )
 
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert len(data) == 100
         assert total == 120
@@ -766,6 +770,7 @@ class TestAPIEndpoints:
     def test_get_instance_logs_endpoint(self, mock_manager, client):
         """Test getting instance logs without Range header returns 200"""
         mock_manager.get_instance_log_bytes.return_value = (
+            0,
             b"Log line 1Log line 2Log line 3",
             30,
         )
@@ -781,7 +786,7 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_get_instance_logs_with_range_header(self, mock_manager, client):
         """Test getting instance logs with Range header"""
-        mock_manager.get_instance_log_bytes.return_value = (b"A" * 5000, 10000)
+        mock_manager.get_instance_log_bytes.return_value = (0, b"A" * 5000, 10000)
 
         response = client.get(
             "/v2/vllm/instances/test-id/log",
@@ -818,7 +823,7 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_get_instance_logs_partial_content_206(self, mock_manager, client):
         """Test 206 Partial Content with correct Content-Range header"""
-        mock_manager.get_instance_log_bytes.return_value = (b"ABCDE", 100)
+        mock_manager.get_instance_log_bytes.return_value = (10, b"ABCDE", 100)
 
         response = client.get(
             "/v2/vllm/instances/test-id/log",
@@ -832,7 +837,7 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_get_instance_logs_open_ended_range(self, mock_manager, client):
         """Test open-ended Range: bytes=100-"""
-        mock_manager.get_instance_log_bytes.return_value = (b"rest of log", 200)
+        mock_manager.get_instance_log_bytes.return_value = (100, b"rest of log", 200)
 
         response = client.get(
             "/v2/vllm/instances/test-id/log",
@@ -856,14 +861,20 @@ class TestAPIEndpoints:
         assert response.status_code == 400
 
     @patch("launcher.vllm_manager")
-    def test_get_instance_logs_suffix_range_rejected(self, mock_manager, client):
-        """Test suffix range bytes=-500 returns 400"""
+    def test_get_instance_logs_suffix_range_zeroed(self, mock_manager, client):
+        """Test suffix range bytes=-500"""
+        mock_manager.get_instance_log_bytes.return_value = (0, b"rest of log", 11)
+
         response = client.get(
             "/v2/vllm/instances/test-id/log",
             headers={"Range": "bytes=-500"},
         )
 
-        assert response.status_code == 400
+        assert response.status_code == 206
+        mock_manager.get_instance_log_bytes.assert_called_once_with(
+            "test-id", None, 500
+        )
+        assert response.headers["content-range"] == "bytes 0-10/11"
 
 
 # Tests for VllmInstance log functionality
@@ -897,8 +908,8 @@ class TestVllmInstanceLogs:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"Log 1Log 2")
 
-        data, total = instance.get_log_bytes()
-
+        read_start, data, total = instance.get_log_bytes()
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert b"Log 1" in data
         assert b"Log 2" in data
@@ -910,8 +921,9 @@ class TestVllmInstanceLogs:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"A" * 50 + b"B" * 50 + b"C" * 50)
 
-        data, total = instance.get_log_bytes(start=0, end=99)
+        read_start, data, total = instance.get_log_bytes(start=0, end=99)
 
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert len(data) == 100
         assert total == 150
@@ -922,13 +934,15 @@ class TestVllmInstanceLogs:
 
         with open(instance._log_file_path, "wb") as f:
             f.write(b"Hello World")
-        data, total = instance.get_log_bytes(start=0)
+        read_start, data, total = instance.get_log_bytes(start=0)
+        assert read_start == 0
         assert data == b"Hello World"
         assert total == 11
 
         with open(instance._log_file_path, "ab") as f:
             f.write(b"!")
-        data, total = instance.get_log_bytes(start=0)
+        read_start, data, total = instance.get_log_bytes(start=0)
+        assert read_start == 0
         assert data == b"Hello World!"
         assert total == 12
 
@@ -974,7 +988,8 @@ class TestLogFile:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"Test message 1Test message 2")
 
-        data, total = instance.get_log_bytes(start=0)
+        read_start, data, total = instance.get_log_bytes(start=0)
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert b"Test message 1" in data
         assert b"Test message 2" in data
@@ -996,7 +1011,8 @@ class TestLogFile:
         with open(instance._log_file_path, "wb") as f:
             f.write(content.encode("utf-8"))
 
-        data, total = instance.get_log_bytes(start=0, end=49)
+        read_start, data, total = instance.get_log_bytes(start=0, end=49)
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert len(data) == 50
 
@@ -1006,7 +1022,8 @@ class TestLogFile:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"ShortMessage")
 
-        data, total = instance.get_log_bytes(start=0, end=9999)
+        read_start, data, total = instance.get_log_bytes(start=0, end=9999)
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert b"Short" in data
         assert b"Message" in data
@@ -1019,7 +1036,8 @@ class TestLogFile:
         with open(instance._log_file_path, "wb") as f:
             f.write(raw)
 
-        data, total = instance.get_log_bytes(start=0)
+        read_start, data, total = instance.get_log_bytes(start=0)
+        assert read_start == 0
         assert isinstance(data, bytes)
         assert data == raw
         assert total == len(raw)
@@ -1030,7 +1048,8 @@ class TestLogFile:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"A" * 20 + b"B" * 20 + b"C" * 20)
 
-        data, total = instance.get_log_bytes(start=0, end=44)
+        read_start, data, total = instance.get_log_bytes(start=0, end=44)
+        assert read_start == 0
         assert data == b"A" * 20 + b"B" * 20 + b"C" * 5
         assert total == 60
 
@@ -1354,7 +1373,8 @@ class TestLogStartOffset:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"A" * 10 + b"B" * 10 + b"C" * 10)
 
-        data, total = instance.get_log_bytes(start=15)
+        read_start, data, total = instance.get_log_bytes(start=15)
+        assert read_start == 15
         assert data == b"B" * 5 + b"C" * 10
         assert total == 30
 
@@ -1364,7 +1384,8 @@ class TestLogStartOffset:
         with open(instance._log_file_path, "wb") as f:
             f.write(b"A" * 10 + b"B" * 10 + b"C" * 10)
 
-        data, total = instance.get_log_bytes(start=10)
+        read_start, data, total = instance.get_log_bytes(start=10)
+        assert read_start == 10
         assert data == b"B" * 10 + b"C" * 10
         assert total == 30
 
@@ -1448,10 +1469,9 @@ class TestParseRangeHeader:
         """Test parsing large byte values"""
         assert parse_range_header("bytes=1048576-2097151") == (1048576, 2097151)
 
-    def test_suffix_range_rejected(self):
-        """Test that suffix range bytes=-500 raises ValueError"""
-        with pytest.raises(ValueError, match="Unsupported or malformed"):
-            parse_range_header("bytes=-500")
+    def test_suffix_range(self):
+        """Test parsing suffix range bytes=-500"""
+        assert parse_range_header("bytes=-500") == (None, 500)
 
     def test_invalid_unit(self):
         """Test that non-bytes unit raises ValueError"""

--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -401,6 +401,7 @@ type GpuLocation struct {
 	Index uint
 }
 
+// nodeData is the root of data specific to a node.
 type nodeData struct {
 	NodeName string
 
@@ -412,6 +413,8 @@ type nodeData struct {
 	// Access only inside the calling hierarchy that `nodeItem.process()` is the root caller.
 	Launchers map[string]*launcherData
 
+	rateLimiter workqueue.TypedRateLimiter[itemOnNode]
+
 	// ItemsMutex may be acquired while holding controller mutex, not vice-versa.
 	ItemsMutex sync.Mutex
 
@@ -419,8 +422,6 @@ type nodeData struct {
 	// and for each the time at which it was first injected into this set.
 	// Hold ItemsMutex while accessing this.
 	LocalQueue map[itemOnNode]*scheduledItem
-
-	rateLimiter workqueue.TypedRateLimiter[itemOnNode]
 }
 
 type itemOnNode interface {
@@ -517,18 +518,35 @@ type serverData struct {
 	RequesterDeleteRequested bool
 }
 
+// Access only within `nodeItem.process`.
 type launcherData struct {
 	// Instances is a map,
 	// where key is an instance's ID which is the instance' nominal hash,
-	// and value is the last used time of the instance.
-	Instances map[string]time.Time
+	// and value is the a non-nil `*instanceData`.
+	Instances instanceTable
 
 	// Accurate indicates whether the set of nominal hash in Instances is accurate.
+	// TODO: make this field useful.
 	Accurate bool
 }
+
+// instanceTable is a map,
+// where key is an instance's ID which is the instance' nominal hash,
+// and value is the a non-nil `*instanceData`.
+type instanceTable map[string]*instanceData
+
+// instanceData is what the controller tracks per vLLM instance.
+// Access only within `nodeItem.process`.
+type instanceData struct {
+	LastUsed      time.Time
+	Stopped       bool
+	LogTailLogged bool
+}
+
 type queueItem interface {
 	// process returns (err error, retry bool).
 	// There will be a retry iff `retry`, error logged if `err != nil`.
+	// Only called within `nodeItem.process`.
 	process(ctx context.Context, ctl *controller) (error, bool)
 }
 
@@ -1017,6 +1035,10 @@ func (ctl *controller) enqueueUnboundInfSvrItemsOnNode(ctx context.Context, node
 	ctl.Queue.Add(nodeItem{nodeName})
 }
 
+// creates the `*nodeData` if it does not already exist.
+// Call while controller is NOT locked.
+// TODO: someday define a way for `*nodeData` objects to be removed;
+// today is not that day.
 func (ctl *controller) getNodeData(nodeName string) *nodeData {
 	ctl.mutex.Lock()
 	defer ctl.mutex.Unlock()
@@ -1111,7 +1133,7 @@ func (ctl *controller) getLauncherData(nodeDat *nodeData, launcherPodName string
 	ans := nodeDat.Launchers[launcherPodName]
 	if ans == nil {
 		ans = &launcherData{
-			Instances: make(map[string]time.Time),
+			Instances: make(map[string]*instanceData),
 		}
 		nodeDat.Launchers[launcherPodName] = ans
 	}

--- a/pkg/controller/dual-pods/controller.go
+++ b/pkg/controller/dual-pods/controller.go
@@ -522,7 +522,7 @@ type serverData struct {
 type launcherData struct {
 	// Instances is a map,
 	// where key is an instance's ID which is the instance' nominal hash,
-	// and value is the a non-nil `*instanceData`.
+	// and value is a non-nil `*instanceData`.
 	Instances instanceTable
 
 	// Accurate indicates whether the set of nominal hash in Instances is accurate.
@@ -532,7 +532,7 @@ type launcherData struct {
 
 // instanceTable is a map,
 // where key is an instance's ID which is the instance' nominal hash,
-// and value is the a non-nil `*instanceData`.
+// and value is a non-nil `*instanceData`.
 type instanceTable map[string]*instanceData
 
 // instanceData is what the controller tracks per vLLM instance.

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -501,7 +501,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 				}
 				serverDat.InstanceKnownToExist = true
 				launcherDat := ctl.getLauncherData(nodeDat, providingPod.Name)
-				launcherDat.Instances[serverDat.InstanceID] = time.Now()
+				launcherDat.Instances.setLastUsed(serverDat.InstanceID, time.Now())
 				logger.V(2).Info("Created vLLM instance", "instance_id", result.InstanceID, "status", result.Status)
 			}
 			serverDat.InstanceKnownToExist = true
@@ -565,7 +565,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 					url += stubapi.BecomeUnreadyPath
 					readiness = "unready"
 				}
-				_, err = doHTTP(ctx, "relay_"+readiness, "POST", url, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, nil)
+				_, err = doHTTP(ctx, "relay_"+readiness, "POST", url, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{})
 				if err != nil {
 					logger.Error(err, "Failed to relay the readiness", "name", providingPod.Name, "readiness", readiness, "url", url)
 					return processResult{err: err, retry: true}
@@ -909,8 +909,8 @@ func (ctl *controller) selectOrReclaimLauncherPod(
 		toDelete := max(insts.TotalInstances-maxOthers, 1)
 		// Any conflicting vLLM instance must be deleted; deleting only other
 		// vLLM instances would leave the desired port unavailable.
-		victims := append(portConflictVictims, pickInstanceVictims(otherVictims, launcherDat.Instances, toDelete-len(portConflictVictims))...)
-		lruID, lruTime := reclaimPlanLRU(victims, launcherDat.Instances)
+		victims := append(portConflictVictims, pickInstanceVictims(otherVictims, launcherDat.Instances.getLastUsedIfNotStopped, toDelete-len(portConflictVictims))...)
+		lruID, lruTime := reclaimPlanLRU(victims, launcherDat.Instances.getLastUsedIfNotStopped)
 		plan := &launcherReclaimPlan{
 			launcherPod: launcherPod,
 			launcherDat: launcherDat,
@@ -963,7 +963,7 @@ func (ctl *controller) selectOrReclaimLauncherPod(
 // pickInstanceVictims chooses up to limit instance IDs to delete.
 func pickInstanceVictims(
 	candidates []string,
-	knownLastUsed map[string]time.Time,
+	knownLastUsed Getter[string, time.Time],
 	limit int,
 ) []string {
 	if limit <= 0 {
@@ -976,11 +976,11 @@ func pickInstanceVictims(
 	return candidates[:min(limit, len(candidates))]
 }
 
-func reclaimPlanLRU(victims []string, knownLastUsed map[string]time.Time) (string, time.Time) {
+func reclaimPlanLRU(victims []string, knownLastUsed Getter[string, time.Time]) (string, time.Time) {
 	lruID := victims[0]
-	lruTime := knownLastUsed[lruID]
+	lruTime, _ := knownLastUsed(lruID)
 	for _, victim := range victims[1:] {
-		victimTime := knownLastUsed[victim]
+		victimTime, _ := knownLastUsed(victim)
 		if compareLastUsed(victim, victimTime, lruID, lruTime) < 0 {
 			lruID = victim
 			lruTime = victimTime
@@ -996,8 +996,8 @@ func compareReclaimPlans(a, b *launcherReclaimPlan) int {
 	return compareLastUsed(a.lruID, a.lruTime, b.lruID, b.lruTime)
 }
 
-func compareInstanceLastUsed(a, b string, knownLastUsed map[string]time.Time) int {
-	return compareLastUsed(a, knownLastUsed[a], b, knownLastUsed[b])
+func compareInstanceLastUsed(a, b string, knownLastUsed Getter[string, time.Time]) int {
+	return compareLastUsed(a, dropHave(knownLastUsed(a)), b, dropHave(knownLastUsed(b)))
 }
 
 func compareLastUsed(a string, aTime time.Time, b string, bTime time.Time) int {
@@ -1495,7 +1495,7 @@ func (ctl *controller) wakeUp(ctx context.Context, serverDat *serverData, reques
 	}
 	endpoint := fmt.Sprintf("%s:%d", providingPod.Status.PodIP, serverPort)
 	wakeURL := "http://" + endpoint + "/wake_up"
-	_, err := doHTTP(ctx, "wake", "POST", wakeURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, nil)
+	_, err := doHTTP(ctx, "wake", "POST", wakeURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, httpResultConsumer{})
 	if err != nil {
 		return fmt.Errorf("failed to wake inference server at %s: %w", endpoint, err)
 	}
@@ -1710,7 +1710,7 @@ func (ctl *controller) ensureUnbound(ctx context.Context, serverDat *serverData,
 			}
 			endpoint := fmt.Sprintf("%s:%d", providingPod.Status.PodIP, serverPort)
 			sleepURL := "http://" + endpoint + "/sleep"
-			_, err := doHTTP(ctx, "sleep", "POST", sleepURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, nil)
+			_, err := doHTTP(ctx, "sleep", "POST", sleepURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{})
 			if err != nil {
 				return fmt.Errorf("failed to put provider %q to sleep, POST %s: %w", serverDat.ProvidingPodName, sleepURL, err)
 			}
@@ -1984,7 +1984,7 @@ func getReducedInferenceContainerState(from *corev1.Pod) *reducedContainerState 
 func (ctl *controller) querySleeping(ctx context.Context, iscName string, providingPod *corev1.Pod, serverPort int32) (bool, error) {
 	queryURL := fmt.Sprintf("http://%s:%d/is_sleeping", providingPod.Status.PodIP, serverPort)
 	var sleepState api.SleepState
-	_, err := doHTTP(ctx, "query_sleeping", "GET", queryURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, &sleepState)
+	_, err := doHTTP(ctx, "query_sleeping", "GET", queryURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{json: &sleepState})
 	return sleepState.IsSleeping, err
 }
 
@@ -1995,7 +1995,7 @@ func (ctl *controller) accelMemoryIsLowEnough(ctx context.Context, requestingPod
 	}
 	url := fmt.Sprintf("http://%s:%s%s", requestingPod.Status.PodIP, adminPort, stubapi.AcceleratorMemoryQueryPath)
 	usageMap := map[string]int64{}
-	_, err := doHTTP(ctx, "get_accel_memory_usage", "GET", url, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, &usageMap)
+	_, err := doHTTP(ctx, "get_accel_memory_usage", "GET", url, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, httpResultConsumer{json: &usageMap})
 	if err != nil {
 		return err
 	}
@@ -2122,16 +2122,23 @@ func (ctl *controller) syncLauncherInstances(ctx context.Context, nodeDat *nodeD
 		}
 	}
 
-	newInstances := make(map[string]time.Time)
+	newInstances := make(instanceTable)
 	remainingInstances := make([]InstanceState, 0, len(insts.Instances))
 	stoppedInstanceIDs := sets.New[string]()
 	runningCount := 0
 	for _, inst := range insts.Instances {
+		if instDat, exists := launcherDat.Instances[inst.InstanceID]; exists {
+			newInstances[inst.InstanceID] = instDat
+		} else {
+			newInstances[inst.InstanceID] = &instanceData{LastUsed: time.Now()}
+		}
 		if inst.Status == InstanceStatusStopped {
+			ctl.ensureLogTailLogged(ctx, newInstances, launcherPod.Name, inst.InstanceID, lClient)
 			if boundInstanceIDs.Has(inst.InstanceID) {
 				// Bound stopped instance — defer deletion so the caller can
 				// delete the requesting Pod first (resolves create/delete ambiguity).
 				stoppedInstanceIDs.Insert(inst.InstanceID)
+				newInstances.setStopped(inst.InstanceID, true)
 				logger.V(2).Info("Found stopped bound instance, deferring cleanup",
 					"instanceID", inst.InstanceID)
 			} else {
@@ -2146,17 +2153,13 @@ func (ctl *controller) syncLauncherInstances(ctx context.Context, nodeDat *nodeD
 					logger.V(2).Info("Deleted stopped instance from launcher during sync",
 						"instanceID", inst.InstanceID)
 				}
+				delete(newInstances, inst.InstanceID)
 			}
 			continue
 		}
 		remainingInstances = append(remainingInstances, inst)
 		if inst.Status == "running" {
 			runningCount++
-		}
-		if lastUsed, exists := launcherDat.Instances[inst.InstanceID]; exists {
-			newInstances[inst.InstanceID] = lastUsed
-		} else {
-			newInstances[inst.InstanceID] = time.Now()
 		}
 	}
 
@@ -2204,9 +2207,15 @@ type ObserverCube interface {
 	WithLabelValues(values ...string) prometheus.Observer
 }
 
+// This is a union type; at most one member should be non-nil
+type httpResultConsumer struct {
+	json   any
+	octets io.Writer
+}
+
 // Do an HTTP call.
 // latencyHistogramVec needs values for labels purpose, method, status_code
-func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVec ObserverCube, requestData, resultData any) (int, error) {
+func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVec ObserverCube, requestData any, resultConsumer httpResultConsumer) (int, error) {
 	var reqBody io.Reader
 	if requestData != nil {
 		b, err := json.Marshal(requestData)
@@ -2222,8 +2231,11 @@ func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVe
 	if requestData != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if resultData != nil {
+	switch {
+	case resultConsumer.json != nil:
 		req.Header.Set("Accept", "application/json")
+	case resultConsumer.octets != nil:
+		req.Header.Set("Accept", "application/octet-stream")
 	}
 	httpCallStartTime := time.Now()
 	resp, err := myHTTPClient.Do(req)
@@ -2239,11 +2251,19 @@ func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVe
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			body, bodyReadErr := io.ReadAll(resp.Body)
 			err = fmt.Errorf("HTTP %s %q returned unexpected status %d; bodyReadErr=%v; responseBody=%s", method, url, resp.StatusCode, bodyReadErr, string(body))
-		} else if resultData != nil {
-			decoder := json.NewDecoder(resp.Body)
-			bodyErr := decoder.Decode(resultData)
-			if bodyErr != nil {
-				err = fmt.Errorf("failed to decode response to %s %q: %w", method, url, bodyErr)
+		} else {
+			switch {
+			case resultConsumer.json != nil:
+				decoder := json.NewDecoder(resp.Body)
+				bodyErr := decoder.Decode(resultConsumer.json)
+				if bodyErr != nil {
+					err = fmt.Errorf("failed to decode response to %s %q: %w", method, url, bodyErr)
+				}
+			case resultConsumer.octets != nil:
+				_, copyErr := io.Copy(resultConsumer.octets, resp.Body)
+				if copyErr != nil {
+					err = fmt.Errorf("failed to read body of response to %s %q: %w", method, url, copyErr)
+				}
 			}
 		}
 	}
@@ -2262,7 +2282,7 @@ func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVe
 // getGPUUUIDs does the HTTP GET on the given URL to fetch the assigned GPU UUIDs.
 func getGPUUUIDs(ctx context.Context, httpLatencySecsHistograms ObserverCube, url string) ([]string, error) {
 	var uuids []string
-	_, err := doHTTP(ctx, "get_gpu_uuids", "GET", url, httpLatencySecsHistograms, nil, &uuids)
+	_, err := doHTTP(ctx, "get_gpu_uuids", "GET", url, httpLatencySecsHistograms, nil, httpResultConsumer{json: &uuids})
 	return uuids, err
 }
 

--- a/pkg/controller/dual-pods/inference-server.go
+++ b/pkg/controller/dual-pods/inference-server.go
@@ -565,7 +565,7 @@ func (item infSvrItem) process(urCtx context.Context, ctl *controller, nodeDat *
 					url += stubapi.BecomeUnreadyPath
 					readiness = "unready"
 				}
-				_, err = doHTTP(ctx, "relay_"+readiness, "POST", url, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{})
+				_, err = doHTTP(ctx, "relay_"+readiness, "POST", url, nil, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{})
 				if err != nil {
 					logger.Error(err, "Failed to relay the readiness", "name", providingPod.Name, "readiness", readiness, "url", url)
 					return processResult{err: err, retry: true}
@@ -1495,7 +1495,7 @@ func (ctl *controller) wakeUp(ctx context.Context, serverDat *serverData, reques
 	}
 	endpoint := fmt.Sprintf("%s:%d", providingPod.Status.PodIP, serverPort)
 	wakeURL := "http://" + endpoint + "/wake_up"
-	_, err := doHTTP(ctx, "wake", "POST", wakeURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, httpResultConsumer{})
+	_, err := doHTTP(ctx, "wake", "POST", wakeURL, nil, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, httpResultConsumer{})
 	if err != nil {
 		return fmt.Errorf("failed to wake inference server at %s: %w", endpoint, err)
 	}
@@ -1710,7 +1710,7 @@ func (ctl *controller) ensureUnbound(ctx context.Context, serverDat *serverData,
 			}
 			endpoint := fmt.Sprintf("%s:%d", providingPod.Status.PodIP, serverPort)
 			sleepURL := "http://" + endpoint + "/sleep"
-			_, err := doHTTP(ctx, "sleep", "POST", sleepURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{})
+			_, err := doHTTP(ctx, "sleep", "POST", sleepURL, nil, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{})
 			if err != nil {
 				return fmt.Errorf("failed to put provider %q to sleep, POST %s: %w", serverDat.ProvidingPodName, sleepURL, err)
 			}
@@ -1984,7 +1984,7 @@ func getReducedInferenceContainerState(from *corev1.Pod) *reducedContainerState 
 func (ctl *controller) querySleeping(ctx context.Context, iscName string, providingPod *corev1.Pod, serverPort int32) (bool, error) {
 	queryURL := fmt.Sprintf("http://%s:%d/is_sleeping", providingPod.Status.PodIP, serverPort)
 	var sleepState api.SleepState
-	_, err := doHTTP(ctx, "query_sleeping", "GET", queryURL, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{json: &sleepState})
+	_, err := doHTTP(ctx, "query_sleeping", "GET", queryURL, nil, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName}), nil, httpResultConsumer{json: &sleepState})
 	return sleepState.IsSleeping, err
 }
 
@@ -1995,7 +1995,7 @@ func (ctl *controller) accelMemoryIsLowEnough(ctx context.Context, requestingPod
 	}
 	url := fmt.Sprintf("http://%s:%s%s", requestingPod.Status.PodIP, adminPort, stubapi.AcceleratorMemoryQueryPath)
 	usageMap := map[string]int64{}
-	_, err := doHTTP(ctx, "get_accel_memory_usage", "GET", url, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, httpResultConsumer{json: &usageMap})
+	_, err := doHTTP(ctx, "get_accel_memory_usage", "GET", url, nil, ctl.httpLatencySecsHistograms.MustCurryWith(prometheus.Labels{"isc_name": requestingPod.Annotations[api.InferenceServerConfigAnnotationName]}), nil, httpResultConsumer{json: &usageMap})
 	if err != nil {
 		return err
 	}
@@ -2215,7 +2215,7 @@ type httpResultConsumer struct {
 
 // Do an HTTP call.
 // latencyHistogramVec needs values for labels purpose, method, status_code
-func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVec ObserverCube, requestData any, resultConsumer httpResultConsumer) (int, error) {
+func doHTTP(ctx context.Context, purpose, method, url string, reqHeaders http.Header, latencyHistogramVec ObserverCube, requestData any, resultConsumer httpResultConsumer) (int, error) {
 	var reqBody io.Reader
 	if requestData != nil {
 		b, err := json.Marshal(requestData)
@@ -2236,6 +2236,11 @@ func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVe
 		req.Header.Set("Accept", "application/json")
 	case resultConsumer.octets != nil:
 		req.Header.Set("Accept", "application/octet-stream")
+	}
+	for key, values := range reqHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
 	}
 	httpCallStartTime := time.Now()
 	resp, err := myHTTPClient.Do(req)
@@ -2282,7 +2287,7 @@ func doHTTP(ctx context.Context, purpose, method, url string, latencyHistogramVe
 // getGPUUUIDs does the HTTP GET on the given URL to fetch the assigned GPU UUIDs.
 func getGPUUUIDs(ctx context.Context, httpLatencySecsHistograms ObserverCube, url string) ([]string, error) {
 	var uuids []string
-	_, err := doHTTP(ctx, "get_gpu_uuids", "GET", url, httpLatencySecsHistograms, nil, httpResultConsumer{json: &uuids})
+	_, err := doHTTP(ctx, "get_gpu_uuids", "GET", url, nil, httpLatencySecsHistograms, nil, httpResultConsumer{json: &uuids})
 	return uuids, err
 }
 

--- a/pkg/controller/dual-pods/instance-data.go
+++ b/pkg/controller/dual-pods/instance-data.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dualpods
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// ensureLogTailLogged will, if it has not already been done, read the tail of the log
+// of the given instance and log it in a huge log message of this controller.
+func (ctl *controller) ensureLogTailLogged(ctx context.Context, instab instanceTable, launcherName, instanceID string, lClient *LauncherClient) {
+	if alreadyLogged, _ := instab.getLogTailLogged(instanceID); alreadyLogged {
+		return
+	}
+	logger := klog.FromContext(ctx)
+	tail, err := lClient.GetLog(ctx, instanceID)
+	if err != nil {
+		logger.V(3).Info("Failed to fetch log tail of instance", "launcherName", launcherName, "instanceID", instanceID, "err", err)
+		return
+	}
+	logger.V(2).Info("Fetched tail of log of instance", "launcherName", launcherName, "instanceID", instanceID, "tail", tail)
+	instab.setLogTailLogged(instanceID, true)
+}
+
+// Call only within `nodeItem.process.`
+func (instab instanceTable) getLastUsedIfNotStopped(instanceID string) (time.Time, bool) {
+	if instDat, have := instab[instanceID]; have && !instDat.Stopped {
+		return instDat.LastUsed, true
+	}
+	return time.Time{}, false
+}
+
+// Call only within `nodeItem.process.`
+func (instab instanceTable) getLogTailLogged(instanceID string) (bool, bool) {
+	if instDat, have := instab[instanceID]; have {
+		return instDat.LogTailLogged, true
+	}
+	return false, false
+}
+
+// Call only within `nodeItem.process.`
+func (instab instanceTable) setLastUsed(instanceID string, lastUsed time.Time) {
+	instDat := instab[instanceID]
+	if instDat == nil {
+		instDat = &instanceData{LastUsed: lastUsed}
+		instab[instanceID] = instDat
+	} else {
+		instDat.LastUsed = lastUsed
+	}
+}
+
+// Call only within `nodeItem.process.`
+func (instab instanceTable) setLogTailLogged(instanceID string, logged bool) {
+	instDat := instab[instanceID]
+	if instDat == nil {
+		instDat = &instanceData{LogTailLogged: logged}
+		instab[instanceID] = instDat
+	} else {
+		instDat.LogTailLogged = logged
+	}
+}
+
+// Call only within `nodeItem.process.`
+func (instab instanceTable) setStopped(instanceID string, stopped bool) {
+	instDat := instab[instanceID]
+	if instDat == nil {
+		instDat = &instanceData{Stopped: stopped}
+		instab[instanceID] = instDat
+	} else {
+		instDat.Stopped = stopped
+	}
+}
+
+// Getter is the type signature of reading from a Go-language map.
+type Getter[Dom, Rng any] = func(Dom) (Rng, bool)
+
+func dropHave[Base any](base Base, _ bool) Base { return base }

--- a/pkg/controller/dual-pods/instance-data.go
+++ b/pkg/controller/dual-pods/instance-data.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 // ensureLogTailLogged will, if it has not already been done, read the tail of the log
@@ -30,7 +31,7 @@ func (ctl *controller) ensureLogTailLogged(ctx context.Context, instab instanceT
 		return
 	}
 	logger := klog.FromContext(ctx)
-	tail, err := lClient.GetLog(ctx, instanceID)
+	tail, err := lClient.GetLog(ctx, instanceID, nil, ptr.To(int(100*1000)))
 	if err != nil {
 		logger.V(3).Info("Failed to fetch log tail of instance", "launcherName", launcherName, "instanceID", instanceID, "err", err)
 		return

--- a/pkg/controller/dual-pods/launcherclient.go
+++ b/pkg/controller/dual-pods/launcherclient.go
@@ -138,7 +138,7 @@ func (c *LauncherClient) GetInstanceState(
 ) (*InstanceState, error) {
 	path := fmt.Sprintf("/v2/vllm/instances/%s", instanceID)
 	var out InstanceState
-	if err := c.fullDo(ctx, "get_instance_state", http.MethodGet, path, nil, httpResultConsumer{json: &out}, func() {
+	if err := c.fullDo(ctx, "get_instance_state", http.MethodGet, path, nil, nil, httpResultConsumer{json: &out}, func() {
 		iscName := out.Annotations[VllmConfigISCNameAnnotationKey]
 		c.latencyHistograms = c.isclessLatencyHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName})
 	}); err != nil {
@@ -176,10 +176,25 @@ func (c *LauncherClient) ListInstanceIDs(
 
 func (c *LauncherClient) GetLog(ctx context.Context,
 	instanceID string,
+	start, end *int,
 ) (string, error) {
 	path := fmt.Sprintf("/v2/vllm/instances/%s/log", instanceID)
 	var logBuilder strings.Builder
-	err := c.fullDo(ctx, "get_log_tail", http.MethodGet, path, nil, httpResultConsumer{octets: &logBuilder}, nil)
+	var headers http.Header
+	if start != nil || end != nil {
+		headers = make(http.Header)
+		var valBuilder strings.Builder
+		valBuilder.WriteString("bytes=")
+		if start != nil {
+			fmt.Fprintf(&valBuilder, "%d", *start)
+		}
+		valBuilder.WriteRune('-')
+		if end != nil {
+			fmt.Fprintf(&valBuilder, "%d", *end)
+		}
+		headers.Add("Range", valBuilder.String())
+	}
+	err := c.fullDo(ctx, "get_log_tail", http.MethodGet, path, headers, nil, httpResultConsumer{octets: &logBuilder}, nil)
 	return logBuilder.String(), err
 }
 
@@ -241,7 +256,7 @@ func (c *LauncherClient) do(
 	body any,
 	outData any,
 ) error {
-	return c.fullDo(ctx, purpose, method, path, body, httpResultConsumer{json: outData}, nil)
+	return c.fullDo(ctx, purpose, method, path, nil, body, httpResultConsumer{json: outData}, nil)
 }
 
 // complete is called after attempted HTTP call and response parse and,
@@ -252,6 +267,7 @@ func (c *LauncherClient) fullDo(
 	purpose string,
 	method string,
 	path string,
+	reqHeaders http.Header,
 	body any,
 	out httpResultConsumer,
 	complete func(),
@@ -271,7 +287,7 @@ func (c *LauncherClient) fullDo(
 		c.latencyHistograms = c.isclessLatencyHistograms.MustCurryWith(prometheus.Labels{"isc_name": ""})
 		oc = c.latencyHistograms
 	}
-	statusCode, err := doHTTP(ctx, purpose, method, u.String(), oc, body, out)
+	statusCode, err := doHTTP(ctx, purpose, method, u.String(), reqHeaders, oc, body, out)
 
 	if err != nil || statusCode >= 300 {
 		return &launcherError{StatusCode: statusCode, Err: err}

--- a/pkg/controller/dual-pods/launcherclient.go
+++ b/pkg/controller/dual-pods/launcherclient.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -137,7 +138,7 @@ func (c *LauncherClient) GetInstanceState(
 ) (*InstanceState, error) {
 	path := fmt.Sprintf("/v2/vllm/instances/%s", instanceID)
 	var out InstanceState
-	if err := c.fullDo(ctx, "get_instance_state", http.MethodGet, path, nil, &out, func() {
+	if err := c.fullDo(ctx, "get_instance_state", http.MethodGet, path, nil, httpResultConsumer{json: &out}, func() {
 		iscName := out.Annotations[VllmConfigISCNameAnnotationKey]
 		c.latencyHistograms = c.isclessLatencyHistograms.MustCurryWith(prometheus.Labels{"isc_name": iscName})
 	}); err != nil {
@@ -171,6 +172,15 @@ func (c *LauncherClient) ListInstanceIDs(
 		return nil, err
 	}
 	return out.InstanceIDs, nil
+}
+
+func (c *LauncherClient) GetLog(ctx context.Context,
+	instanceID string,
+) (string, error) {
+	path := fmt.Sprintf("/v2/vllm/instances/%s/log", instanceID)
+	var logBuilder strings.Builder
+	err := c.fullDo(ctx, "get_log_tail", http.MethodGet, path, nil, httpResultConsumer{octets: &logBuilder}, nil)
+	return logBuilder.String(), err
 }
 
 // DeleteInstance removes a specific instance.
@@ -229,9 +239,9 @@ func (c *LauncherClient) do(
 	method string,
 	path string,
 	body any,
-	out any,
+	outData any,
 ) error {
-	return c.fullDo(ctx, purpose, method, path, body, out, nil)
+	return c.fullDo(ctx, purpose, method, path, body, httpResultConsumer{json: outData}, nil)
 }
 
 // complete is called after attempted HTTP call and response parse and,
@@ -243,7 +253,7 @@ func (c *LauncherClient) fullDo(
 	method string,
 	path string,
 	body any,
-	out any,
+	out httpResultConsumer,
 	complete func(),
 ) error {
 	parsed, err := url.Parse(path)

--- a/test/e2e/mkobjs-openshift.sh
+++ b/test/e2e/mkobjs-openshift.sh
@@ -72,9 +72,6 @@ else
     node_selector=""
 fi
 
-# GPU utilization is temporarily hacked below 0.825 because we have
-# mysteries still to chase.
-
 if out=$(kubectl apply "${ns_flag[@]}" -f - 2>&1 <<EOF
 apiVersion: v1
 kind: ServiceAccount
@@ -124,7 +121,7 @@ spec:
     options: >-
       --model HuggingFaceTB/SmolLM2-360M-Instruct
       --enable-sleep-mode
-      --gpu-memory-utilization 0.8
+      --gpu-memory-utilization 0.825
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -146,7 +143,7 @@ spec:
     options: >-
       --model Qwen/Qwen2.5-0.5B-Instruct
       --enable-sleep-mode
-      --gpu-memory-utilization 0.8
+      --gpu-memory-utilization 0.825
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -168,7 +165,7 @@ spec:
     options: >-
       --model TinyLlama/TinyLlama-1.1B-Chat-v1.0
       --enable-sleep-mode
-      --gpu-memory-utilization 0.8
+      --gpu-memory-utilization 0.825
     env_vars:
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_LOGGING_LEVEL: "DEBUG"
@@ -219,7 +216,7 @@ spec:
             value: "/tmp"
           resources:
             limits:
-              ephemeral-storage: "5Gi"
+              ephemeral-storage: "4.5Gi"
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: LauncherPopulationPolicy


### PR DESCRIPTION
Simple initial attempt.

Put the tail in a log message in the controller log because that is more persistent than the server-requesting Pod or the launcher.

This PR is hoped to shed some light on Issues #709 and #720. Maybe even #712 if we get lucky.

This is deliberately not what #160 calls for --- relaying log content to the server-requesting Pod --- because those get quickly deleted in the failure mode at hand.