### PR TITLE
Stop blocking the launcher's event loop while stopping an instance

### DIFF
--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -49,6 +49,12 @@ from vllm.entrypoints.serve.utils.api_utils import cli_env_setup
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 MAX_LOG_RESPONSE_BYTES = 1 * 1024 * 1024  # 1 MB default for API response
+
+# How long to wait for a child to be reaped after its process group was
+# SIGKILLed.  SIGKILL cannot be caught, so this only bounds the pathological
+# case; it exists so that no code path can block its caller indefinitely.
+POST_KILL_JOIN_TIMEOUT = 5
+
 _MAX_BROADCASTER_EVENTS = 1000
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
@@ -262,17 +268,17 @@ class VllmInstance:
 
         return self._make_state("started")
 
-    def stop(self, timeout: int = 10) -> dict:
-        """
-        Stop existing vLLM instance
-        :param timeout: waits for the process to stop, defaults to 10
-        :return: a dictionary with the status "terminated"
+    def _send_sigterm(self) -> tuple[Optional[dict], int]:
+        """Start stopping: send SIGTERM.  Shared by stop() and stop_async().
+
+        :return: (early result, child pid).  A non-None early result means there
+                 was nothing to stop and the caller is done.
         """
         if self.process is None:
             raise HalfMade(self.instance_id)
         if not self.process.is_alive():
             self._cleanup_log_file()
-            return self._make_state("not_running")
+            return self._make_state("not_running"), 0
 
         vllm_pid = self.process.pid
         assert vllm_pid is not None
@@ -284,48 +290,130 @@ class VllmInstance:
         # which will propagate shutdown to the EngineCore via vLLM's
         # own cleanup logic.
         self.process.terminate()
-        self.process.join(timeout=timeout)
+        return None, vllm_pid
 
-        # Force kill the entire process group (vLLM server + EngineCore)
-        # if graceful shutdown did not complete in time.
-        if self.process.is_alive():
-            if logger.getEffectiveLevel() <= logging.DEBUG:
-                dump_process_group(
-                    self.instance_id, vllm_pid, "between terminate and killpg"
+    def _kill_process_group(self, vllm_pid: int) -> None:
+        """SIGKILL the child's whole process group, after SIGTERM fell short."""
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            dump_process_group(
+                self.instance_id, vllm_pid, "between terminate and killpg"
+            )
+        try:
+            os.killpg(vllm_pid, signal.SIGKILL)
+            logger.debug(
+                f"In stop({self.instance_id}), os.killpg({vllm_pid}) "
+                f"because waiting for the first exit was not enough"
+            )
+        except ProcessLookupError as exn:
+            logger.error(
+                f"In stop({self.instance_id}), tried to os.killpg({vllm_pid}) "
+                f"but that threw ProcessLookupError ({exn})"
+            )
+        except Exception as exn:
+            logger.error(
+                f"In stop({self.instance_id}), tried to os.killpg({vllm_pid}) "
+                f"but that threw an unexpected Exception ({exn})"
+            )
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            dump_process_group(self.instance_id, vllm_pid, "between killpg and wait")
+
+    def _finish_stop(self, vllm_pid: int, took_hard_path: bool) -> dict:
+        """Finish stopping: report what happened and clean up."""
+        if took_hard_path:
+            if self.process.is_alive():
+                logger.error(
+                    f"In stop({self.instance_id}), still alive"
+                    f" {POST_KILL_JOIN_TIMEOUT}s after SIGKILL of the process"
+                    f" group; giving up on reaping it"
                 )
-            try:
-                os.killpg(vllm_pid, signal.SIGKILL)
+            else:
                 logger.debug(
-                    f"In stop({self.instance_id}), os.killpg({vllm_pid}) "
-                    f"because the first process.join was not enough"
+                    f"In stop({self.instance_id}), the child exited after the killpg"
                 )
-            except ProcessLookupError as exn:
-                logger.error(
-                    f"In stop({self.instance_id}), tried to os.killpg({vllm_pid}) "
-                    f"but that threw ProcessLookupError ({exn})"
-                )
-            except Exception as exn:
-                logger.error(
-                    f"In stop({self.instance_id}), tried to os.killpg({vllm_pid}) "
-                    f"but that threw an unexpected Exception ({exn})"
-                )
-            if logger.getEffectiveLevel() <= logging.DEBUG:
-                dump_process_group(
-                    self.instance_id, vllm_pid, "between killpg and join"
-                )
-            self.process.join()
-            logger.debug(
-                f"In stop({self.instance_id}), finished the second process.join"
-            )
         else:
