### PR TITLE
fix: resolve named readiness ports from the server container

### DIFF
--- a/pkg/controller/utils/pod-helper.go
+++ b/pkg/controller/utils/pod-helper.go
@@ -103,11 +103,12 @@ func GetInferenceServerContainerIndexAndPort(pod *corev1.Pod) (int, int32, error
 	case intstr.Int:
 		return cIdx, portIOS.IntVal, nil
 	case intstr.String:
-		if portIOS.StrVal == "http" || portIOS.StrVal == "HTTP" {
-			return cIdx, 80, nil
-		} else {
-			return 0, 0, fmt.Errorf("unsupported readinessProbe port %q", portIOS.StrVal)
+		for _, port := range isCtr.Ports {
+			if port.Name == portIOS.StrVal {
+				return cIdx, port.ContainerPort, nil
+			}
 		}
+		return 0, 0, fmt.Errorf("readinessProbe port %q not found in container %q", portIOS.StrVal, isCtr.Name)
 	default:
 		return 0, 0, fmt.Errorf("the readinessProbe port has unexpected type %q", portIOS.Type)
 	}

--- a/pkg/controller/utils/pod-helper_test.go
+++ b/pkg/controller/utils/pod-helper_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package utils
 
 import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	machtypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1alpha1 "github.com/llm-d-incubation/llm-d-fast-model-actuation/api/fma/v1alpha1"
 	"github.com/llm-d-incubation/llm-d-fast-model-actuation/pkg/api"
@@ -249,5 +254,59 @@ func TestConfigureRequiredEnvVars(t *testing.T) {
 		if tail[i] != want[i] {
 			t.Errorf("appended[%d] = %+v, want %+v (declaration order)", i, tail[i], want[i])
 		}
+	}
+}
+
+func TestGetInferenceServerContainerIndexAndPort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	address := server.Listener.Addr().(*net.TCPAddr)
+	for _, tc := range []struct {
+		name      string
+		probePort intstr.IntOrString
+		portName  string
+		wantError bool
+	}{
+		{name: "numeric", probePort: intstr.FromInt(address.Port)},
+		{name: "http name", probePort: intstr.FromString("http"), portName: "http"},
+		{name: "custom name", probePort: intstr.FromString("inference"), portName: "inference"},
+		{name: "missing http name", probePort: intstr.FromString("http"), wantError: true},
+		{name: "name only in another container", probePort: intstr.FromString("other"), wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+				{Name: "sidecar", Ports: []corev1.ContainerPort{{Name: "other", ContainerPort: 12345}, {Name: tc.portName, ContainerPort: 23456}}},
+				{Name: api.InferenceServerContainerName,
+					Ports:          []corev1.ContainerPort{{Name: tc.portName, ContainerPort: int32(address.Port)}},
+					ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Port: tc.probePort}}}},
+			}}}
+			index, port, err := GetInferenceServerContainerIndexAndPort(pod)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("expected an unresolved named port error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if index != 1 || port != int32(address.Port) {
+				t.Fatalf("container index and port = (%d, %d), want (1, %d)", index, port, address.Port)
+			}
+			response, err := server.Client().Get("http://" + net.JoinHostPort(address.IP.String(), strconv.Itoa(int(port))) + "/health")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := response.Body.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			if response.StatusCode != http.StatusNoContent {
+				t.Errorf("HTTP status = %d", response.StatusCode)
+			}
+		})
 	}
 }


### PR DESCRIPTION
A direct inference-server Pod can use a named readiness-probe port such as `http` mapped to container port 8000. The controller currently treats `http` as port 80 and rejects other names, so it contacts the wrong port or fails to configure the server.

Resolve the name from the inference-server container's declared ports. Numeric ports retain their existing behavior, and unresolved names return an error.

Tests cover numeric ports, `http` and custom names, same-named sidecar ports, and missing names. Successful resolutions reach a local HTTP server. Three cases fail on the upstream baseline and pass with the fix.

Validation:
- `go test ./...` and `make test`
- Launcher pytest suites: 85 passed
- `pre-commit run --all-files`
- Pre-push `go-mod-tidy`; golangci-lint v2.12.2 on Go 1.26.6: 0 issues
- `typos` on both changed files

The default pre-commit Go environment installs Go 1.27.1, which causes the pinned linter to panic while analyzing the standard library. The same failure reproduces on the upstream baseline. Linting with v2.12.2 built and run on Go 1.26.6 passes with the repository configuration.