-            logger.debug(
-                f"In stop({self.instance_id}), the first process.join was enough"
-            )
+            logger.debug(f"In stop({self.instance_id}), SIGTERM alone was enough")
 
         if logger.getEffectiveLevel() <= logging.DEBUG:
             dump_process_group(self.instance_id, vllm_pid, "at end of stop")
         self._cleanup_log_file()
         return self._make_state("terminated")
+
+    async def _await_exit(self, timeout: float) -> bool:
+        """Wait for the child to exit, using the event loop's own poll.
+
+        The kernel makes the sentinel fd readable when the child exits, and the
+        loop is already watching fds; so waiting means adding this one to what the
+        loop polls, rather than blocking the loop in a poll of our own the way
+        process.join() does (it polls the very same fd internally, on the calling
+        thread).  The caller must have removed any other reader for this fd first
+        --- asyncio allows only one --- which stop_instance_async does by way of
+        cancel_sentinel_watcher().
+
+        :return: True if the child exited, False if *timeout* elapsed first.
+        """
+        loop = asyncio.get_running_loop()
+        exited = loop.create_future()
+
+        def on_readable():
+            if not exited.done():
+                exited.set_result(True)
+
+        # If the child is already gone the fd is readable now, and the loop calls
+        # on_readable on its next pass; no need to special-case that.
+        loop.add_reader(self.process.sentinel, on_readable)
+        try:
+            await asyncio.wait_for(exited, timeout)
+            return True
+        except TimeoutError:
+            return False
+        finally:
+            loop.remove_reader(self.process.sentinel)
+
+    def stop(self, timeout: int = 10) -> dict:
+        """
+        Stop existing vLLM instance, blocking the caller.
+
+        This waits with process.join(), which blocks the calling thread; use
+        stop_async() from anything that must not block, such as a request handler.
+        :param timeout: waits for the process to stop, defaults to 10
+        :return: a dictionary with the status "terminated"
+        """
+        early, vllm_pid = self._send_sigterm()
+        if early is not None:
+            return early
+
+        self.process.join(timeout=timeout)
+        took_hard_path = self.process.is_alive()
+        if took_hard_path:
+            self._kill_process_group(vllm_pid)
+            # Bounded: an unbounded join here would block the caller forever if
+            # the child could never be reaped.  SIGKILL cannot be caught, so
+            # reaching this timeout would mean something is badly wrong.
+            self.process.join(timeout=POST_KILL_JOIN_TIMEOUT)
+        return self._finish_stop(vllm_pid, took_hard_path)
+
+    async def stop_async(self, timeout: int = 10) -> dict:
+        """
+        Stop existing vLLM instance without blocking the event loop.
+
+        Same sequence as stop(), except that each wait is the loop polling the
+        child's sentinel fd instead of a blocking process.join().
+        :param timeout: waits for the process to stop, defaults to 10
+        :return: a dictionary with the status "terminated"
+        """
+        early, vllm_pid = self._send_sigterm()
+        if early is not None:
+            return early
+
+        exited = await self._await_exit(timeout)
+        took_hard_path = not exited
+        if took_hard_path:
+            self._kill_process_group(vllm_pid)
+            await self._await_exit(POST_KILL_JOIN_TIMEOUT)
+        # Reap the child.  This cannot block: either the sentinel became readable,
+        # which means the child is already gone, or it did not and join() is bounded.
+        self.process.join(timeout=POST_KILL_JOIN_TIMEOUT if took_hard_path else 0)
+        return self._finish_stop(vllm_pid, took_hard_path)
 
     def _on_sentinel_exit(self):
         """Handle process exit detected by the sentinel fd.
@@ -430,6 +518,9 @@ class VllmMultiProcessManager:
         debug_gpu_memory: bool = False,
     ):
         self.instances: Dict[str, VllmInstance] = {}
+        # Per-instance-id locks, reference counted; see _instance_lock.
+        self._instance_locks: Dict[str, asyncio.Lock] = {}
+        self._instance_lock_users: Dict[str, int] = {}
         self.broadcaster = EventBroadcaster()
         # Monotonically increasing counter owned by the manager.
         # The manager stamps every event before handing it to the
@@ -509,20 +600,53 @@ class VllmMultiProcessManager:
             pass  # No running event loop (e.g. in sync tests)
         return result
 
-    def stop_instance(self, instance_id: str, timeout: int = 10) -> dict:
-        """Stop a specific vLLM instance"""
+    @asynccontextmanager
+    async def _instance_lock(self, instance_id: str):
+        """Serialize the operations that create and destroy one instance.
+
+        Until stop_instance_async existed, a DELETE held the event loop for its
+        whole duration, so it could not interleave with a PUT of the same id.
+        Now that it awaits, that accidental serialization is gone and has to be
+        explicit.  The lock is per instance id, so unrelated instances still
+        stop concurrently.
+
+        Entries are reference-counted rather than left to accumulate: instance
+        ids are one-shot, so a plain dict would grow without bound.  The count
+        is safe to keep unguarded because it is only touched between awaits.
+        """
+        lock = self._instance_locks.setdefault(instance_id, asyncio.Lock())
+        self._instance_lock_users[instance_id] = (
+            self._instance_lock_users.get(instance_id, 0) + 1
+        )
+        try:
+            async with lock:
+                yield
+        finally:
+            self._instance_lock_users[instance_id] -= 1
+            if self._instance_lock_users[instance_id] == 0:
+                del self._instance_lock_users[instance_id]
+                del self._instance_locks[instance_id]
+
+    def _stop_begin(self, instance_id: str) -> VllmInstance:
+        """The part of stopping that must run on the event loop, before.
+
+        cancel_sentinel_watcher needs the running loop to remove its reader, so
+        it cannot be moved to a worker thread.
+        """
         if instance_id not in self.instances:
             raise KeyError(f"Instance {instance_id} not found")
 
         instance = self.instances[instance_id]
         instance.cancel_sentinel_watcher()
-        instance.stop(timeout)
+        return instance
 
+    def _stop_end(self, instance: VllmInstance) -> dict:
+        """The part of stopping that must run on the event loop, after."""
         revision = self._next_revision()
         instance.last_revision = revision
         result = instance.get_status()
 
-        del self.instances[instance_id]
+        del self.instances[instance.instance_id]
 
         event = WatchEvent(type="DELETED", object=result)
         self.broadcaster._append(event)
@@ -532,6 +656,74 @@ class VllmMultiProcessManager:
         except RuntimeError:
             pass  # No running event loop (e.g. in sync tests)
         return result
+
+    def stop_instance(self, instance_id: str, timeout: int = 10) -> dict:
+        """Stop a specific vLLM instance, blocking the caller.
+
+        Kept for callers with no event loop to protect: the lifespan shutdown
+        and the synchronous tests.  Request handling should use
+        stop_instance_async instead.
+        """
+        instance = self._stop_begin(instance_id)
+        instance.stop(timeout)
+        return self._stop_end(instance)
+
+    async def stop_instance_async(self, instance_id: str, timeout: int = 10) -> dict:
+        """Stop a specific vLLM instance without blocking the event loop.
+
+        Waiting for a child to exit takes seconds of wall clock in the good case
+        and up to the timeout in the bad one.  Doing that with process.join()
+        blocks the calling thread, so on the event loop the launcher answers
+        nothing meanwhile -- health probes included -- and the liveness probe the
+        controller injects allows each of those only a second before it counts as
+        a failure.  stop_async() waits on the child's sentinel fd through the
+        loop's own poll instead.
+        """
+        async with self._instance_lock(instance_id):
+            instance = self._stop_begin(instance_id)
+            await instance.stop_async(timeout)
+            return self._stop_end(instance)
+
+    async def create_instance_async(
+        self, vllm_config: VllmConfig, instance_id: str
+    ) -> dict:
+        """Create an instance with a caller-chosen id, under that id's lock.
+
+        Only needed for the named form: a generated id cannot collide with a
+        concurrent stop.
+        """
+        async with self._instance_lock(instance_id):
+            return self.create_instance(vllm_config, instance_id)
+
+    async def stop_all_instances_async(self, timeout: int = 10) -> dict:
+        """Stop every instance concurrently, off the event loop.
+
+        The synchronous version stops them one after another, so N instances
+        cost up to N times the timeout with the launcher unresponsive
+        throughout.
+        """
+        instance_ids = list(self.instances.keys())
+        settled = await asyncio.gather(
+            *(
+                self.stop_instance_async(instance_id, timeout)
+                for instance_id in instance_ids
+            ),
+            return_exceptions=True,
+        )
+        results = []
+        for instance_id, outcome in zip(instance_ids, settled):
+            if isinstance(outcome, KeyError):
+                continue  # Instance was already removed
+            if isinstance(outcome, BaseException):
+                logger.error(f"Failed to stop instance {instance_id}: {outcome}")
+                continue
+            results.append(outcome)
+
+        return {
+            "status": "all_stopped",
+            "stopped_instances": results,
+            "total_stopped": len(results),
+        }
 
     def stop_all_instances(self, timeout: int = 10) -> dict:
         """Stop all running vLLM instances"""
@@ -765,7 +957,7 @@ async def create_id_vllm_instance(
 ):
     """Create a new vLLM instance with instance ID"""
     try:
-        result = vllm_manager.create_instance(vllm_config, instance_id)
+        result = await vllm_manager.create_instance_async(vllm_config, instance_id)
         return JSONResponse(content=result, status_code=HTTPStatus.CREATED)
     except ValueError as e:
         raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=str(e))
@@ -782,7 +974,7 @@ async def delete_vllm_instance(
 ):
     """Delete a specific vLLM instance"""
     try:
-        result = vllm_manager.stop_instance(instance_id)
+        result = await vllm_manager.stop_instance_async(instance_id)
         return JSONResponse(content=result, status_code=HTTPStatus.OK)
     except KeyError:
         raise HTTPException(
@@ -799,7 +991,7 @@ async def delete_vllm_instance(
 async def delete_all_vllm_instances():
     """Delete all vLLM instances"""
     try:
-        result = vllm_manager.stop_all_instances()
+        result = await vllm_manager.stop_all_instances_async()
         return JSONResponse(content=result, status_code=HTTPStatus.OK)
     except Exception as e:
         logger.error(f"Failed to delete all vLLM instances: {e}")

--- a/inference_server/launcher/launcher.py
+++ b/inference_server/launcher/launcher.py
@@ -167,6 +167,25 @@ class HalfMade(Exception):
         self.instance_id = instance_id
 
 
+class ChildSurvivedKill(Exception):
+    """Raised when a vLLM process outlived the SIGKILL of its process group.
+
+    Reporting the instance as terminated would be a lie with consequences: the
+    caller would be told the GPU is free, the instance would be forgotten, and a
+    new one could be created with the same id while the old process is still
+    running.  Failing instead keeps the instance tracked so the operation can be
+    retried.
+    """
+
+    def __init__(self, instance_id, pid, waited):
+        super().__init__(
+            f"vLLM process {pid} of instance {instance_id} was still alive"
+            f" {waited}s after SIGKILL of its process group"
+        )
+        self.instance_id = instance_id
+        self.pid = pid
+
+
 def dump_process_group(subject: str, pgpid: int, when: str) -> None:
     members = []
     for proc in psutil.process_iter(attrs=["pid", "ppid", "name"]):
@@ -318,18 +337,26 @@ class VllmInstance:
             dump_process_group(self.instance_id, vllm_pid, "between killpg and wait")
 
     def _finish_stop(self, vllm_pid: int, took_hard_path: bool) -> dict:
-        """Finish stopping: report what happened and clean up."""
+        """Finish stopping: report what happened and clean up.
+
+        :raises ChildSurvivedKill: if the child outlived the SIGKILL of its group,
+            in which case nothing is cleaned up and no state is reported, because
+            the instance is not in fact stopped.
+        """
         if took_hard_path:
             if self.process.is_alive():
                 logger.error(
                     f"In stop({self.instance_id}), still alive"
                     f" {POST_KILL_JOIN_TIMEOUT}s after SIGKILL of the process"
-                    f" group; giving up on reaping it"
+                    f" group; leaving the instance in place rather than reporting"
+                    f" it stopped"
                 )
-            else:
-                logger.debug(
-                    f"In stop({self.instance_id}), the child exited after the killpg"
+                raise ChildSurvivedKill(
+                    self.instance_id, vllm_pid, POST_KILL_JOIN_TIMEOUT
                 )
+            logger.debug(
+                f"In stop({self.instance_id}), the child exited after the killpg"
+            )
         else:
             logger.debug(f"In stop({self.instance_id}), SIGTERM alone was enough")
 
@@ -409,10 +436,12 @@ class VllmInstance:
         took_hard_path = not exited
         if took_hard_path:
             self._kill_process_group(vllm_pid)
-            await self._await_exit(POST_KILL_JOIN_TIMEOUT)
-        # Reap the child.  This cannot block: either the sentinel became readable,
-        # which means the child is already gone, or it did not and join() is bounded.
-        self.process.join(timeout=POST_KILL_JOIN_TIMEOUT if took_hard_path else 0)
+            exited = await self._await_exit(POST_KILL_JOIN_TIMEOUT)
+        # Reap the child, without ever blocking the loop.  A zero timeout makes
+        # this a WNOHANG waitpid: it collects the child when the sentinel is
+        # readable and returns immediately when it is not, which is the case this
+        # method must not stall on -- a child that outlived even the SIGKILL.
+        self.process.join(timeout=0)
         return self._finish_stop(vllm_pid, took_hard_path)
 
     def _on_sentinel_exit(self):
@@ -681,7 +710,13 @@ class VllmMultiProcessManager:
         """
         async with self._instance_lock(instance_id):
             instance = self._stop_begin(instance_id)
-            await instance.stop_async(timeout)
+            try:
+                await instance.stop_async(timeout)
+            except Exception:
+                # _stop_begin cancelled the sentinel watcher; since the instance
+                # stays tracked, put it back so its eventual exit is still noticed.
+                instance.start_sentinel_watcher(self._on_instance_stopped)
+                raise
             return self._stop_end(instance)
 
     async def create_instance_async(
@@ -711,13 +746,24 @@ class VllmMultiProcessManager:
             return_exceptions=True,
         )
         results = []
+        failures = []
         for instance_id, outcome in zip(instance_ids, settled):
             if isinstance(outcome, KeyError):
                 continue  # Instance was already removed
             if isinstance(outcome, BaseException):
                 logger.error(f"Failed to stop instance {instance_id}: {outcome}")
+                failures.append(outcome)
                 continue
             results.append(outcome)
+
+        if failures:
+            # Every instance got its chance to stop -- that is why this is raised
+            # after they all settled rather than at the first failure -- but the
+            # caller must not be told the bulk delete succeeded when it did not.
+            raise ExceptionGroup(  # noqa: F821 (builtin since 3.11)
+                f"failed to stop {len(failures)} of {len(instance_ids)} instance(s)",
+                failures,
+            )
 
         return {
             "status": "all_stopped",

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -22,7 +22,9 @@ import asyncio
 import os
 import signal
 import sys
-from unittest.mock import MagicMock, patch
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -607,6 +609,174 @@ class TestVllmMultiProcessManager:
 
 
 # Tests for API Endpoints
+class SlowExitProcess:
+    """Stand-in for multiprocessing.Process that takes *delay* to exit.
+
+    Faithful on the two things these tests turn on, and that MockProcess does not
+    model: join() blocks the calling thread, and the sentinel fd becomes readable
+    when the child exits.  Without both, a test cannot tell waiting on the loop
+    apart from blocking it.
+    """
+
+    def __init__(self, delay):
+        self._delay = delay
+        self.pid = 12345
+        self.exitcode = None
+        self._sentinel_r, self._sentinel_w = os.pipe()
+        self.sentinel = self._sentinel_r
+        self._timer = None
+
+    def start(self):
+        pass
+
+    def terminate(self):
+        self._timer = threading.Timer(self._delay, self._expire)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _expire(self):
+        """Stand in for the kernel: mark exited and make the sentinel readable."""
+        self.exitcode = 0
+        try:
+            os.write(self._sentinel_w, b"x")
+        except OSError:
+            pass
+
+    def is_alive(self):
+        return self.exitcode is None
+
+    def join(self, timeout=None):
+        deadline = time.monotonic() + (timeout if timeout is not None else 3600)
+        while self.exitcode is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    def close(self):
+        if self._timer is not None:
+            self._timer.cancel()
+        for fd in (self._sentinel_r, self._sentinel_w):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+# Long enough to measure, short enough to keep the suite quick.
+SLOW_EXIT_SECS = 0.3
+
+
+class TestAsyncStop:
+    """Stopping must not hold up the event loop; see PR #751."""
+
+    @patch("launcher.multiprocessing.Process")
+    def test_stop_instance_async_leaves_the_loop_running(
+        self, mock_process_class, manager, vllm_config
+    ):
+        """Other coroutines must keep making progress while a stop is in flight."""
+        proc = SlowExitProcess(SLOW_EXIT_SECS)
+        mock_process_class.return_value = proc
+
+        async def run():
+            manager.create_instance(vllm_config, "slow-id")
+            ticks = 0
+
+            async def ticker():
+                nonlocal ticks
+                while True:
+                    await asyncio.sleep(0.01)
+                    ticks += 1
+
+            task = asyncio.create_task(ticker())
+            await manager.stop_instance_async("slow-id")
+            task.cancel()
+            return ticks
+
+        try:
+            ticks = asyncio.run(run())
+        finally:
+            proc.close()
+        # Waiting with a blocking join would leave this at 0.
+        assert ticks >= 5, f"event loop only ticked {ticks} times during the stop"
+
+    @patch("launcher.multiprocessing.Process")
+    def test_instance_lock_keeps_a_stop_from_eating_a_later_create(
+        self, mock_process_class, manager, vllm_config
+    ):
+        """A create of the same id must not land inside a stop of that id.
+
+        Without the per-instance lock the create runs while the instance being
+        stopped is still in ``self.instances``, so it is rejected as a duplicate
+        and then the stop deletes the entry anyway: the caller loses its create
+        for no real reason.
+        """
+        proc = SlowExitProcess(SLOW_EXIT_SECS)
+        mock_process_class.return_value = proc
+
+        async def run():
+            manager.create_instance(vllm_config, "dup-id")
+
+            async def creator():
+                await asyncio.sleep(0.05)  # while the stop is still in flight
+                await manager.create_instance_async(vllm_config, "dup-id")
+
+            await asyncio.gather(manager.stop_instance_async("dup-id"), creator())
+
+        try:
+            asyncio.run(run())
+        finally:
+            proc.close()
+        assert "dup-id" in manager.instances
+
+    @patch("launcher.os.killpg")
+    @patch("launcher.multiprocessing.Process")
+    def test_stop_async_escalates_to_killpg_when_sigterm_is_not_enough(
+        self, mock_process_class, mock_killpg, manager, vllm_config
+    ):
+        """The hard path has to work when waiting on the sentinel times out."""
+        proc = SlowExitProcess(3600)  # never exits of its own accord
+        mock_process_class.return_value = proc
+        # Stand in for the group actually dying on SIGKILL.
+        mock_killpg.side_effect = lambda pgid, sig: proc._expire()
+
+        async def run():
+            manager.create_instance(vllm_config, "stubborn-id")
+            return await manager.stop_instance_async("stubborn-id", timeout=0.1)
+
+        try:
+            result = asyncio.run(run())
+        finally:
+            proc.close()
+
+        mock_killpg.assert_called_once_with(proc.pid, signal.SIGKILL)
+        assert result["status"] == "stopped"
+        assert manager.instances == {}
+
+    @patch("launcher.multiprocessing.Process")
+    def test_stop_all_instances_async_stops_them_concurrently(
+        self, mock_process_class, manager, vllm_config
+    ):
+        """N instances must cost about one stop, not N of them."""
+        procs = [SlowExitProcess(SLOW_EXIT_SECS) for _ in range(3)]
+        mock_process_class.side_effect = procs
+
+        async def run():
+            for instance_id in ("id-1", "id-2", "id-3"):
+                manager.create_instance(vllm_config, instance_id)
+
+            started = time.monotonic()
+            result = await manager.stop_all_instances_async()
+            return result, time.monotonic() - started
+
+        try:
+            result, elapsed = asyncio.run(run())
+        finally:
+            for proc in procs:
+                proc.close()
+        assert result["total_stopped"] == 3
+        assert manager.instances == {}
+        # Sequentially this would be ~3x SLOW_EXIT_SECS.
+        assert elapsed < 2 * SLOW_EXIT_SECS, f"stopping three took {elapsed:.2f}s"
+
+
 class TestAPIEndpoints:
     def test_health_endpoint(self, client):
         """Test health check endpoint"""
@@ -644,10 +814,9 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_create_id_vllm_instance(self, mock_manager, client):
         """Test creating vLLM instance with custom ID via API"""
-        mock_manager.create_instance.return_value = {
-            "status": "started",
-            "instance_id": "custom-id",
-        }
+        mock_manager.create_instance_async = AsyncMock(
+            return_value={"status": "started", "instance_id": "custom-id"}
+        )
 
         response = client.put(
             "/v2/vllm/instances/custom-id", json={"options": "--model test --port 8000"}
@@ -660,7 +829,9 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_create_duplicate_instance(self, mock_manager, client):
         """Test creating instance with duplicate ID returns 409"""
-        mock_manager.create_instance.side_effect = ValueError("already exists")
+        mock_manager.create_instance_async = AsyncMock(
+            side_effect=ValueError("already exists")
+        )
 
         response = client.put(
             "/v2/vllm/instances/duplicate-id",
@@ -672,10 +843,9 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_delete_vllm_instance(self, mock_manager, client):
         """Test deleting vLLM instance via API"""
-        mock_manager.stop_instance.return_value = {
-            "status": "terminated",
-            "instance_id": "test-id",
-        }
+        mock_manager.stop_instance_async = AsyncMock(
+            return_value={"status": "terminated", "instance_id": "test-id"}
+        )
 
         response = client.delete("/v2/vllm/instances/test-id")
 
@@ -686,7 +856,7 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_delete_nonexistent_instance(self, mock_manager, client):
         """Test deleting nonexistent instance returns 404"""
-        mock_manager.stop_instance.side_effect = KeyError("not found")
+        mock_manager.stop_instance_async = AsyncMock(side_effect=KeyError("not found"))
 
         response = client.delete("/v2/vllm/instances/nonexistent-id")
 
@@ -695,10 +865,9 @@ class TestAPIEndpoints:
     @patch("launcher.vllm_manager")
     def test_delete_all_instances(self, mock_manager, client):
         """Test deleting all instances via API"""
-        mock_manager.stop_all_instances.return_value = {
-            "status": "all_stopped",
-            "stopped_instances": [],
-        }
+        mock_manager.stop_all_instances_async = AsyncMock(
+            return_value={"status": "all_stopped", "stopped_instances": []}
+        )
 
         response = client.delete("/v2/vllm/instances")
 

--- a/inference_server/launcher/tests/test_launcher.py
+++ b/inference_server/launcher/tests/test_launcher.py
@@ -41,6 +41,7 @@ sys.modules["vllm.entrypoints.serve.utils.api_utils"] = MagicMock()
 # Import the application and classes
 from launcher import (  # noqa: E402
     MAX_LOG_RESPONSE_BYTES,
+    ChildSurvivedKill,
     EventBroadcaster,
     HalfMade,
     LogRangeNotAvailable,
@@ -750,6 +751,59 @@ class TestAsyncStop:
         assert result["status"] == "stopped"
         assert manager.instances == {}
 
+    @patch("launcher.POST_KILL_JOIN_TIMEOUT", 0.3)
+    @patch("launcher.os.killpg")
+    @patch("launcher.multiprocessing.Process")
+    def test_stop_async_reports_a_child_that_survives_sigkill(
+        self, mock_process_class, mock_killpg, manager, vllm_config
+    ):
+        """A child that outlives the SIGKILL must fail loudly, without stalling.
+
+        Two things have to hold on this path, and neither is covered by the other
+        tests: the loop must keep running while we wait (a bounded wait is not the
+        same as a non-blocking one), and the instance must not be reported stopped
+        and dropped, or the caller would be told a still-running process had gone
+        and could reuse its id.
+        """
+        proc = SlowExitProcess(3600)  # outlives everything, SIGKILL included
+        mock_process_class.return_value = proc
+        mock_killpg.return_value = None  # the group does not die
+
+        async def run():
+            manager.create_instance(vllm_config, "immortal-id")
+            gaps = []
+
+            async def ticker():
+                previous = time.monotonic()
+                while True:
+                    await asyncio.sleep(0.01)
+                    now = time.monotonic()
+                    gaps.append(now - previous)
+                    previous = now
+
+            task = asyncio.create_task(ticker())
+            try:
+                with pytest.raises(ChildSurvivedKill):
+                    await manager.stop_instance_async("immortal-id", timeout=0.1)
+                # Let the ticker run once more.  The exception propagates without
+                # yielding, so without this the gap that a blocking reap caused
+                # would never get recorded and this test would pass either way.
+                await asyncio.sleep(0.01)
+            finally:
+                task.cancel()
+            return gaps
+
+        try:
+            gaps = asyncio.run(run())
+        finally:
+            proc.close()
+
+        # A blocking reap would show up as one long gap between ticks.
+        assert max(gaps) < 0.15, f"the loop stalled for {max(gaps):.2f}s"
+        # The instance is still ours to deal with, and still watched.
+        assert "immortal-id" in manager.instances
+        assert manager.instances["immortal-id"]._sentinel_active
+
     @patch("launcher.multiprocessing.Process")
     def test_stop_all_instances_async_stops_them_concurrently(
         self, mock_process_class, manager, vllm_config
@@ -775,6 +829,41 @@ class TestAsyncStop:
         assert manager.instances == {}
         # Sequentially this would be ~3x SLOW_EXIT_SECS.
         assert elapsed < 2 * SLOW_EXIT_SECS, f"stopping three took {elapsed:.2f}s"
+
+    @patch("launcher.POST_KILL_JOIN_TIMEOUT", 0.1)
+    @patch("launcher.os.killpg")
+    @patch("launcher.multiprocessing.Process")
+    def test_stop_all_instances_async_reports_the_ones_that_failed(
+        self, mock_process_class, mock_killpg, manager, vllm_config
+    ):
+        """A bulk delete must stop what it can, then admit what it could not.
+
+        Reporting "all_stopped" with a 200 while an instance is still running and
+        still tracked would leave the caller with no way to find out.
+        """
+        cooperative = SlowExitProcess(0.05)
+        immortal = SlowExitProcess(3600)
+        mock_process_class.side_effect = [cooperative, immortal]
+        mock_killpg.return_value = None  # the immortal one's group does not die
+
+        async def run():
+            manager.create_instance(vllm_config, "good-id")
+            manager.create_instance(vllm_config, "immortal-id")
+            with pytest.raises(ExceptionGroup) as caught:
+                await manager.stop_all_instances_async(timeout=0.2)
+            return caught.value
+
+        try:
+            group = asyncio.run(run())
+        finally:
+            cooperative.close()
+            immortal.close()
+
+        # The failure did not stop the others from being stopped...
+        assert "good-id" not in manager.instances
+        # ...and the one that failed is still there to be dealt with.
+        assert "immortal-id" in manager.instances
+        assert [type(exn) for exn in group.exceptions] == [ChildSurvivedKill]
 
 
 class TestAPIEndpoints:


### PR DESCRIPTION
## What this fixes

`VllmInstance.stop()` waits on `process.join()`, which is seconds of wall clock in
the good case and up to the timeout in the bad one. The DELETE handlers called it
directly from the event loop:

```python
@app.delete("/v2/vllm/instances/{instance_id}")
async def delete_vllm_instance(instance_id: str = Path(...)):
    result = vllm_manager.stop_instance(instance_id)   # blocks the loop
```

With a single uvicorn process and a single event loop, the launcher answers nothing
for that whole time — `GET /health` included.


Two more specific problems:

- The second `join()`, after the `killpg`, had **no timeout at all**. A child that
  could not be reaped would wedge the launcher indefinitely.
- `DELETE /v2/vllm/instances` stopped instances one at a time, so N instances cost
  up to N times the timeout with the launcher unresponsive throughout.

## What changed

`VllmInstance` gains `_await_exit()` and `stop_async()`. The parts that are not the
wait — sending SIGTERM, the `killpg` escalation, the reporting and cleanup — are
factored into `_send_sigterm()`, `_kill_process_group()` and `_finish_stop()`, shared
with the synchronous `stop()`, so the two orchestrators differ only in how they
wait. `stop()` stays for callers with no event loop to protect: the `lifespan`
shutdown and the tests.

On the manager side:

- **`stop_instance_async()` / `stop_all_instances_async()`** for the handlers, the
  latter stopping instances concurrently (`asyncio.gather(...,
  return_exceptions=True)`).
- **Per-instance lock.** Not about threads: the moment the handler awaits at all, a
  DELETE can interleave with a PUT of the same id, which the blocking version
  prevented by accident. Without it, a `PUT /v2/vllm/instances/{id}` during a DELETE
  of that id is rejected as a duplicate (the old instance is still in
  `self.instances`) and then the DELETE removes the entry anyway — the caller loses
  its create for no real reason. Entries are reference counted, since instance ids
  are single use.
- **`create_instance_async()`** takes that lock for the caller-chosen-id form; a
  generated id cannot collide, so `POST /v2/vllm/instances` is unchanged.
- **The wait after the SIGKILL is bounded** (`POST_KILL_JOIN_TIMEOUT`), with an
  error log if the child is still alive afterwards.

## Testing

`89 passed`. Four new tests in `TestAsyncStop`, each **verified by mutation** —
reverting the change it covers makes it fail:

| test | what it catches |
|---|---|
| `test_stop_instance_async_leaves_the_loop_running` | going back to a blocking `join()` |
| `test_stop_all_instances_async_stops_them_concurrently` | that, and stopping in sequence |
| `test_instance_lock_keeps_a_stop_from_eating_a_later_create` | dropping the lock |
| `test_stop_async_escalates_to_killpg_when_sigterm_is_not_enough` | not escalating to the `killpg` |

These needed a new process double, `SlowExitProcess`. `MockProcess` doesn't model
the two things the tests turn on — that `join()` blocks the calling thread, and that
the sentinel fd becomes readable on exit — and without both, a test cannot tell
waiting on the loop apart from blocking it, so it would pass either way. The double
uses a `threading.Timer` as stand-in for the kernel writing to the sentinel.

Five existing endpoint tests moved to `AsyncMock`, since the handlers now call the
async variants.